### PR TITLE
Handle manual PTT overrides for Voice Keyer

### DIFF
--- a/packages/contracts/src/schema/voice-keyer.schema.ts
+++ b/packages/contracts/src/schema/voice-keyer.schema.ts
@@ -44,6 +44,7 @@ export const VoiceKeyerPlayRequestSchema = z.object({
   callsign: z.string(),
   slotId: z.string(),
   repeat: z.boolean().optional(),
+  startImmediately: z.boolean().optional(),
 });
 
 export type VoiceKeyerSlot = z.infer<typeof VoiceKeyerSlotSchema>;

--- a/packages/core/src/websocket/WSClient.ts
+++ b/packages/core/src/websocket/WSClient.ts
@@ -493,8 +493,8 @@ export class WSClient extends WSMessageHandler {
     this.send(WSMessageType.VOICE_PTT_RELEASE);
   }
 
-  playVoiceKeyer(callsign: string, slotId: string, repeat = false): void {
-    this.send(WSMessageType.VOICE_KEYER_PLAY, { callsign, slotId, repeat });
+  playVoiceKeyer(callsign: string, slotId: string, repeat = false, startImmediately = true): void {
+    this.send(WSMessageType.VOICE_KEYER_PLAY, { callsign, slotId, repeat, startImmediately });
   }
 
   stopVoiceKeyer(): void {

--- a/packages/server/src/DigitalRadioEngine.ts
+++ b/packages/server/src/DigitalRadioEngine.ts
@@ -53,6 +53,7 @@ import { CallsignContextTracker } from './slot/CallsignContextTracker.js';
 import { NtpCalibrationService } from './services/NtpCalibrationService.js';
 import { RigctldBridge } from './rigctld/RigctldBridge.js';
 import { SquelchStatusMonitor } from './radio/SquelchStatusMonitor.js';
+import { PhysicalPttMonitor } from './radio/PhysicalPttMonitor.js';
 import type { RigctldBridgeConfig, RigctldStatus } from '@tx5dr/contracts';
 
 /**
@@ -100,12 +101,17 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
   private radioBridge: RadioBridge;
   private rigctldBridge: RigctldBridge;
   private squelchStatusMonitor: SquelchStatusMonitor;
+  private physicalPttMonitor: PhysicalPttMonitor;
   private transmissionPipeline: TransmissionPipeline;
   private clockCoordinator!: ClockCoordinator;  // 在 initialize() 中初始化
   private engineLifecycle!: EngineLifecycle;     // 在构造函数末尾初始化
   private _pluginManager!: PluginManager;        // 在构造函数末尾初始化
   private _callsignTracker: CallsignContextTracker;
   private ntpCalibrationService: NtpCalibrationService;
+  private voiceManualPttActive = false;
+  private voiceKeyerPttActive = false;
+  private physicalPttActive = false;
+  private unifiedVoicePttActive = false;
 
   // 频谱分析配置常量
   private static readonly SPECTRUM_CONFIG = {
@@ -331,8 +337,18 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       getEngineMode: () => this.engineMode,
       emitStatus: (status) => this.emit('squelchStatusChanged', status),
     });
+    this.physicalPttMonitor = new PhysicalPttMonitor({
+      radioManager: this.radioManager,
+      getEngineMode: () => this.engineMode,
+      // CAT PTT reads report the radio's TX/RX state, not who caused TX.
+      // Keep polling paused while tx5dr or the keyer is holding PTT so our own
+      // keyer transmission is not misclassified as a physical manual override.
+      isSoftwarePttActive: () => this.voiceManualPttActive || this.voiceKeyerPttActive,
+      emitStatus: (active) => this.handlePhysicalPttChanged(active),
+    });
     this.on('radioStatusChanged', () => {
       this.squelchStatusMonitor.reevaluate();
+      this.physicalPttMonitor.reevaluate();
     });
 
     this.rigctldBridge = new RigctldBridge(this.radioManager);
@@ -572,8 +588,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       this.emit('voicePttLockChanged', lock);
     });
     this.voiceSessionManager.on('pttStatusChanged', (data) => {
-      this.squelchStatusMonitor.setPTTActive(data.isTransmitting);
-      this.emit('pttStatusChanged', data);
+      this.handleVoiceSoftwarePttChanged(data);
     });
     this.voiceSessionManager.on('voiceRadioModeChanged', (data) => {
       this.emit('voiceRadioModeChanged', data);
@@ -635,6 +650,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     }
     await this.stop();
     this.squelchStatusMonitor.stop();
+    this.physicalPttMonitor.stop();
 
     // rigctld bridge: tear down outside the engine resource pipeline so we
     // stop accepting external connections before the radio is torn down.
@@ -842,7 +858,9 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
     this.emitModeAndStatusSnapshot();
 
+    this.resetVoicePttState();
     this.squelchStatusMonitor.reevaluate();
+    this.physicalPttMonitor.reevaluate();
 
     if (shouldResumeAfterSwitch) {
       await this.engineLifecycle.startAndWaitForRunning();
@@ -850,6 +868,52 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     }
 
     logger.info(`Engine mode switched to ${targetEngineMode}/${targetMode.name}`);
+  }
+
+  private handleVoiceSoftwarePttChanged(data: { isTransmitting: boolean; operatorIds: string[]; source?: 'manual' | 'voice-keyer' }): void {
+    if (data.source === 'voice-keyer') {
+      this.voiceKeyerPttActive = data.isTransmitting;
+    } else {
+      this.voiceManualPttActive = data.isTransmitting;
+    }
+
+    this.physicalPttMonitor.setSoftwarePttActive(this.voiceManualPttActive || this.voiceKeyerPttActive);
+    this.applyUnifiedVoicePttState(data.operatorIds ?? []);
+  }
+
+  private handlePhysicalPttChanged(active: boolean): void {
+    this.physicalPttActive = active;
+    this.voiceKeyerManager?.setManualPttActive(this.voiceManualPttActive || this.physicalPttActive);
+    this.applyUnifiedVoicePttState([]);
+  }
+
+  private resetVoicePttState(): void {
+    this.voiceManualPttActive = false;
+    this.voiceKeyerPttActive = false;
+    this.physicalPttActive = false;
+    this.voiceKeyerManager?.setManualPttActive(false);
+    this.physicalPttMonitor.setSoftwarePttActive(false);
+    this.applyUnifiedVoicePttState([]);
+  }
+
+  private applyUnifiedVoicePttState(operatorIds: string[]): void {
+    const manualPttActive = this.voiceManualPttActive || this.physicalPttActive;
+    this.voiceKeyerManager?.setManualPttActive(manualPttActive);
+
+    const unifiedActive = manualPttActive || this.voiceKeyerPttActive;
+    const changed = unifiedActive !== this.unifiedVoicePttActive;
+    this.unifiedVoicePttActive = unifiedActive;
+
+    this.radioManager.setPTTActive(unifiedActive);
+    this.spectrumScheduler.setPTTActive(unifiedActive);
+    this.squelchStatusMonitor.setPTTActive(unifiedActive);
+
+    if (changed) {
+      this.emit('pttStatusChanged', {
+        isTransmitting: unifiedActive,
+        operatorIds: unifiedActive ? operatorIds : [],
+      });
+    }
   }
 
   private emitModeAndStatusSnapshot(): void {

--- a/packages/server/src/audio/AudioStreamManager.ts
+++ b/packages/server/src/audio/AudioStreamManager.ts
@@ -1307,7 +1307,11 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       });
 
       } catch (error) {
-        logger.error('audio playback failed', error);
+        if (error instanceof Error && error.message.includes('playback interrupted')) {
+          logger.debug('audio playback interrupted');
+        } else {
+          logger.error('audio playback failed', error);
+        }
         throw error;
       } finally {
         // 清理播放状态

--- a/packages/server/src/radio/PhysicalPttMonitor.ts
+++ b/packages/server/src/radio/PhysicalPttMonitor.ts
@@ -1,0 +1,155 @@
+import type { EngineMode } from '@tx5dr/contracts';
+import type { PhysicalRadioManager } from './PhysicalRadioManager.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('PhysicalPttMonitor');
+const POLL_INTERVAL_MS = 300;
+
+type PhysicalPttMonitorOptions = {
+  radioManager: PhysicalRadioManager;
+  getEngineMode: () => EngineMode;
+  isSoftwarePttActive: () => boolean;
+  emitStatus: (active: boolean) => void;
+};
+
+export class PhysicalPttMonitor {
+  private readonly radioManager: PhysicalRadioManager;
+  private readonly getEngineMode: () => EngineMode;
+  private readonly isSoftwarePttActive: () => boolean;
+  private readonly emitStatus: (active: boolean) => void;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private pollInFlight = false;
+  private lastActive = false;
+  private consecutiveErrors = 0;
+  private disabledForConnection: unknown = null;
+
+  constructor(options: PhysicalPttMonitorOptions) {
+    this.radioManager = options.radioManager;
+    this.getEngineMode = options.getEngineMode;
+    this.isSoftwarePttActive = options.isSoftwarePttActive;
+    this.emitStatus = options.emitStatus;
+  }
+
+  reevaluate(): void {
+    const connection = this.radioManager.getCurrentConnection();
+    const shouldPoll = this.shouldPoll(connection);
+    logger.debug('Physical PTT monitor reevaluate', {
+      shouldPoll,
+      engineMode: this.getEngineMode(),
+      connected: this.radioManager.isConnected(),
+      softwarePttActive: this.isSoftwarePttActive(),
+      hasPTTRead: typeof connection?.getPTT === 'function',
+      disabledForCurrentConnection: this.disabledForConnection === connection,
+    });
+
+    if (shouldPoll) {
+      this.startPolling();
+      return;
+    }
+
+    this.stopPolling();
+    if (!this.isSoftwarePttActive()) {
+      this.publish(false);
+    }
+  }
+
+  setSoftwarePttActive(active: boolean): void {
+    if (active) {
+      this.stopPolling();
+      logger.debug('Physical PTT polling paused while software PTT is active');
+      return;
+    }
+
+    void this.pollOnce({ force: true });
+    this.reevaluate();
+  }
+
+  stop(): void {
+    this.stopPolling();
+    this.pollInFlight = false;
+    this.consecutiveErrors = 0;
+    this.disabledForConnection = null;
+    this.publish(false);
+  }
+
+  private shouldPoll(connection = this.radioManager.getCurrentConnection()): boolean {
+    if (this.getEngineMode() !== 'voice') return false;
+    if (!this.radioManager.isConnected()) return false;
+    if (this.isSoftwarePttActive()) return false;
+    if (!connection || this.disabledForConnection === connection) return false;
+    return typeof connection.getPTT === 'function';
+  }
+
+  private startPolling(): void {
+    if (this.pollTimer) return;
+    logger.debug('Starting physical PTT polling');
+    this.consecutiveErrors = 0;
+    void this.pollOnce();
+    this.pollTimer = setInterval(() => {
+      void this.pollOnce();
+    }, POLL_INTERVAL_MS);
+  }
+
+  private stopPolling(): void {
+    if (!this.pollTimer) return;
+    logger.debug('Stopping physical PTT polling');
+    clearInterval(this.pollTimer);
+    this.pollTimer = null;
+  }
+
+  private async pollOnce(options: { force?: boolean } = {}): Promise<void> {
+    if (this.pollInFlight) return;
+    const connection = this.radioManager.getCurrentConnection();
+    const canPoll = options.force
+      ? this.getEngineMode() === 'voice'
+        && this.radioManager.isConnected()
+        && Boolean(connection?.getPTT)
+        && this.disabledForConnection !== connection
+      : this.shouldPoll(connection);
+
+    if (!canPoll) {
+      this.reevaluate();
+      return;
+    }
+
+    this.pollInFlight = true;
+    try {
+      const active = await connection!.getPTT!();
+      if (
+        this.getEngineMode() !== 'voice'
+        || !this.radioManager.isConnected()
+        || this.radioManager.getCurrentConnection() !== connection
+        || this.disabledForConnection === connection
+        || this.isSoftwarePttActive()
+      ) {
+        return;
+      }
+      this.consecutiveErrors = 0;
+      if (this.disabledForConnection === connection) {
+        this.disabledForConnection = null;
+      }
+      this.publish(active);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('radio I/O is busy')) {
+        return;
+      }
+
+      this.consecutiveErrors += 1;
+      logger.debug('Physical PTT poll failed', { error: message, consecutiveErrors: this.consecutiveErrors });
+      if (this.consecutiveErrors >= 5) {
+        logger.warn('Disabling physical PTT polling for current radio connection after repeated failures', { error: message });
+        this.disabledForConnection = connection;
+        this.stopPolling();
+      }
+    } finally {
+      this.pollInFlight = false;
+    }
+  }
+
+  private publish(active: boolean): void {
+    if (this.lastActive === active) return;
+    this.lastActive = active;
+    this.emitStatus(active);
+  }
+}

--- a/packages/server/src/radio/__tests__/HamlibConnection.test.ts
+++ b/packages/server/src/radio/__tests__/HamlibConnection.test.ts
@@ -11,6 +11,7 @@ type MockRig = {
   setSplitFreq: ReturnType<typeof vi.fn>;
   setMode: ReturnType<typeof vi.fn>;
   setPtt: ReturnType<typeof vi.fn>;
+  getPtt: ReturnType<typeof vi.fn>;
   getFrequency: ReturnType<typeof vi.fn>;
   getMode: ReturnType<typeof vi.fn>;
   getLevel: ReturnType<typeof vi.fn>;
@@ -88,6 +89,7 @@ function createConnectedConnection(rigOverrides: Partial<MockRig> = {}): {
     setSplitFreq: vi.fn().mockResolvedValue(0),
     setMode: vi.fn().mockResolvedValue(0),
     setPtt: vi.fn().mockResolvedValue(0),
+    getPtt: vi.fn().mockResolvedValue(false),
     getFrequency: vi.fn().mockResolvedValue(7100000),
     getMode: vi.fn().mockResolvedValue({ mode: 'USB', bandwidth: 2400 }),
     getLevel: vi.fn().mockResolvedValue(0),
@@ -136,6 +138,32 @@ describe('HamlibConnection', () => {
 
     await expect(connection.getDCD()).resolves.toBe(true);
     expect(rig.getDcd).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads PTT state via low-priority Hamlib polling', async () => {
+    const { connection, rig } = createConnectedConnection({
+      getPtt: vi.fn().mockResolvedValue(true),
+    });
+
+    await expect(connection.getPTT()).resolves.toBe(true);
+    expect(rig.getPtt).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips PTT polling while a critical CAT write is active', async () => {
+    const firstWrite = createDeferred<number>();
+    const { connection, rig } = createConnectedConnection({
+      setFrequency: vi.fn().mockReturnValue(firstWrite.promise),
+      getPtt: vi.fn().mockResolvedValue(true),
+    });
+
+    const writePromise = connection.setFrequency(7100000);
+    await Promise.resolve();
+
+    await expect(connection.getPTT()).rejects.toThrow(/busy/);
+    expect(rig.getPtt).not.toHaveBeenCalled();
+
+    firstWrite.resolve(0);
+    await writePromise;
   });
 
   it('skips DCD polling while a critical CAT write is active', async () => {

--- a/packages/server/src/radio/__tests__/IcomWlanConnection.test.ts
+++ b/packages/server/src/radio/__tests__/IcomWlanConnection.test.ts
@@ -12,6 +12,7 @@ type MockRig = {
   setFrequency: ReturnType<typeof vi.fn>;
   setMode: ReturnType<typeof vi.fn>;
   setPtt: ReturnType<typeof vi.fn>;
+  readTransceiverState: ReturnType<typeof vi.fn>;
   readSWR: ReturnType<typeof vi.fn>;
   readALC: ReturnType<typeof vi.fn>;
   getLevelMeter: ReturnType<typeof vi.fn>;
@@ -45,6 +46,7 @@ function createConnectedConnection(): { connection: IcomWlanConnection; rig: Moc
     setFrequency: vi.fn().mockResolvedValue(undefined),
     setMode: vi.fn().mockResolvedValue(undefined),
     setPtt: vi.fn().mockResolvedValue(undefined),
+    readTransceiverState: vi.fn().mockResolvedValue('RX'),
     readSWR: vi.fn().mockResolvedValue(null),
     readALC: vi.fn().mockResolvedValue(null),
     getLevelMeter: vi.fn().mockResolvedValue(null),
@@ -98,6 +100,25 @@ describe('IcomWlanConnection', () => {
     });
     expect(rig.setFrequency).toHaveBeenCalledWith(7100000);
     expect(rig.setMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps ICOM transceiver TX/RX state to PTT state', async () => {
+    const { connection, rig } = createConnectedConnection();
+    rig.readTransceiverState
+      .mockResolvedValueOnce('TX')
+      .mockResolvedValueOnce('RX');
+
+    await expect(connection.getPTT()).resolves.toBe(true);
+    await expect(connection.getPTT()).resolves.toBe(false);
+
+    expect(rig.readTransceiverState).toHaveBeenCalledWith({ timeout: 1000 });
+  });
+
+  it('treats unknown ICOM transceiver state as unavailable PTT state', async () => {
+    const { connection, rig } = createConnectedConnection();
+    rig.readTransceiverState.mockResolvedValueOnce('UNKNOWN');
+
+    await expect(connection.getPTT()).rejects.toThrow(/getPTT/);
   });
 
   it('reads ICOM meter values sequentially within one polling pass', async () => {

--- a/packages/server/src/radio/__tests__/PhysicalPttMonitor.test.ts
+++ b/packages/server/src/radio/__tests__/PhysicalPttMonitor.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EngineMode } from '@tx5dr/contracts';
+import { PhysicalPttMonitor } from '../PhysicalPttMonitor.js';
+
+function createRadioManager(overrides: Record<string, unknown> = {}) {
+  const connection = {
+    getPTT: vi.fn().mockResolvedValue(false),
+  };
+  const radioManager = {
+    isConnected: vi.fn().mockReturnValue(true),
+    getCurrentConnection: vi.fn().mockReturnValue(connection),
+    ...overrides,
+  };
+  return { radioManager, connection };
+}
+
+describe('PhysicalPttMonitor', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('polls and broadcasts physical PTT state in voice mode', async () => {
+    const { radioManager, connection } = createRadioManager();
+    connection.getPTT.mockResolvedValueOnce(true);
+    const emitStatus = vi.fn();
+    const monitor = new PhysicalPttMonitor({
+      radioManager: radioManager as any,
+      getEngineMode: () => 'voice',
+      isSoftwarePttActive: () => false,
+      emitStatus,
+    });
+
+    monitor.reevaluate();
+    await vi.waitFor(() => expect(emitStatus).toHaveBeenCalledWith(true));
+    monitor.stop();
+  });
+
+  it('does not poll outside voice mode', async () => {
+    const { radioManager, connection } = createRadioManager();
+    const emitStatus = vi.fn();
+    const monitor = new PhysicalPttMonitor({
+      radioManager: radioManager as any,
+      getEngineMode: () => 'digital',
+      isSoftwarePttActive: () => false,
+      emitStatus,
+    });
+
+    monitor.reevaluate();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(connection.getPTT).not.toHaveBeenCalled();
+    expect(emitStatus).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it('pauses polling while software PTT is active and performs an immediate read after release', async () => {
+    let softwarePttActive = true;
+    const { radioManager, connection } = createRadioManager();
+    connection.getPTT.mockResolvedValue(true);
+    const emitStatus = vi.fn();
+    const monitor = new PhysicalPttMonitor({
+      radioManager: radioManager as any,
+      getEngineMode: () => 'voice',
+      isSoftwarePttActive: () => softwarePttActive,
+      emitStatus,
+    });
+
+    monitor.reevaluate();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(connection.getPTT).not.toHaveBeenCalled();
+
+    softwarePttActive = false;
+    monitor.setSoftwarePttActive(false);
+    await vi.waitFor(() => expect(emitStatus).toHaveBeenCalledWith(true));
+    expect(connection.getPTT).toHaveBeenCalledTimes(1);
+    monitor.stop();
+  });
+
+  it('preserves last state when low-priority polling is skipped as busy', async () => {
+    const { radioManager, connection } = createRadioManager();
+    connection.getPTT
+      .mockResolvedValueOnce(true)
+      .mockRejectedValueOnce(new Error('PTT poll skipped because radio I/O is busy'))
+      .mockResolvedValueOnce(false);
+    const emitStatus = vi.fn();
+    const monitor = new PhysicalPttMonitor({
+      radioManager: radioManager as any,
+      getEngineMode: () => 'voice',
+      isSoftwarePttActive: () => false,
+      emitStatus,
+    });
+
+    monitor.reevaluate();
+    await vi.waitFor(() => expect(emitStatus).toHaveBeenCalledWith(true));
+    vi.clearAllMocks();
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(connection.getPTT).toHaveBeenCalledTimes(1);
+    expect(emitStatus).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(300);
+    await vi.waitFor(() => expect(emitStatus).toHaveBeenCalledWith(false));
+    monitor.stop();
+  });
+
+  it('does not poll unsupported connections', async () => {
+    const unsupportedConnection = {};
+    const { radioManager } = createRadioManager({
+      getCurrentConnection: vi.fn().mockReturnValue(unsupportedConnection),
+    });
+    const emitStatus = vi.fn();
+    const monitor = new PhysicalPttMonitor({
+      radioManager: radioManager as any,
+      getEngineMode: () => 'voice' as EngineMode,
+      isSoftwarePttActive: () => false,
+      emitStatus,
+    });
+
+    monitor.reevaluate();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(emitStatus).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+});

--- a/packages/server/src/radio/connections/HamlibConnection.ts
+++ b/packages/server/src/radio/connections/HamlibConnection.ts
@@ -711,6 +711,31 @@ export class HamlibConnection
     }, { critical: true });
   }
 
+  async getPTT(): Promise<boolean> {
+    this.checkConnected();
+    const result = await this.ioQueue.runLowPriority({ sessionId: this.ioSessionId }, async (activeSessionId) => {
+      this.ensureSession(activeSessionId);
+      try {
+        const value = (await Promise.race([
+          this.rig!.getPtt(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('Get PTT timeout')), 1000)
+          ),
+        ])) as boolean;
+        this.lastSuccessfulOperation = Date.now();
+        return value;
+      } catch (error) {
+        throw this.convertOptionalOperationError(error, 'getPTT');
+      }
+    });
+
+    if (result === RADIO_IO_SKIPPED) {
+      throw new Error('PTT poll skipped because radio I/O is busy');
+    }
+
+    return result;
+  }
+
   /**
    * 设置模式
    */

--- a/packages/server/src/radio/connections/IRadioConnection.ts
+++ b/packages/server/src/radio/connections/IRadioConnection.ts
@@ -290,6 +290,15 @@ export interface IRadioConnection extends EventEmitter<IRadioConnectionEvents> {
   setPTT(enabled: boolean): Promise<void>;
 
   /**
+   * 获取电台当前 PTT/TX 状态。
+   * true = radio reports TX, false = radio reports RX.
+   *
+   * Optional and intended for low-priority observation only. Implementations
+   * should skip or fail softly when the radio I/O path is busy.
+   */
+  getPTT?(): Promise<boolean>;
+
+  /**
    * 设置电台工作模式
    *
    * @param mode - 模式名称 (USB, LSB, AM, CW, FM, etc.)

--- a/packages/server/src/radio/connections/IcomWlanConnection.ts
+++ b/packages/server/src/radio/connections/IcomWlanConnection.ts
@@ -383,6 +383,27 @@ export class IcomWlanConnection
     }, { critical: true });
   }
 
+  async getPTT(): Promise<boolean> {
+    this.checkConnected();
+    const result = await this.ioQueue.runLowPriority({ sessionId: this.ioSessionId }, async (activeSessionId) => {
+      this.ensureSession(activeSessionId);
+      try {
+        const state = await this.rig!.readTransceiverState({ timeout: 1000 });
+        if (state === 'TX') return true;
+        if (state === 'RX') return false;
+        throw new Error(`ICOM PTT state unavailable: ${state ?? 'null'}`);
+      } catch (error) {
+        throw this.convertError(error, 'getPTT');
+      }
+    });
+
+    if (result === RADIO_IO_SKIPPED) {
+      throw new Error('PTT poll skipped because radio I/O is busy');
+    }
+
+    return result;
+  }
+
   /**
    * 设置电台工作模式
    */

--- a/packages/server/src/voice/VoiceKeyerManager.ts
+++ b/packages/server/src/voice/VoiceKeyerManager.ts
@@ -33,6 +33,8 @@ interface ActivePlayback {
   callsign: string;
   slotId: string;
   repeating: boolean;
+  startImmediately: boolean;
+  playbackInterrupted: boolean;
   stopRequested: boolean;
   timer: NodeJS.Timeout | null;
   timerResolve: ((reason: WaitWakeReason) => void) | null;
@@ -167,6 +169,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
       callsign: string;
       slotId: string;
       repeat: boolean;
+      startImmediately?: boolean;
       connectionId: string;
       label: string;
     },
@@ -187,6 +190,8 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
       callsign: normalized,
       slotId: slot.id,
       repeating: params.repeat,
+      startImmediately: params.startImmediately ?? true,
+      playbackInterrupted: false,
       stopRequested: false,
       timer: null,
       timerResolve: null,
@@ -232,6 +237,20 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     }
   }
 
+  async preemptForManualPtt(): Promise<void> {
+    const current = this.active;
+    if (!current || current.stopRequested) {
+      return;
+    }
+
+    if (current.repeating && this.status.mode === 'playing') {
+      await this.preemptPlaybackForManualPtt(current);
+      return;
+    }
+
+    await this.stopActive('manual PTT override');
+  }
+
   setManualPttActive(active: boolean): void {
     if (this.manualPttActive === active) {
       return;
@@ -240,6 +259,11 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
 
     const current = this.active;
     if (!current || current.stopRequested) {
+      return;
+    }
+
+    if (active && this.status.mode === 'playing' && current.repeating) {
+      void this.preemptPlaybackForManualPtt(current);
       return;
     }
 
@@ -258,16 +282,21 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
 
   private async runPlaybackLoop(active: ActivePlayback): Promise<void> {
     try {
+      let shouldPlayNow = active.startImmediately;
       while (!active.stopRequested && this.active === active) {
+        if (!shouldPlayNow) {
+          const shouldPlayAfterDelay = await this.waitForRepeatDelay(active);
+          if (!shouldPlayAfterDelay) {
+            break;
+          }
+        }
+
         await this.playOnce(active);
         if (!active.repeating || active.stopRequested || this.active !== active) {
           break;
         }
 
-        const shouldPlayAgain = await this.waitForRepeatDelay(active);
-        if (!shouldPlayAgain) {
-          break;
-        }
+        shouldPlayNow = false;
       }
     } catch (error) {
       logger.error('Voice keyer playback failed', error);
@@ -286,6 +315,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
   private async playOnce(active: ActivePlayback): Promise<void> {
     const audioPath = await this.getSlotAudioPathForRead(active.callsign, active.slotId);
     const decoded = this.decodeWav(await fs.readFile(audioPath));
+    active.playbackInterrupted = false;
     const lock = await this.deps.voiceSessionManager.startTransmit(
       active.keyerClientId,
       `${active.startedByLabel} Voice Keyer`,
@@ -296,16 +326,28 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
 
     this.setStatus(this.statusFor(active, 'playing'));
     await this.sleep(PTT_LEAD_IN_MS, active);
-    if (active.stopRequested || this.active !== active) {
+    if (active.stopRequested || active.playbackInterrupted || this.active !== active) {
       return;
     }
     await this.deps.audioStreamManager.playAudio(decoded.samples, decoded.sampleRate, {
       injectIntoMonitor: true,
     });
-    if (active.stopRequested || this.active !== active) {
+    if (active.stopRequested || active.playbackInterrupted || this.active !== active) {
       return;
     }
     await this.sleep(PTT_TAIL_MS, active);
+    await this.deps.voiceSessionManager.stopTransmit(active.keyerClientId);
+  }
+
+  private async preemptPlaybackForManualPtt(active: ActivePlayback): Promise<void> {
+    active.playbackInterrupted = true;
+    this.setStatus(this.statusFor(active, 'repeat-waiting', null));
+
+    try {
+      await this.deps.audioStreamManager.stopCurrentPlayback();
+    } catch {
+      // The lead-in/tail path may not have an audio clip in flight yet.
+    }
     await this.deps.voiceSessionManager.stopTransmit(active.keyerClientId);
   }
 

--- a/packages/server/src/voice/VoiceKeyerManager.ts
+++ b/packages/server/src/voice/VoiceKeyerManager.ts
@@ -17,6 +17,7 @@ const MAX_AUDIO_DURATION_MS = 120_000;
 const MIN_AUDIO_DURATION_MS = 500;
 const PTT_LEAD_IN_MS = 150;
 const PTT_TAIL_MS = 500;
+type WaitWakeReason = 'elapsed' | 'ptt-change' | 'stop';
 
 interface StoredManifest {
   version: 1;
@@ -34,7 +35,7 @@ interface ActivePlayback {
   repeating: boolean;
   stopRequested: boolean;
   timer: NodeJS.Timeout | null;
-  timerResolve: (() => void) | null;
+  timerResolve: ((reason: WaitWakeReason) => void) | null;
 }
 
 export interface VoiceKeyerManagerEvents {
@@ -50,6 +51,7 @@ export interface VoiceKeyerManagerDeps {
 export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
   private rootDir: string | null = null;
   private active: ActivePlayback | null = null;
+  private manualPttActive = false;
   private status: VoiceKeyerStatus = {
     active: false,
     callsign: null,
@@ -201,12 +203,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     }
 
     active.stopRequested = true;
-    if (active.timer) {
-      clearTimeout(active.timer);
-      active.timer = null;
-    }
-    active.timerResolve?.();
-    active.timerResolve = null;
+    this.interruptActiveWait(active, 'stop');
     this.setStatus({
       ...this.status,
       active: true,
@@ -235,6 +232,30 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     }
   }
 
+  setManualPttActive(active: boolean): void {
+    if (this.manualPttActive === active) {
+      return;
+    }
+    this.manualPttActive = active;
+
+    const current = this.active;
+    if (!current || current.stopRequested) {
+      return;
+    }
+
+    if (active && this.status.mode === 'playing') {
+      void this.stopActive('manual PTT override');
+      return;
+    }
+
+    if (this.status.mode === 'repeat-waiting') {
+      if (active) {
+        this.setStatus(this.statusFor(current, 'repeat-waiting', null));
+      }
+      this.interruptActiveWait(current, 'ptt-change');
+    }
+  }
+
   private async runPlaybackLoop(active: ActivePlayback): Promise<void> {
     try {
       while (!active.stopRequested && this.active === active) {
@@ -243,20 +264,10 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
           break;
         }
 
-        const panel = await this.getPanel(active.callsign);
-        const slot = this.requireSlot(panel, active.slotId);
-        if (!slot.repeatEnabled) {
+        const shouldPlayAgain = await this.waitForRepeatDelay(active);
+        if (!shouldPlayAgain) {
           break;
         }
-        const waitMs = slot.repeatIntervalSec * 1000;
-        const nextRunAt = Date.now() + waitMs;
-        this.setStatus(this.statusFor(active, 'repeat-waiting', nextRunAt));
-        await new Promise<void>((resolve) => {
-          active.timerResolve = resolve;
-          active.timer = setTimeout(resolve, waitMs);
-        });
-        active.timer = null;
-        active.timerResolve = null;
       }
     } catch (error) {
       logger.error('Voice keyer playback failed', error);
@@ -286,13 +297,13 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     this.setStatus(this.statusFor(active, 'playing'));
     await this.sleep(PTT_LEAD_IN_MS, active);
     if (active.stopRequested || this.active !== active) {
-      throw new Error('playback interrupted');
+      return;
     }
     await this.deps.audioStreamManager.playAudio(decoded.samples, decoded.sampleRate, {
       injectIntoMonitor: true,
     });
     if (active.stopRequested || this.active !== active) {
-      throw new Error('playback interrupted');
+      return;
     }
     await this.sleep(PTT_TAIL_MS, active);
     await this.deps.voiceSessionManager.stopTransmit(active.keyerClientId);
@@ -303,6 +314,69 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
       return Promise.resolve();
     }
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private async waitForRepeatDelay(active: ActivePlayback): Promise<boolean> {
+    while (!active.stopRequested && this.active === active) {
+      const panel = await this.getPanel(active.callsign);
+      const slot = this.requireSlot(panel, active.slotId);
+      if (!slot.repeatEnabled) {
+        return false;
+      }
+
+      if (this.manualPttActive) {
+        this.setStatus(this.statusFor(active, 'repeat-waiting', null));
+        const reason = await this.waitForWake(active);
+        if (reason === 'stop') {
+          return false;
+        }
+        continue;
+      }
+
+      const waitMs = slot.repeatIntervalSec * 1000;
+      const nextRunAt = Date.now() + waitMs;
+      this.setStatus(this.statusFor(active, 'repeat-waiting', nextRunAt));
+      const reason = await this.waitForWake(active, waitMs);
+      if (reason === 'elapsed') {
+        return !active.stopRequested && this.active === active;
+      }
+      if (reason === 'stop') {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  private waitForWake(active: ActivePlayback, waitMs?: number): Promise<WaitWakeReason> {
+    return new Promise<WaitWakeReason>((resolve) => {
+      active.timerResolve = resolve;
+      if (typeof waitMs === 'number') {
+        active.timer = setTimeout(() => {
+          active.timer = null;
+          active.timerResolve = null;
+          resolve('elapsed');
+        }, waitMs);
+      }
+    }).finally(() => {
+      if (active.timer) {
+        clearTimeout(active.timer);
+        active.timer = null;
+      }
+      if (active.timerResolve) {
+        active.timerResolve = null;
+      }
+    });
+  }
+
+  private interruptActiveWait(active: ActivePlayback, reason: WaitWakeReason): void {
+    if (active.timer) {
+      clearTimeout(active.timer);
+      active.timer = null;
+    }
+    const resolve = active.timerResolve;
+    active.timerResolve = null;
+    resolve?.(reason);
   }
 
   private decodeWav(buffer: Buffer): { sampleRate: number; samples: Float32Array } {
@@ -432,6 +506,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
       || !active.repeating
       || this.status.mode !== 'repeat-waiting'
       || !active.timerResolve
+      || this.manualPttActive
     ) {
       return;
     }
@@ -443,10 +518,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     const nextRunAt = Date.now() + waitMs;
     this.setStatus(this.statusFor(active, 'repeat-waiting', nextRunAt));
     active.timer = setTimeout(() => {
-      active.timer = null;
-      const resolve = active.timerResolve;
-      active.timerResolve = null;
-      resolve?.();
+      this.interruptActiveWait(active, 'elapsed');
     }, waitMs);
   }
 

--- a/packages/server/src/voice/VoiceKeyerManager.ts
+++ b/packages/server/src/voice/VoiceKeyerManager.ts
@@ -19,6 +19,10 @@ const PTT_LEAD_IN_MS = 150;
 const PTT_TAIL_MS = 500;
 type WaitWakeReason = 'elapsed' | 'ptt-change' | 'stop';
 
+function isPlaybackInterrupted(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('playback interrupted');
+}
+
 interface StoredManifest {
   version: 1;
   callsign: string;
@@ -329,9 +333,16 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     if (active.stopRequested || active.playbackInterrupted || this.active !== active) {
       return;
     }
-    await this.deps.audioStreamManager.playAudio(decoded.samples, decoded.sampleRate, {
-      injectIntoMonitor: true,
-    });
+    try {
+      await this.deps.audioStreamManager.playAudio(decoded.samples, decoded.sampleRate, {
+        injectIntoMonitor: true,
+      });
+    } catch (error) {
+      if ((active.stopRequested || active.playbackInterrupted) && isPlaybackInterrupted(error)) {
+        return;
+      }
+      throw error;
+    }
     if (active.stopRequested || active.playbackInterrupted || this.active !== active) {
       return;
     }

--- a/packages/server/src/voice/VoiceSessionManager.ts
+++ b/packages/server/src/voice/VoiceSessionManager.ts
@@ -13,7 +13,7 @@ const logger = createLogger('VoiceSessionManager');
 
 export interface VoiceSessionManagerEvents {
   voicePttLockChanged: (lock: VoicePTTLock) => void;
-  pttStatusChanged: (data: { isTransmitting: boolean; operatorIds: string[] }) => void;
+  pttStatusChanged: (data: { isTransmitting: boolean; operatorIds: string[]; source: 'manual' | 'voice-keyer' }) => void;
   voiceRadioModeChanged: (data: { radioMode: string }) => void;
 }
 
@@ -109,7 +109,7 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
       await this.radioManager.setPTT(true);
 
       // 3. Broadcast PTT status (frontend handles monitor muting via gain node)
-      this.emit('pttStatusChanged', { isTransmitting: true, operatorIds: [] });
+      this.emit('pttStatusChanged', { isTransmitting: true, operatorIds: [], source: this.getPttSource(clientId) });
 
       logger.info('Voice transmission started', { clientId, label });
       return { success: true };
@@ -202,8 +202,18 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
     this.diagnostics.endSession();
 
     // 2. Broadcast PTT status (frontend handles monitor unmuting via gain node)
-    this.emit('pttStatusChanged', { isTransmitting: false, operatorIds: [] });
+    this.emit('pttStatusChanged', {
+      isTransmitting: false,
+      operatorIds: [],
+      source: this.getPttSource(this.pttLockManager.getLockHolder()),
+    });
 
     logger.info('Voice transmission stopped', { reason });
+  }
+
+  private getPttSource(clientId: string | null | undefined): 'manual' | 'voice-keyer' {
+    return typeof clientId === 'string' && clientId.startsWith('voice-keyer:')
+      ? 'voice-keyer'
+      : 'manual';
   }
 }

--- a/packages/server/src/voice/__tests__/VoiceKeyerManager.test.ts
+++ b/packages/server/src/voice/__tests__/VoiceKeyerManager.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import * as nodeWav from 'node-wav';
 import { VoiceKeyerManager } from '../VoiceKeyerManager.js';
 
@@ -35,6 +35,7 @@ async function createManager() {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) await rm(dir, { recursive: true, force: true });
@@ -107,4 +108,58 @@ describe('VoiceKeyerManager', () => {
     expect(audioStreamManager.playAudio).not.toHaveBeenCalled();
     expect(manager.getStatus().error).toContain('locked');
   });
+
+  describe('manual PTT overrides repeat CQ', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    it('clears repeat countdown during manual PTT and restarts a full interval after release', async () => {
+      const { manager, voiceSessionManager } = await createManager();
+      await manager.saveSlotAudio('BG5DRB', '1', makeWav());
+      await manager.updateSlot('BG5DRB', '1', { repeatEnabled: true, repeatIntervalSec: 4 });
+
+      await manager.play({ callsign: 'BG5DRB', slotId: '1', repeat: true, connectionId: 'c1', label: 'Op' });
+      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('playing'));
+      await vi.advanceTimersByTimeAsync(PTT_AUDIO_WINDOW_MS);
+      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('repeat-waiting'));
+
+      const firstCountdown = manager.getStatus().nextRunAt;
+      expect(firstCountdown).toEqual(expect.any(Number));
+      expect(voiceSessionManager.startTransmit).toHaveBeenCalledTimes(1);
+
+      manager.setManualPttActive(true);
+      expect(manager.getStatus().nextRunAt).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(voiceSessionManager.startTransmit).toHaveBeenCalledTimes(1);
+
+      manager.setManualPttActive(false);
+      await vi.waitFor(() => expect(manager.getStatus().nextRunAt).toEqual(expect.any(Number)));
+      const restartedCountdown = manager.getStatus().nextRunAt!;
+      expect(restartedCountdown).toBeGreaterThan(Date.now() + 3_500);
+
+      await vi.advanceTimersByTimeAsync(3_999);
+      expect(voiceSessionManager.startTransmit).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(voiceSessionManager.startTransmit).toHaveBeenCalledTimes(2));
+    });
+
+    it('stops active playback when manual PTT starts', async () => {
+      const { manager, voiceSessionManager, audioStreamManager } = await createManager();
+      await manager.saveSlotAudio('BG5DRB', '1', makeWav());
+      await manager.updateSlot('BG5DRB', '1', { repeatEnabled: true, repeatIntervalSec: 4 });
+
+      await manager.play({ callsign: 'BG5DRB', slotId: '1', repeat: true, connectionId: 'c1', label: 'Op' });
+      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('playing'));
+
+      manager.setManualPttActive(true);
+      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('idle'));
+
+      expect(audioStreamManager.stopCurrentPlayback).toHaveBeenCalled();
+      expect(voiceSessionManager.stopTransmit).toHaveBeenCalledWith('voice-keyer:c1');
+    });
+  });
 });
+
+const PTT_AUDIO_WINDOW_MS = 150 + 500;

--- a/packages/server/src/voice/__tests__/VoiceKeyerManager.test.ts
+++ b/packages/server/src/voice/__tests__/VoiceKeyerManager.test.ts
@@ -145,7 +145,30 @@ describe('VoiceKeyerManager', () => {
       await vi.waitFor(() => expect(voiceSessionManager.startTransmit).toHaveBeenCalledTimes(2));
     });
 
-    it('stops active playback when manual PTT starts', async () => {
+    it('can start repeat CQ in countdown mode without an immediate first transmission', async () => {
+      const { manager, voiceSessionManager } = await createManager();
+      await manager.saveSlotAudio('BG5DRB', '1', makeWav());
+      await manager.updateSlot('BG5DRB', '1', { repeatEnabled: true, repeatIntervalSec: 4 });
+
+      await manager.play({
+        callsign: 'BG5DRB',
+        slotId: '1',
+        repeat: true,
+        startImmediately: false,
+        connectionId: 'c1',
+        label: 'Op',
+      });
+
+      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('repeat-waiting'));
+      expect(voiceSessionManager.startTransmit).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(3_999);
+      expect(voiceSessionManager.startTransmit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.waitFor(() => expect(voiceSessionManager.startTransmit).toHaveBeenCalledTimes(1));
+    });
+
+    it('stops active playback but keeps repeat CQ waiting when manual PTT starts', async () => {
       const { manager, voiceSessionManager, audioStreamManager } = await createManager();
       await manager.saveSlotAudio('BG5DRB', '1', makeWav());
       await manager.updateSlot('BG5DRB', '1', { repeatEnabled: true, repeatIntervalSec: 4 });
@@ -154,10 +177,14 @@ describe('VoiceKeyerManager', () => {
       await vi.waitFor(() => expect(manager.getStatus().mode).toBe('playing'));
 
       manager.setManualPttActive(true);
-      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('idle'));
+      await vi.waitFor(() => expect(manager.getStatus().mode).toBe('repeat-waiting'));
 
       expect(audioStreamManager.stopCurrentPlayback).toHaveBeenCalled();
-      expect(voiceSessionManager.stopTransmit).toHaveBeenCalledWith('voice-keyer:c1');
+      await vi.waitFor(() => expect(voiceSessionManager.stopTransmit).toHaveBeenCalledWith('voice-keyer:c1'));
+      expect(manager.getStatus().nextRunAt).toBeNull();
+
+      manager.setManualPttActive(false);
+      await vi.waitFor(() => expect(manager.getStatus().nextRunAt).toEqual(expect.any(Number)));
     });
   });
 });

--- a/packages/server/src/voice/__tests__/VoiceKeyerManager.test.ts
+++ b/packages/server/src/voice/__tests__/VoiceKeyerManager.test.ts
@@ -15,6 +15,16 @@ function makeWav(durationSec = 1, sampleRate = 16000): Buffer {
   return nodeWav.encode([samples], { sampleRate, float: false, bitDepth: 16 });
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 async function createManager() {
   const root = await mkdtemp(join(tmpdir(), 'tx5dr-voice-keyer-'));
   tempDirs.push(root);
@@ -170,11 +180,21 @@ describe('VoiceKeyerManager', () => {
 
     it('stops active playback but keeps repeat CQ waiting when manual PTT starts', async () => {
       const { manager, voiceSessionManager, audioStreamManager } = await createManager();
+      const playback = createDeferred<void>();
+      audioStreamManager.playAudio.mockReturnValueOnce(playback.promise);
+      audioStreamManager.stopCurrentPlayback.mockImplementationOnce(async () => {
+        playback.reject(new Error('playback interrupted'));
+        await playback.promise.catch(() => undefined);
+        return 1200;
+      });
+
       await manager.saveSlotAudio('BG5DRB', '1', makeWav());
       await manager.updateSlot('BG5DRB', '1', { repeatEnabled: true, repeatIntervalSec: 4 });
 
       await manager.play({ callsign: 'BG5DRB', slotId: '1', repeat: true, connectionId: 'c1', label: 'Op' });
       await vi.waitFor(() => expect(manager.getStatus().mode).toBe('playing'));
+      await vi.advanceTimersByTimeAsync(PTT_AUDIO_WINDOW_MS);
+      await vi.waitFor(() => expect(audioStreamManager.playAudio).toHaveBeenCalled());
 
       manager.setManualPttActive(true);
       await vi.waitFor(() => expect(manager.getStatus().mode).toBe('repeat-waiting'));
@@ -182,6 +202,7 @@ describe('VoiceKeyerManager', () => {
       expect(audioStreamManager.stopCurrentPlayback).toHaveBeenCalled();
       await vi.waitFor(() => expect(voiceSessionManager.stopTransmit).toHaveBeenCalledWith('voice-keyer:c1'));
       expect(manager.getStatus().nextRunAt).toBeNull();
+      expect(manager.getStatus().error).toBeNull();
 
       manager.setManualPttActive(false);
       await vi.waitFor(() => expect(manager.getStatus().nextRunAt).toEqual(expect.any(Number)));

--- a/packages/server/src/websocket/WSServer.ts
+++ b/packages/server/src/websocket/WSServer.ts
@@ -1145,6 +1145,10 @@ export class WSServer extends WSMessageHandler {
       const connection = this.getConnection(connectionId);
       const label = connection?.getAuthLabel() || connectionId;
       const voiceAudioClientId = data?.voiceAudioClientId as string | undefined;
+      const lock = voiceSessionManager.getPTTLockState();
+      if (lock.locked && typeof lock.lockedBy === 'string' && lock.lockedBy.startsWith('voice-keyer:')) {
+        await this.digitalRadioEngine.getVoiceKeyerManager()?.stopActive('manual PTT override');
+      }
       const result = await voiceSessionManager.startTransmit(connectionId, label, voiceAudioClientId);
 
       if (!result.success) {

--- a/packages/server/src/websocket/WSServer.ts
+++ b/packages/server/src/websocket/WSServer.ts
@@ -1147,7 +1147,7 @@ export class WSServer extends WSMessageHandler {
       const voiceAudioClientId = data?.voiceAudioClientId as string | undefined;
       const lock = voiceSessionManager.getPTTLockState();
       if (lock.locked && typeof lock.lockedBy === 'string' && lock.lockedBy.startsWith('voice-keyer:')) {
-        await this.digitalRadioEngine.getVoiceKeyerManager()?.stopActive('manual PTT override');
+        await this.digitalRadioEngine.getVoiceKeyerManager()?.preemptForManualPtt();
       }
       const result = await voiceSessionManager.startTransmit(connectionId, label, voiceAudioClientId);
 
@@ -1194,6 +1194,7 @@ export class WSServer extends WSMessageHandler {
         callsign,
         slotId,
         repeat: Boolean(data?.repeat),
+        startImmediately: data?.startImmediately !== false,
         connectionId,
         label,
       });

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -622,6 +622,7 @@ export const VoiceKeyerCard: React.FC = () => {
       const seconds = Math.max(0, Math.ceil((status.nextRunAt - Date.now()) / 1000));
       return t('keyer.waiting', { callsign: status.callsign, seconds });
     }
+    if (status.mode === 'repeat-waiting') return t('keyer.waitingForPtt', { callsign: status.callsign });
     if (status.mode === 'playing') return t('keyer.transmittingSlot', { callsign: status.callsign, slot: status.slotId });
     if (status.mode === 'stopping') return t('keyer.stopping');
     if (status.mode === 'error') return t('keyer.error');

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -18,7 +18,6 @@ import {
   faClock,
   faCircle,
   faPen,
-  faPause,
   faPlay,
   faRepeat,
   faStop,
@@ -787,10 +786,10 @@ export const VoiceKeyerCard: React.FC = () => {
       </CardHeader>
 
       <div
-        className="grid transition-[grid-template-rows] duration-200 ease-in-out"
+        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${isCollapsed ? 'overflow-hidden' : 'overflow-visible'}`}
         style={{ gridTemplateRows: isCollapsed ? '0fr' : '1fr' }}
       >
-        <div className="overflow-hidden">
+        <div className={isCollapsed ? 'overflow-hidden' : 'overflow-visible'}>
           <CardBody className="pt-0">
             {!canOperate && (
               <div className="rounded-md bg-warning-50 px-2 py-1.5 text-xs text-warning dark:bg-warning-50/10">
@@ -1007,7 +1006,7 @@ export const VoiceKeyerCard: React.FC = () => {
                             <FontAwesomeIcon icon={faTrash} className="text-xs" />
                           </Button>
                         </div>
-                        {recording ? (
+                        {recording && (
                           <div className="mt-1 flex h-6 items-center gap-1 rounded-md bg-danger-50 px-1.5 text-danger dark:bg-danger-950/20">
                             <span className="shrink-0 text-[10px] font-semibold uppercase">{t('keyer.recordingActive')}</span>
                             <div
@@ -1029,35 +1028,6 @@ export const VoiceKeyerCard: React.FC = () => {
                             >
                               {formatRecordingElapsed(recordingElapsedMs)}
                             </span>
-                          </div>
-                        ) : (
-                          <div className="mt-1 flex h-6 items-center gap-1 text-[11px] text-default-500">
-                            <Button
-                              isIconOnly
-                              size="sm"
-                              color={slot.repeatEnabled ? 'warning' : 'default'}
-                              variant="flat"
-                              aria-label={t('keyer.repeatToggle')}
-                              onPress={() => void toggleRepeat(slot)}
-                              isDisabled={!canOperate || !slot.hasAudio}
-                              className="h-6 min-w-6 rounded-md"
-                            >
-                              <FontAwesomeIcon icon={active && status.mode === 'repeat-waiting' ? faPause : faRepeat} className="text-[10px]" />
-                            </Button>
-                            <Input
-                              type="number"
-                              min={1}
-                              max={300}
-                              size="sm"
-                              variant="flat"
-                              value={String(intervalValue)}
-                              aria-label={t('keyer.repeatInterval')}
-                              classNames={{ inputWrapper: 'h-6 min-h-6 px-1', input: 'text-[11px]' }}
-                              onValueChange={(value) => updateSlotLocal(slot.id, { repeatIntervalSec: Math.max(1, Math.min(300, Math.round(Number(value) || 1))) })}
-                              onBlur={(event) => void updateSlot(slot.id, { repeatIntervalSec: Number(event.currentTarget.value) || 1 })}
-                              isDisabled={!canOperate}
-                            />
-                            <span>s</span>
                           </div>
                         )}
                       </div>

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -235,6 +235,7 @@ export const VoiceKeyerCard: React.FC = () => {
   const radioService = connection.state.radioService;
 
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [bodyOverflowVisible, setBodyOverflowVisible] = useState(false);
   const [panel, setPanel] = useState<VoiceKeyerPanel | null>(null);
   const [status, setStatus] = useState<VoiceKeyerStatus>(idleStatus);
   const [loading, setLoading] = useState(false);
@@ -686,11 +687,19 @@ export const VoiceKeyerCard: React.FC = () => {
     return callsign;
   }, [callsign, hasCallsign, status.active, status.callsign, status.mode, status.nextRunAt, status.slotId, t]);
 
+  const toggleCollapsed = useCallback(() => {
+    setBodyOverflowVisible(false);
+    setShortcutMenuSlotId(null);
+    setIsCollapsed(current => !current);
+  }, []);
+
+  const bodyOverflowClass = bodyOverflowVisible ? 'overflow-visible' : 'overflow-hidden';
+
   return (
     <Card className="w-full overflow-visible" shadow="sm">
       <CardHeader
         className="flex items-center justify-between gap-2 cursor-pointer select-none py-2"
-        onClick={() => setIsCollapsed(prev => !prev)}
+        onClick={toggleCollapsed}
       >
         <div className="flex min-w-0 items-center gap-2">
           <FontAwesomeIcon
@@ -788,10 +797,16 @@ export const VoiceKeyerCard: React.FC = () => {
       </CardHeader>
 
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${isCollapsed ? 'overflow-hidden' : 'overflow-visible'}`}
+        className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${bodyOverflowClass}`}
         style={{ gridTemplateRows: isCollapsed ? '0fr' : '1fr' }}
+        onTransitionEnd={(event) => {
+          if (event.target !== event.currentTarget || event.propertyName !== 'grid-template-rows') return;
+          if (!isCollapsed) {
+            setBodyOverflowVisible(true);
+          }
+        }}
       >
-        <div className={isCollapsed ? 'overflow-hidden' : 'overflow-visible'}>
+        <div className={bodyOverflowClass}>
           <CardBody className="overflow-visible pt-0">
             {!canOperate && (
               <div className="rounded-md bg-warning-50 px-2 py-1.5 text-xs text-warning dark:bg-warning-50/10">

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -128,6 +128,44 @@ function getTxProgressStyle(durationMs: number): React.CSSProperties {
   };
 }
 
+function getRemainingSeconds(nextRunAt: number | null): number | null {
+  if (!nextRunAt) return null;
+  return Math.max(0, Math.ceil((nextRunAt - Date.now()) / 1000));
+}
+
+function getWaitProgressStyle(nextRunAt: number, intervalSec: number): React.CSSProperties {
+  const totalMs = Math.max(1000, intervalSec * 1000);
+  const remainingMs = Math.max(0, nextRunAt - Date.now());
+  const elapsedMs = Math.max(0, totalMs - remainingMs);
+  const startPercent = Math.max(0, Math.min(100, (elapsedMs / totalMs) * 100));
+
+  return {
+    '--voice-keyer-progress-start': `${startPercent}%`,
+    animation: `voice-keyer-wait-progress ${Math.max(1, remainingMs)}ms linear forwards`,
+  } as React.CSSProperties;
+}
+
+const VoiceKeyerWaitProgress = React.memo(function VoiceKeyerWaitProgress({
+  nextRunAt,
+  intervalSec,
+}: {
+  nextRunAt: number;
+  intervalSec: number;
+}) {
+  const style = useMemo(
+    () => getWaitProgressStyle(nextRunAt, intervalSec),
+    [intervalSec, nextRunAt],
+  );
+
+  return (
+    <span
+      key={`${nextRunAt}-${intervalSec}`}
+      className="voice-keyer-wait-progress absolute inset-y-0 left-0 pointer-events-none bg-warning/25"
+      style={style}
+    />
+  );
+});
+
 function mergeChunks(chunks: Float32Array[]): Float32Array {
   const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
   const merged = new Float32Array(length);
@@ -201,7 +239,7 @@ export const VoiceKeyerCard: React.FC = () => {
   const [panel, setPanel] = useState<VoiceKeyerPanel | null>(null);
   const [status, setStatus] = useState<VoiceKeyerStatus>(idleStatus);
   const [loading, setLoading] = useState(false);
-  const [tick, setTick] = useState(0);
+  const [, setCountdownTick] = useState(0);
   const [selectedOperatorId, setSelectedOperatorId] = useState<string | null>(currentOperatorId);
   const [recordingSlotId, setRecordingSlotId] = useState<string | null>(null);
   const [recordingElapsedMs, setRecordingElapsedMs] = useState(0);
@@ -239,7 +277,7 @@ export const VoiceKeyerCard: React.FC = () => {
     if (!(status.active && status.mode === 'repeat-waiting')) {
       return undefined;
     }
-    const timer = window.setInterval(() => setTick(value => value + 1), 1000);
+    const timer = window.setInterval(() => setCountdownTick(value => value + 1), 1000);
     return () => window.clearInterval(timer);
   }, [status.active, status.mode]);
 
@@ -641,16 +679,12 @@ export const VoiceKeyerCard: React.FC = () => {
 
   const statusText = useMemo(() => {
     if (!status.active) return hasCallsign ? callsign : t('keyer.noCallsign');
-    if (status.mode === 'repeat-waiting' && status.nextRunAt) {
-      const seconds = Math.max(0, Math.ceil((status.nextRunAt - Date.now()) / 1000));
-      return t('keyer.waiting', { callsign: status.callsign, seconds });
-    }
     if (status.mode === 'repeat-waiting') return t('keyer.waitingForPtt', { callsign: status.callsign });
     if (status.mode === 'playing') return t('keyer.transmittingSlot', { callsign: status.callsign, slot: status.slotId });
     if (status.mode === 'stopping') return t('keyer.stopping');
     if (status.mode === 'error') return t('keyer.error');
     return callsign;
-  }, [callsign, hasCallsign, status.active, status.callsign, status.mode, status.nextRunAt, status.slotId, t, tick]);
+  }, [callsign, hasCallsign, status.active, status.callsign, status.mode, status.slotId, t]);
 
   return (
     <Card className="w-full" shadow="sm">
@@ -786,14 +820,19 @@ export const VoiceKeyerCard: React.FC = () => {
                     const previewLoading = previewLoadingSlotId === slot.id;
                     const previewPlaying = previewPlayingSlotId === slot.id;
                     const shortcutPreset = slotShortcuts[slot.id] ?? VOICE_KEYER_SHORTCUT_NONE;
+                    const waiting = active && status.mode === 'repeat-waiting';
+                    const activeToneClass = waiting
+                      ? 'bg-warning-50 dark:bg-warning-950/20'
+                      : active
+                        ? 'bg-danger-50 dark:bg-danger-950/20'
+                        : 'bg-content2';
                     if (panelMode === 'operate') {
                       const transmitting = active && status.mode === 'playing';
+                      const remainingSeconds = waiting ? getRemainingSeconds(status.nextRunAt) : null;
                       return (
                         <div
                           key={slot.id}
-                          className={`rounded-lg p-2 transition-colors ${
-                            active ? 'bg-danger-50 dark:bg-danger-950/20' : 'bg-content2'
-                          }`}
+                          className={`rounded-lg p-2 transition-colors ${activeToneClass}`}
                         >
                           <Button
                             color={transmitting ? 'danger' : active ? 'warning' : 'primary'}
@@ -809,12 +848,22 @@ export const VoiceKeyerCard: React.FC = () => {
                                 style={getTxProgressStyle(slot.durationMs)}
                               />
                             )}
+                            {waiting && status.nextRunAt && (
+                              <VoiceKeyerWaitProgress
+                                nextRunAt={status.nextRunAt}
+                                intervalSec={intervalValue}
+                              />
+                            )}
                             <div className="relative z-10 flex w-full flex-col items-start gap-1 text-left">
                               <div className="flex w-full items-center justify-between gap-1">
                                 <span className="font-mono text-xs font-semibold">
                                   {getShortcutOptionLabel(shortcutPreset)}
                                 </span>
-                                <span className="text-[11px] opacity-80">{formatDuration(slot.durationMs)}</span>
+                                <span className={`font-mono opacity-90 ${waiting ? 'text-sm font-semibold tabular-nums' : 'text-[11px]'}`}>
+                                  {waiting
+                                    ? remainingSeconds !== null ? `${remainingSeconds}s` : 'PTT'
+                                    : formatDuration(slot.durationMs)}
+                                </span>
                               </div>
                               <span className="max-w-full truncate text-sm font-semibold">
                                 {slot.hasAudio ? slot.label : t('keyer.emptySlot')}
@@ -858,9 +907,7 @@ export const VoiceKeyerCard: React.FC = () => {
                     return (
                       <div
                         key={slot.id}
-                        className={`rounded-lg p-2 transition-colors ${
-                          active ? 'bg-danger-50 dark:bg-danger-950/20' : 'bg-content2'
-                        }`}
+                        className={`rounded-lg p-2 transition-colors ${activeToneClass}`}
                       >
                         <div className="flex items-center justify-between gap-1">
                           <div

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -839,7 +839,7 @@ export const VoiceKeyerCard: React.FC = () => {
                             variant={transmitting ? 'solid' : active ? 'flat' : 'solid'}
                             className="relative h-16 w-full overflow-hidden rounded-md px-2 pt-1 pb-1.5"
                             onPress={() => active ? stopKeyer() : playSlot(slot, slot.repeatEnabled)}
-                            isDisabled={!slot.hasAudio || !canOperate || (status.active && !active)}
+                            isDisabled={!slot.hasAudio || !canOperate}
                           >
                             {transmitting && (
                               <span

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -774,11 +774,13 @@ export const VoiceKeyerCard: React.FC = () => {
                 const selected = Number(Array.from(keys)[0]);
                 if (selected) void updateSlotCount(selected);
               }}
-              className="w-16 sm:w-20"
+              className="w-20 sm:w-24"
               classNames={{ trigger: 'h-7 min-h-7', value: 'text-xs' }}
             >
               {[3, 4, 5, 6, 8, 10, 12].map((count) => (
-                <SelectItem key={String(count)} textValue={String(count)}>{count}</SelectItem>
+                <SelectItem key={String(count)} textValue={t('keyer.slotCountOption', { count })}>
+                  {t('keyer.slotCountOption', { count })}
+                </SelectItem>
               ))}
             </Select>
           )}

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -679,12 +679,13 @@ export const VoiceKeyerCard: React.FC = () => {
 
   const statusText = useMemo(() => {
     if (!status.active) return hasCallsign ? callsign : t('keyer.noCallsign');
+    if (status.mode === 'repeat-waiting' && status.nextRunAt) return t('keyer.waitingArmed', { callsign: status.callsign });
     if (status.mode === 'repeat-waiting') return t('keyer.waitingForPtt', { callsign: status.callsign });
     if (status.mode === 'playing') return t('keyer.transmittingSlot', { callsign: status.callsign, slot: status.slotId });
     if (status.mode === 'stopping') return t('keyer.stopping');
     if (status.mode === 'error') return t('keyer.error');
     return callsign;
-  }, [callsign, hasCallsign, status.active, status.callsign, status.mode, status.slotId, t]);
+  }, [callsign, hasCallsign, status.active, status.callsign, status.mode, status.nextRunAt, status.slotId, t]);
 
   return (
     <Card className="w-full" shadow="sm">
@@ -837,7 +838,7 @@ export const VoiceKeyerCard: React.FC = () => {
                           <Button
                             color={transmitting ? 'danger' : active ? 'warning' : 'primary'}
                             variant={transmitting ? 'solid' : active ? 'flat' : 'solid'}
-                            className="relative h-16 w-full overflow-hidden rounded-md px-2"
+                            className="relative h-16 w-full overflow-hidden rounded-md px-2 pt-1 pb-1.5"
                             onPress={() => active ? stopKeyer() : playSlot(slot, slot.repeatEnabled)}
                             isDisabled={!slot.hasAudio || !canOperate || (status.active && !active)}
                           >

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -453,13 +453,18 @@ export const VoiceKeyerCard: React.FC = () => {
     }
   }, [callsign, previewPlayingSlotId, stopPreview, t]);
 
-  const updateSlot = useCallback(async (slotId: string, update: Partial<Pick<VoiceKeyerSlot, 'label' | 'repeatEnabled' | 'repeatIntervalSec'>>) => {
-    if (!callsign) return;
+  const updateSlot = useCallback(async (
+    slotId: string,
+    update: Partial<Pick<VoiceKeyerSlot, 'label' | 'repeatEnabled' | 'repeatIntervalSec'>>,
+  ): Promise<VoiceKeyerPanel | null> => {
+    if (!callsign) return null;
     try {
       const response = await api.updateVoiceKeyerSlot(callsign, slotId, update);
       setPanel(response.panel);
+      return response.panel;
     } catch (error) {
       logger.error('Failed to update voice keyer slot', error);
+      return null;
     }
   }, [callsign]);
 
@@ -503,15 +508,33 @@ export const VoiceKeyerCard: React.FC = () => {
     }
   }, [callsign, t]);
 
-  const playSlot = useCallback((slot: VoiceKeyerSlot, repeat = false) => {
+  const playSlot = useCallback((slot: VoiceKeyerSlot, repeat = false, startImmediately = true) => {
     if (!canOperate || !slot.hasAudio || !callsign) return;
     stopPreview();
-    radioService?.playVoiceKeyer(callsign, slot.id, repeat);
+    radioService?.playVoiceKeyer(callsign, slot.id, repeat, startImmediately);
   }, [callsign, canOperate, radioService, stopPreview]);
 
   const stopKeyer = useCallback(() => {
     radioService?.stopVoiceKeyer();
   }, [radioService]);
+
+  const toggleRepeat = useCallback(async (slot: VoiceKeyerSlot) => {
+    const repeatEnabled = !slot.repeatEnabled;
+    updateSlotLocal(slot.id, { repeatEnabled });
+    const updatedPanel = await updateSlot(slot.id, { repeatEnabled });
+    if (!updatedPanel) {
+      updateSlotLocal(slot.id, { repeatEnabled: slot.repeatEnabled });
+      return;
+    }
+
+    const updatedSlot = updatedPanel.slots.find(candidate => candidate.id === slot.id) ?? slot;
+    const activeOnThisSlot = activeForCallsign && status.slotId === slot.id;
+    if (repeatEnabled) {
+      playSlot(updatedSlot, true, false);
+    } else if (activeOnThisSlot) {
+      stopKeyer();
+    }
+  }, [activeForCallsign, playSlot, status.slotId, stopKeyer, updateSlot, updateSlotLocal]);
 
   const changePanelMode = useCallback((mode: KeyerPanelMode) => {
     if (mode === panelMode) return;
@@ -805,11 +828,7 @@ export const VoiceKeyerCard: React.FC = () => {
                               color={slot.repeatEnabled ? 'warning' : 'default'}
                               variant={slot.repeatEnabled ? 'solid' : 'flat'}
                               aria-label={t('keyer.repeatToggle')}
-                              onPress={() => {
-                                const repeatEnabled = !slot.repeatEnabled;
-                                updateSlotLocal(slot.id, { repeatEnabled });
-                                void updateSlot(slot.id, { repeatEnabled });
-                              }}
+                              onPress={() => void toggleRepeat(slot)}
                               isDisabled={!canOperate || !slot.hasAudio}
                               className="h-7 min-w-7 rounded-md"
                             >
@@ -971,12 +990,8 @@ export const VoiceKeyerCard: React.FC = () => {
                               color={slot.repeatEnabled ? 'warning' : 'default'}
                               variant="flat"
                               aria-label={t('keyer.repeatToggle')}
-                              onPress={() => {
-                                const repeatEnabled = !slot.repeatEnabled;
-                                updateSlotLocal(slot.id, { repeatEnabled });
-                                void updateSlot(slot.id, { repeatEnabled });
-                              }}
-                              isDisabled={!canOperate}
+                              onPress={() => void toggleRepeat(slot)}
+                              isDisabled={!canOperate || !slot.hasAudio}
                               className="h-6 min-w-6 rounded-md"
                             >
                               <FontAwesomeIcon icon={active && status.mode === 'repeat-waiting' ? faPause : faRepeat} className="text-[10px]" />

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -687,7 +687,7 @@ export const VoiceKeyerCard: React.FC = () => {
   }, [callsign, hasCallsign, status.active, status.callsign, status.mode, status.nextRunAt, status.slotId, t]);
 
   return (
-    <Card className="w-full" shadow="sm">
+    <Card className="w-full overflow-visible" shadow="sm">
       <CardHeader
         className="flex items-center justify-between gap-2 cursor-pointer select-none py-2"
         onClick={() => setIsCollapsed(prev => !prev)}
@@ -790,7 +790,7 @@ export const VoiceKeyerCard: React.FC = () => {
         style={{ gridTemplateRows: isCollapsed ? '0fr' : '1fr' }}
       >
         <div className={isCollapsed ? 'overflow-hidden' : 'overflow-visible'}>
-          <CardBody className="pt-0">
+          <CardBody className="overflow-visible pt-0">
             {!canOperate && (
               <div className="rounded-md bg-warning-50 px-2 py-1.5 text-xs text-warning dark:bg-warning-50/10">
                 {hasCallsign ? t('keyer.operatorRequired') : t('keyer.noOperator')}

--- a/packages/web/src/components/voice/VoiceKeyerCard.tsx
+++ b/packages/web/src/components/voice/VoiceKeyerCard.tsx
@@ -128,14 +128,14 @@ function getTxProgressStyle(durationMs: number): React.CSSProperties {
   };
 }
 
-function getRemainingSeconds(nextRunAt: number | null): number | null {
+function getRemainingSeconds(nextRunAt: number | null, intervalSec: number): number | null {
   if (!nextRunAt) return null;
-  return Math.max(0, Math.ceil((nextRunAt - Date.now()) / 1000));
+  return Math.min(intervalSec, Math.max(0, Math.ceil((nextRunAt - Date.now()) / 1000)));
 }
 
 function getWaitProgressStyle(nextRunAt: number, intervalSec: number): React.CSSProperties {
   const totalMs = Math.max(1000, intervalSec * 1000);
-  const remainingMs = Math.max(0, nextRunAt - Date.now());
+  const remainingMs = Math.min(totalMs, Math.max(0, nextRunAt - Date.now()));
   const elapsedMs = Math.max(0, totalMs - remainingMs);
   const startPercent = Math.max(0, Math.min(100, (elapsedMs / totalMs) * 100));
 
@@ -828,7 +828,7 @@ export const VoiceKeyerCard: React.FC = () => {
                         : 'bg-content2';
                     if (panelMode === 'operate') {
                       const transmitting = active && status.mode === 'playing';
-                      const remainingSeconds = waiting ? getRemainingSeconds(status.nextRunAt) : null;
+                      const remainingSeconds = waiting ? getRemainingSeconds(status.nextRunAt, intervalValue) : null;
                       return (
                         <div
                           key={slot.id}

--- a/packages/web/src/components/voice/VoicePTTButton.tsx
+++ b/packages/web/src/components/voice/VoicePTTButton.tsx
@@ -236,7 +236,6 @@ export const VoicePTTButton: React.FC<VoicePTTButtonProps> = ({ voiceCaptureCont
 
   const attemptPTTDown = useCallback(async () => {
     if (!isOperator || !radioService || isPttDownRef.current) return;
-    if (isVoiceKeyerPttLock) return;
     if (pttState === 'locked-by-other') return;
 
     const pressId = pressTrackerRef.current.beginPress();
@@ -286,7 +285,7 @@ export const VoicePTTButton: React.FC<VoicePTTButtonProps> = ({ voiceCaptureCont
     }
 
     logger.debug('PTT pressed');
-  }, [acquireWakeLock, isOperator, isVoiceKeyerPttLock, pttState, radioService, voiceCaptureController]);
+  }, [acquireWakeLock, isOperator, pttState, radioService, voiceCaptureController]);
 
   // PTT press handler
   const handlePTTDown = useCallback(async () => {
@@ -458,7 +457,7 @@ export const VoicePTTButton: React.FC<VoicePTTButtonProps> = ({ voiceCaptureCont
   };
 
   const { bgClass, label, subLabel } = getButtonStyle();
-  const isDisabled = !isOperator || pttState === 'locked-by-other' || Boolean(isVoiceKeyerPttLock);
+  const isDisabled = !isOperator || pttState === 'locked-by-other';
   const useDisabledVisual = !isOperator || pttState === 'locked-by-other';
   const currentOrigin = typeof window !== 'undefined' ? window.location.origin : '';
   const meterPercent = Math.round(Math.max(0, Math.min(1, inputLevel)) * 100);

--- a/packages/web/src/i18n/locales/en/voice.json
+++ b/packages/web/src/i18n/locales/en/voice.json
@@ -117,6 +117,7 @@
     "deleteFailed": "Delete failed",
     "noCallsign": "No callsign",
     "waiting": "{{callsign}} waiting {{seconds}}s",
+    "waitingArmed": "{{callsign}} waiting to TX",
     "waitingForPtt": "{{callsign}} waiting for PTT",
     "transmittingSlot": "{{callsign}} TX M{{slot}}",
     "stopping": "Stopping",

--- a/packages/web/src/i18n/locales/en/voice.json
+++ b/packages/web/src/i18n/locales/en/voice.json
@@ -117,6 +117,7 @@
     "deleteFailed": "Delete failed",
     "noCallsign": "No callsign",
     "waiting": "{{callsign}} waiting {{seconds}}s",
+    "waitingForPtt": "{{callsign}} waiting for PTT",
     "transmittingSlot": "{{callsign}} TX M{{slot}}",
     "stopping": "Stopping",
     "error": "Error",

--- a/packages/web/src/i18n/locales/en/voice.json
+++ b/packages/web/src/i18n/locales/en/voice.json
@@ -106,6 +106,7 @@
     "editMode": "Edit",
     "stop": "Stop",
     "slotCount": "Slots",
+    "slotCountOption": "{{count}} slots",
     "loadFailed": "Voice keyer load failed",
     "recordTooShort": "Recording is too short",
     "recordSaved": "Recording saved",

--- a/packages/web/src/i18n/locales/zh/voice.json
+++ b/packages/web/src/i18n/locales/zh/voice.json
@@ -117,6 +117,7 @@
     "deleteFailed": "删除失败",
     "noCallsign": "未选择呼号",
     "waiting": "{{callsign}} 等待 {{seconds}} 秒",
+    "waitingArmed": "{{callsign}} 等待发射",
     "waitingForPtt": "{{callsign}} 等待 PTT 释放",
     "transmittingSlot": "{{callsign}} 发射 M{{slot}}",
     "stopping": "正在停止",

--- a/packages/web/src/i18n/locales/zh/voice.json
+++ b/packages/web/src/i18n/locales/zh/voice.json
@@ -117,6 +117,7 @@
     "deleteFailed": "删除失败",
     "noCallsign": "未选择呼号",
     "waiting": "{{callsign}} 等待 {{seconds}} 秒",
+    "waitingForPtt": "{{callsign}} 等待 PTT 释放",
     "transmittingSlot": "{{callsign}} 发射 M{{slot}}",
     "stopping": "正在停止",
     "error": "错误",

--- a/packages/web/src/i18n/locales/zh/voice.json
+++ b/packages/web/src/i18n/locales/zh/voice.json
@@ -106,6 +106,7 @@
     "editMode": "编辑",
     "stop": "停止",
     "slotCount": "槽位数",
+    "slotCountOption": "{{count}} 槽",
     "loadFailed": "语音键控加载失败",
     "recordTooShort": "录音时间太短",
     "recordSaved": "录音已保存",

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -226,3 +226,16 @@ textarea.font-mono,
 .voice-keyer-tx-progress {
   width: 0%;
 }
+
+@keyframes voice-keyer-wait-progress {
+  from {
+    width: var(--voice-keyer-progress-start, 0%);
+  }
+  to {
+    width: 100%;
+  }
+}
+
+.voice-keyer-wait-progress {
+  width: var(--voice-keyer-progress-start, 0%);
+}

--- a/packages/web/src/services/radioService.ts
+++ b/packages/web/src/services/radioService.ts
@@ -414,9 +414,9 @@ export class RadioService {
     }
   }
 
-  playVoiceKeyer(callsign: string, slotId: string, repeat = false): void {
+  playVoiceKeyer(callsign: string, slotId: string, repeat = false, startImmediately = true): void {
     if (this.isConnected) {
-      this.wsClient.playVoiceKeyer(callsign, slotId, repeat);
+      this.wsClient.playVoiceKeyer(callsign, slotId, repeat, startImmediately);
     }
   }
 


### PR DESCRIPTION
## Summary
- add low-pressure physical PTT polling in voice mode for Hamlib and ICOM WLAN
- unify voice PTT state across manual software PTT, physical PTT, and Voice Keyer PTT
- pause/reset Voice Keyer repeat countdown during manual PTT and stop active keyer playback on manual software PTT override
- allow the frontend PTT button to preempt Voice Keyer playback and show the waiting-for-PTT repeat state

## Tests
- yarn workspace @tx5dr/server tsc --noEmit --pretty false --listFiles false
- yarn workspace @tx5dr/server vitest run src/voice/__tests__/VoiceKeyerManager.test.ts src/radio/__tests__/PhysicalPttMonitor.test.ts src/radio/__tests__/HamlibConnection.test.ts src/radio/__tests__/IcomWlanConnection.test.ts
- yarn workspace @tx5dr/server eslint src/voice/VoiceKeyerManager.ts src/voice/VoiceSessionManager.ts src/voice/__tests__/VoiceKeyerManager.test.ts src/radio/PhysicalPttMonitor.ts src/radio/__tests__/PhysicalPttMonitor.test.ts src/radio/connections/IRadioConnection.ts src/radio/connections/HamlibConnection.ts src/radio/connections/IcomWlanConnection.ts src/radio/__tests__/HamlibConnection.test.ts src/radio/__tests__/IcomWlanConnection.test.ts src/DigitalRadioEngine.ts src/websocket/WSServer.ts
- yarn workspace @tx5dr/web eslint src/components/voice/VoicePTTButton.tsx src/components/voice/VoiceKeyerCard.tsx
- git diff --check