### PR TITLE
Fix macOS production signing and notarization

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -432,9 +432,15 @@ jobs:
               echo "❌ 错误: 未找到 Developer ID Application 证书"
               exit 1
             fi
+            BUILDER_IDENTITY="${CERT_IDENTITY#Developer ID Application: }"
+            if [ -z "$BUILDER_IDENTITY" ]; then
+              echo "❌ 错误: 无法解析 electron-builder 签名身份"
+              exit 1
+            fi
 
             echo "✅ 使用证书: $CERT_IDENTITY"
-            package_with_retry env APPLE_IDENTITY="$CERT_IDENTITY" yarn make:autoupdate
+            echo "✅ electron-builder identity: $BUILDER_IDENTITY"
+            package_with_retry env TX5DR_CODESIGN_IDENTITY_FULL="$CERT_IDENTITY" APPLE_IDENTITY="$BUILDER_IDENTITY" yarn make:autoupdate
           elif [ "${{ matrix.platform }}" = "darwin" ]; then
             echo "📦 PR macOS build: unsigned electron-builder package"
             package_with_retry env CSC_IDENTITY_AUTO_DISCOVERY=false yarn make:autoupdate
@@ -490,6 +496,72 @@ jobs:
           done
 
           echo "✅ electron-builder package content verified: $RESOURCES_DIR"
+
+      - name: Validate macOS signing and notarization
+        if: matrix.platform == 'darwin' && github.event_name != 'pull_request'
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          APP_PATH=$(find out/electron-builder -maxdepth 3 -name "*.app" -type d | head -1)
+          if [ -z "${APP_PATH:-}" ] || [ ! -d "$APP_PATH" ]; then
+            echo "Unable to locate packaged macOS app" >&2
+            find out/electron-builder -maxdepth 4 -type d >&2 || true
+            exit 1
+          fi
+
+          echo "=== macOS signing summary ==="
+          echo "App: ${APP_PATH}"
+          /usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${APP_PATH}/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "${APP_PATH}/Contents/Info.plist"
+          codesign -dv --verbose=4 "${APP_PATH}" 2>&1 | sed -E 's/(TeamIdentifier=).*/\1***/'
+
+          echo "=== Verify app code signature ==="
+          codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+          spctl --assess --type execute --verbose=4 "${APP_PATH}"
+          xcrun stapler validate "${APP_PATH}"
+
+          DMG_FILE=$(find out/electron-builder -maxdepth 1 -name "*.dmg" -type f | head -1)
+          if [ -z "${DMG_FILE:-}" ] || [ ! -f "$DMG_FILE" ]; then
+            echo "Unable to locate macOS DMG artifact" >&2
+            find out/electron-builder -maxdepth 1 -type f >&2 || true
+            exit 1
+          fi
+
+          echo "=== Notarize and staple DMG artifact ==="
+          xcrun notarytool submit "${DMG_FILE}" \
+            --apple-id "${APPLE_ID}" \
+            --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --wait
+          xcrun stapler staple "${DMG_FILE}"
+
+          echo "=== Verify DMG notarization ticket ==="
+          xcrun stapler validate "${DMG_FILE}"
+
+          ZIP_FILE=$(find out/electron-builder -maxdepth 1 -name "*.zip" -type f | head -1)
+          if [ -z "${ZIP_FILE:-}" ] || [ ! -f "$ZIP_FILE" ]; then
+            echo "Unable to locate macOS ZIP artifact" >&2
+            find out/electron-builder -maxdepth 1 -type f >&2 || true
+            exit 1
+          fi
+          ZIP_CHECK_DIR=$(mktemp -d)
+          unzip -q "${ZIP_FILE}" -d "${ZIP_CHECK_DIR}"
+          ZIP_APP_PATH=$(find "${ZIP_CHECK_DIR}" -maxdepth 2 -name "*.app" -type d | head -1)
+          if [ -z "${ZIP_APP_PATH:-}" ] || [ ! -d "$ZIP_APP_PATH" ]; then
+            echo "Unable to locate app inside macOS ZIP artifact" >&2
+            find "${ZIP_CHECK_DIR}" -maxdepth 3 -type d >&2 || true
+            exit 1
+          fi
+          echo "=== Verify ZIP app signature and notarization ticket ==="
+          codesign --verify --deep --strict --verbose=2 "${ZIP_APP_PATH}"
+          spctl --assess --type execute --verbose=4 "${ZIP_APP_PATH}"
+          xcrun stapler validate "${ZIP_APP_PATH}"
+          rm -rf "${ZIP_CHECK_DIR}"
 
       - name: Verify Linux package metadata
         if: matrix.platform == 'linux'

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -17,8 +17,15 @@ const LINUX_DEB_DEPENDS = [
 
 function normalizeBuilderArch(value) {
   if (typeof value === 'string') return value;
-  const archNames = { 0: 'x64', 1: 'ia32', 2: 'armv7l', 3: 'arm64', 4: 'universal' };
+  const archNames = { 0: 'ia32', 1: 'x64', 2: 'armv7l', 3: 'arm64', 4: 'universal' };
   return archNames[value] || process.env.ARCH || process.arch;
+}
+
+function sanitizeMacIdentity(value) {
+  return String(value || '')
+    .trim()
+    .replace(/^Developer ID Application:\s*/i, '')
+    || undefined;
 }
 
 function resolveBuilderPackagePaths(context) {
@@ -74,7 +81,7 @@ module.exports = {
     hardenedRuntime: true,
     entitlements: 'build/entitlements.mac.plist',
     entitlementsInherit: 'build/entitlements.mac.plist',
-    identity: process.env.APPLE_IDENTITY || undefined,
+    identity: sanitizeMacIdentity(process.env.APPLE_IDENTITY),
     notarize: Boolean(
       process.env.APPLE_ID
       && process.env.APPLE_APP_SPECIFIC_PASSWORD

--- a/scripts/electron-package-hooks.cjs
+++ b/scripts/electron-package-hooks.cjs
@@ -104,6 +104,10 @@ function findFilesByExt(dir, ext) {
   return results;
 }
 
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
 function getBuilderExtraResources() {
   return [
     { from: 'resources/bin', to: 'bin' },
@@ -284,18 +288,40 @@ function fixMacosNodeRpaths(appRoot) {
 }
 
 function signMacosBinaries(appRoot, resourcesDir, arch) {
-  if (process.platform !== 'darwin' || !process.env.APPLE_IDENTITY) return;
+  const identity = process.env.TX5DR_CODESIGN_IDENTITY_FULL || process.env.APPLE_IDENTITY;
+  if (process.platform !== 'darwin' || !identity) return;
   const entitlementsPath = path.join(process.cwd(), 'build/entitlements.mac.plist');
+  if (!fs.existsSync(entitlementsPath)) {
+    throw new Error(`macOS entitlements file not found: ${entitlementsPath}`);
+  }
   const nodeFiles = findFilesByExt(path.join(appRoot, 'node_modules'), '.node');
-  console.log(`Signing macOS native modules (${nodeFiles.length})...`);
-  for (const nodeFile of nodeFiles) {
-    execSync(`codesign --force --sign "${process.env.APPLE_IDENTITY}" --options runtime --entitlements "${entitlementsPath}" --timestamp "${nodeFile}"`, { stdio: 'inherit' });
+  const dylibFiles = findFilesByExt(path.join(appRoot, 'node_modules'), '.dylib');
+  const runtimeFiles = [...dylibFiles, ...nodeFiles];
+  console.log(`Signing macOS native runtime files (${runtimeFiles.length})...`);
+  for (const runtimeFile of runtimeFiles) {
+    execSync([
+      'codesign',
+      '--force',
+      '--sign', shellQuote(identity),
+      '--options runtime',
+      '--entitlements', shellQuote(entitlementsPath),
+      '--timestamp',
+      shellQuote(runtimeFile),
+    ].join(' '), { stdio: 'inherit' });
   }
 
   const nodeBinary = path.join(resourcesDir, 'bin', `darwin-${arch}`, 'node');
   if (fs.existsSync(nodeBinary)) {
     console.log(`Signing macOS portable node: ${nodeBinary}`);
-    execSync(`codesign --force --sign "${process.env.APPLE_IDENTITY}" --options runtime --entitlements "${entitlementsPath}" --timestamp "${nodeBinary}"`, { stdio: 'inherit' });
+    execSync([
+      'codesign',
+      '--force',
+      '--sign', shellQuote(identity),
+      '--options runtime',
+      '--entitlements', shellQuote(entitlementsPath),
+      '--timestamp',
+      shellQuote(nodeBinary),
+    ].join(' '), { stdio: 'inherit' });
   }
 }
 


### PR DESCRIPTION
## Summary\n- sanitize Developer ID identity before passing it to electron-builder while preserving the full certificate name for manual codesign\n- sign packaged macOS native runtime files, dylibs, and portable Node with hardened runtime entitlements\n- validate production macOS signing/notarization in CI, including app, DMG, and ZIP contents\n- fix electron-builder arch enum normalization for macOS x64/arm64 package hooks\n\n## Verification\n- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/electron-release.yml')"\n- node identity sanitize / hook load check\n- git diff --check\n- yarn build\n\nNote: PR builds remain unsigned by design. The production signing path requires workflow_dispatch or main push with Apple secrets.