### PR TITLE
Add Plugin: Clublog-Sync

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -106,6 +106,7 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VCS_REF=${{ github.sha }}
+            TX5DR_CLUBLOG_API_KEY=${{ secrets.CLUBLOG_API_KEY }}
           labels: |
             org.opencontainers.image.title=${{ env.DOCKER_IMAGE_NAME }}
             org.opencontainers.image.description=TX-5DR Digital Radio System

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -205,6 +205,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
+          TX5DR_CLUBLOG_API_KEY: ${{ secrets.CLUBLOG_API_KEY }}
 
       - name: Prepare portable Node runtime
         shell: bash

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -92,6 +92,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
+          TX5DR_CLUBLOG_API_KEY: ${{ secrets.CLUBLOG_API_KEY }}
 
       - name: Build server packages (deb + rpm)
         run: scripts/package-linux.sh both --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ data/
 .env.development.local
 .env.test.local
 .env.production.local
+packages/builtin-plugins/src/clublog-sync/generated/api-key.ts
 
 # Logs
 npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production
 ARG VCS_REF=development
 ARG BUILD_DATE=development
+ARG TX5DR_CLUBLOG_API_KEY=
 
 # 显示构建信息
 RUN echo "Building for platform: $(uname -m)" && \
@@ -92,7 +93,7 @@ RUN node scripts/prepare-server-build-info.mjs \
 
 # 构建应用
 RUN echo "Building application for $(uname -m)..." && \
-    yarn build
+    TX5DR_CLUBLOG_API_KEY="$TX5DR_CLUBLOG_API_KEY" yarn build
 
 # 清理不必要的文件但保留生产依赖
 RUN yarn cache clean && \

--- a/packages/builtin-plugins/package.json
+++ b/packages/builtin-plugins/package.json
@@ -12,11 +12,11 @@
     }
   },
   "scripts": {
-    "build": "tsc && node scripts/build-ui.mjs",
-    "dev:server": "tsc --watch",
+    "build": "node scripts/generate-clublog-api-key.mjs && tsc && node scripts/build-ui.mjs",
+    "dev:server": "node scripts/generate-clublog-api-key.mjs && tsc --watch",
     "dev:ui": "node scripts/build-ui.mjs --watch",
-    "lint": "eslint src/**/*.ts",
-    "test": "vitest run --passWithNoTests"
+    "lint": "node scripts/generate-clublog-api-key.mjs && eslint src/**/*.ts",
+    "test": "node scripts/generate-clublog-api-key.mjs && vitest run --passWithNoTests"
   },
   "dependencies": {
     "@tx5dr/contracts": "workspace:*",

--- a/packages/builtin-plugins/scripts/generate-clublog-api-key.mjs
+++ b/packages/builtin-plugins/scripts/generate-clublog-api-key.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outputPath = join(__dirname, '..', 'src', 'clublog-sync', 'generated', 'api-key.ts');
+const apiKey = process.env.TX5DR_CLUBLOG_API_KEY || '';
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `export const BUILTIN_CLUBLOG_API_KEY = ${JSON.stringify(apiKey)};\n`, 'utf8');
+
+console.log(apiKey ? 'Generated Club Log API key module.' : 'Generated empty Club Log API key module.');

--- a/packages/builtin-plugins/src/clublog-sync/index.ts
+++ b/packages/builtin-plugins/src/clublog-sync/index.ts
@@ -1,0 +1,165 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
+import type { PluginDefinition, PluginUIRequestContext } from '@tx5dr/plugin-api';
+import zhLocale from './locales/zh.json' with { type: 'json' };
+import enLocale from './locales/en.json' with { type: 'json' };
+import jaLocale from './locales/ja.json' with { type: 'json' };
+import { createSyncFailure, normalizeCallsign } from '@tx5dr/plugin-api';
+import { ClubLogSyncProvider, type ClubLogPluginConfig } from './provider.js';
+
+export const BUILTIN_CLUBLOG_SYNC_PLUGIN_NAME = 'clublog-sync';
+
+export const clublogSyncDirPath = path.dirname(fileURLToPath(import.meta.url));
+
+function requireBoundCallsign(
+  requestContext: PluginUIRequestContext,
+  data: Record<string, unknown>,
+): string {
+  if (requestContext.resource?.kind === 'callsign' && requestContext.resource.value.trim()) {
+    return normalizeCallsign(requestContext.resource.value);
+  }
+  if (typeof data.callsign === 'string' && data.callsign.trim()) {
+    return normalizeCallsign(data.callsign);
+  }
+  throw new Error('Callsign binding is required');
+}
+
+function mergeDraftConfig(
+  base: ClubLogPluginConfig | null,
+  draft: unknown,
+): ClubLogPluginConfig {
+  const fallback: ClubLogPluginConfig = base ?? {
+    email: '',
+    password: '',
+    autoUploadQSO: false,
+  };
+  const patch = draft && typeof draft === 'object' ? draft as Partial<ClubLogPluginConfig> : {};
+  return {
+    ...fallback,
+    email: typeof patch.email === 'string' ? patch.email : fallback.email,
+    password: typeof patch.password === 'string' ? patch.password : fallback.password,
+    autoUploadQSO: typeof patch.autoUploadQSO === 'boolean' ? patch.autoUploadQSO : fallback.autoUploadQSO,
+  };
+}
+
+export const clublogSyncPlugin: PluginDefinition = {
+  name: BUILTIN_CLUBLOG_SYNC_PLUGIN_NAME,
+  version: '1.0.0',
+  type: 'utility',
+  instanceScope: 'global',
+  description: 'Upload QSO records to Club Log',
+
+  permissions: ['network'],
+
+  ui: {
+    dir: 'ui',
+    pages: [
+      {
+        id: 'settings',
+        title: 'Club Log Settings',
+        entry: 'settings.html',
+        accessScope: 'operator',
+        resourceBinding: 'callsign',
+      },
+      {
+        id: 'upload-wizard',
+        title: 'Club Log Upload',
+        entry: 'upload-wizard.html',
+        accessScope: 'operator',
+        resourceBinding: 'callsign',
+      },
+    ],
+  },
+
+  async onLoad(ctx) {
+    const provider = new ClubLogSyncProvider(ctx);
+    ctx.logbookSync.register(provider);
+
+    ctx.ui.registerPageHandler({
+      async onMessage(_pageId: string, action: string, data: unknown, requestContext) {
+        const d = data as Record<string, unknown>;
+        switch (action) {
+          case 'getConfig': {
+            const cs = requireBoundCallsign(requestContext, d);
+            return {
+              config: provider.getConfig(cs),
+              apiKeyStatus: provider.getApiKeyStatus(),
+            };
+          }
+          case 'saveConfig': {
+            const cs = requireBoundCallsign(requestContext, d);
+            const config = d.config as ClubLogPluginConfig;
+            provider.setConfig(cs, {
+              email: config.email,
+              password: config.password,
+              autoUploadQSO: !!config.autoUploadQSO,
+              lastRealtimeUploadTime: provider.getConfig(cs)?.lastRealtimeUploadTime,
+              lastBatchUploadTime: provider.getConfig(cs)?.lastBatchUploadTime,
+            });
+            return { success: true, apiKeyStatus: provider.getApiKeyStatus() };
+          }
+          case 'testConnection': {
+            const cs = requireBoundCallsign(requestContext, d);
+            return provider.testConnection(cs);
+          }
+          case 'testConnectionDraft': {
+            const cs = requireBoundCallsign(requestContext, d);
+            const draftConfig = mergeDraftConfig(provider.getConfig(cs), d.config);
+            return provider.testConnection(cs, draftConfig);
+          }
+          case 'getUploadPreflight': {
+            const cs = requireBoundCallsign(requestContext, d);
+            const since = d.since as number | undefined;
+            const until = d.until as number | undefined;
+            const includeAlreadyUploaded = d.includeAlreadyUploaded === true;
+            return provider.getUploadPreflight(cs, { since, until, includeAlreadyUploaded });
+          }
+          case 'performUpload': {
+            const cs = requireBoundCallsign(requestContext, d);
+            const since = d.since as number | undefined;
+            const until = d.until as number | undefined;
+            const includeAlreadyUploaded = d.includeAlreadyUploaded === true;
+            const skipBlockedQsos = d.skipBlockedQsos === true;
+            try {
+              return await provider.upload(cs, {
+                trigger: 'manual',
+                since,
+                until,
+                includeAlreadyUploaded,
+                skipBlockedQsos,
+                onProgress: (progress) => {
+                  requestContext.page.push('uploadProgress', progress);
+                },
+              });
+            } catch (err) {
+              return {
+                uploaded: 0,
+                skipped: 0,
+                failed: 0,
+                failures: [
+                  createSyncFailure({
+                    code: 'clublog_upload_failed',
+                    message: err instanceof Error ? err.message : 'Upload failed',
+                    source: 'provider',
+                    operation: 'upload',
+                    providerId: 'clublog',
+                  }),
+                ],
+              };
+            }
+          }
+          default:
+            throw new Error(`Unknown action: ${action}`);
+        }
+      },
+    });
+
+    ctx.log.info('Club Log sync provider registered');
+  },
+};
+
+export const clublogSyncLocales: Record<string, Record<string, string>> = {
+  zh: zhLocale,
+  en: enLocale,
+  ja: jaLocale,
+};

--- a/packages/builtin-plugins/src/clublog-sync/locales/en.json
+++ b/packages/builtin-plugins/src/clublog-sync/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "pluginName": "Club Log Sync",
+  "pluginDescription": "Upload QSO records to Club Log"
+}

--- a/packages/builtin-plugins/src/clublog-sync/locales/ja.json
+++ b/packages/builtin-plugins/src/clublog-sync/locales/ja.json
@@ -1,0 +1,4 @@
+{
+  "pluginName": "Club Log 同期",
+  "pluginDescription": "QSO 記録を Club Log にアップロードします"
+}

--- a/packages/builtin-plugins/src/clublog-sync/locales/zh.json
+++ b/packages/builtin-plugins/src/clublog-sync/locales/zh.json
@@ -1,0 +1,4 @@
+{
+  "pluginName": "Club Log 同步",
+  "pluginDescription": "将 QSO 记录上传到 Club Log"
+}

--- a/packages/builtin-plugins/src/clublog-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/clublog-sync/provider.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { PluginContext } from '@tx5dr/plugin-api';
+import type { QSORecord } from '@tx5dr/contracts';
+import { ClubLogSyncProvider } from './provider.js';
+
+function createQso(id: string, overrides: Partial<QSORecord> = {}): QSORecord {
+  return {
+    id,
+    callsign: 'N0CALL',
+    frequency: 14_074_000,
+    mode: 'FT8',
+    startTime: Date.parse('2026-04-17T12:00:00.000Z'),
+    endTime: Date.parse('2026-04-17T12:01:00.000Z'),
+    messageHistory: [],
+    myCallsign: 'BG5DRB',
+    myGrid: 'PM01AA',
+    ...overrides,
+  };
+}
+
+function createContext(fetchImpl: (input: string, init?: RequestInit) => Promise<Response>) {
+  const store = new Map<string, unknown>();
+  const queryQSOs = vi.fn(async (_filter?: unknown) => [] as QSORecord[]);
+
+  const ctx = {
+    store: {
+      global: {
+        get: vi.fn((key: string) => store.get(key)),
+        set: vi.fn((key: string, value: unknown) => {
+          store.set(key, value);
+        }),
+      },
+    },
+    logbook: {
+      forCallsign: vi.fn(() => ({
+        queryQSOs,
+      })),
+    },
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    fetch: vi.fn(fetchImpl),
+  };
+
+  return {
+    ctx: ctx as unknown as PluginContext,
+    fetch: ctx.fetch,
+    queryQSOs,
+    store,
+  };
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}
+
+function withApiKey(value = 'developer-api-key') {
+  process.env.TX5DR_CLUBLOG_API_KEY = value;
+}
+
+function configure(provider: ClubLogSyncProvider) {
+  provider.setConfig('BG5DRB', {
+    email: 'ham@example.com',
+    password: 'app-password',
+    autoUploadQSO: true,
+  });
+}
+
+describe('ClubLogSyncProvider', () => {
+  afterEach(() => {
+    delete process.env.TX5DR_CLUBLOG_API_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it('requires developer API key in addition to user credentials', async () => {
+    const { ctx } = createContext(async () => textResponse('QSO OK'));
+    const provider = new ClubLogSyncProvider(ctx);
+    provider.setConfig('BG5DRB', {
+      email: 'ham@example.com',
+      password: 'app-password',
+      autoUploadQSO: true,
+    });
+
+    expect(provider.isConfigured('BG5DRB')).toBe(false);
+    const result = await provider.upload('BG5DRB', { trigger: 'auto', records: [createQso('qso-1')] });
+
+    expect(result.failures).toEqual([
+      expect.objectContaining({
+        code: 'clublog_api_key_unavailable',
+        providerId: 'clublog',
+      }),
+    ]);
+  });
+
+  it('auto-upload uses explicit records and posts a realtime form', async () => {
+    withApiKey();
+    const { ctx, fetch, queryQSOs } = createContext(async () => textResponse('QSO OK'));
+    const provider = new ClubLogSyncProvider(ctx);
+    configure(provider);
+
+    const result = await provider.upload('BG5DRB', { trigger: 'auto', records: [createQso('qso-1')] });
+
+    expect(result).toEqual({ uploaded: 1, skipped: 0, failed: 0, failures: undefined });
+    expect(queryQSOs).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBe('https://clublog.org/realtime.php');
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBeInstanceOf(URLSearchParams);
+    const body = init?.body as URLSearchParams;
+    expect(body.get('email')).toBe('ham@example.com');
+    expect(body.get('password')).toBe('app-password');
+    expect(body.get('callsign')).toBe('BG5DRB');
+    expect(body.get('api')).toBe('developer-api-key');
+    expect(body.get('adif')).toContain('<EOR>');
+  });
+
+  it('treats duplicate realtime responses as skipped and remembers them', async () => {
+    withApiKey();
+    const { ctx, fetch } = createContext(async () => textResponse('QSO Duplicate'));
+    const provider = new ClubLogSyncProvider(ctx);
+    configure(provider);
+    const qso = createQso('qso-1');
+
+    const first = await provider.upload('BG5DRB', { trigger: 'auto', records: [qso] });
+    const second = await provider.upload('BG5DRB', { trigger: 'auto', records: [qso] });
+
+    expect(first.uploaded).toBe(0);
+    expect(first.skipped).toBe(1);
+    expect(second.skipped).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops realtime upload on forbidden response', async () => {
+    withApiKey();
+    const { ctx, fetch } = createContext(async () => textResponse('Forbidden', 403));
+    const provider = new ClubLogSyncProvider(ctx);
+    configure(provider);
+
+    const result = await provider.upload('BG5DRB', {
+      trigger: 'auto',
+      records: [createQso('qso-1'), createQso('qso-2')],
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.failures?.[0]).toEqual(expect.objectContaining({
+      code: 'clublog_upload_forbidden',
+      httpStatus: 403,
+      retryable: false,
+    }));
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak secrets in failures', async () => {
+    withApiKey('secret-api-key');
+    const { ctx } = createContext(async () => textResponse('Rejected secret-api-key app-password ham@example.com', 400));
+    const provider = new ClubLogSyncProvider(ctx);
+    configure(provider);
+
+    const result = await provider.upload('BG5DRB', { trigger: 'auto', records: [createQso('qso-1')] });
+    const failureText = JSON.stringify(result.failures);
+
+    expect(failureText).not.toContain('secret-api-key');
+    expect(failureText).not.toContain('app-password');
+    expect(failureText).not.toContain('ham@example.com');
+    expect(failureText).toContain('[redacted]');
+  });
+
+  it('manual upload submits batch ADIF and skips ledger entries later', async () => {
+    withApiKey();
+    const { ctx, fetch, queryQSOs } = createContext(async () => textResponse('File queued'));
+    const provider = new ClubLogSyncProvider(ctx);
+    configure(provider);
+    const qso = createQso('qso-1');
+    queryQSOs.mockResolvedValue([qso]);
+
+    const first = await provider.upload('BG5DRB', { trigger: 'manual' });
+    const second = await provider.upload('BG5DRB', { trigger: 'manual' });
+
+    expect(first).toEqual({ submitted: 1, uploaded: 1, skipped: 0, failed: 0, failures: undefined });
+    expect(second.uploaded).toBe(0);
+    expect(second.skipped).toBe(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBe('https://clublog.org/putlogs.php');
+    expect(init?.body).toBeInstanceOf(FormData);
+    const form = init?.body as FormData;
+    expect(form.get('email')).toBe('ham@example.com');
+    expect(form.get('password')).toBe('app-password');
+    expect(form.get('callsign')).toBe('BG5DRB');
+    expect(form.get('api')).toBe('developer-api-key');
+    expect(form.get('clear')).toBe('0');
+    expect(form.get('file')).toBeInstanceOf(Blob);
+  });
+
+  it('preflight reports blocked callsign mismatches', async () => {
+    withApiKey();
+    const { ctx, queryQSOs } = createContext(async () => textResponse('File queued'));
+    const provider = new ClubLogSyncProvider(ctx);
+    configure(provider);
+    queryQSOs.mockResolvedValue([createQso('qso-1', { myCallsign: 'OTHER' })]);
+
+    const preflight = await provider.getUploadPreflight('BG5DRB');
+
+    expect(preflight.ready).toBe(false);
+    expect(preflight.pendingCount).toBe(1);
+    expect(preflight.uploadableCount).toBe(0);
+    expect(preflight.blockedCount).toBe(1);
+    expect(preflight.issues).toEqual([
+      expect.objectContaining({ code: 'clublog_qso_callsign_mismatch', severity: 'error' }),
+    ]);
+  });
+});

--- a/packages/builtin-plugins/src/clublog-sync/provider.ts
+++ b/packages/builtin-plugins/src/clublog-sync/provider.ts
@@ -1,0 +1,729 @@
+import type {
+  LogbookSyncProvider,
+  PluginContext,
+  SyncAction,
+  SyncDownloadResult,
+  SyncFailure,
+  SyncFailureOperation,
+  SyncTestResult,
+  SyncUploadOptions,
+  SyncUploadPreflightOptions,
+  SyncUploadPreflightResult,
+  SyncUploadProgress,
+  SyncUploadResult,
+} from '@tx5dr/plugin-api';
+import type { QSORecord } from '@tx5dr/contracts';
+import {
+  convertQSOToADIF,
+  createSyncFailure,
+  errorToSyncFailure,
+  generateADIFFile,
+  normalizeCallsign,
+  sanitizeSyncFailureText,
+} from '@tx5dr/plugin-api';
+import { BUILTIN_CLUBLOG_API_KEY } from './generated/api-key.js';
+
+const CONFIG_KEY_PREFIX = 'config:';
+const LEDGER_KEY_PREFIX = 'ledger:';
+const CLUBLOG_REALTIME_URL = 'https://clublog.org/realtime.php';
+const CLUBLOG_BATCH_URL = 'https://clublog.org/putlogs.php';
+const CLUBLOG_USER_AGENT = 'TX5DR-ClubLogSync/1.0';
+const CLUBLOG_REQUEST_TIMEOUT_MS = 30000;
+
+export interface ClubLogPluginConfig {
+  email: string;
+  password: string;
+  autoUploadQSO: boolean;
+  lastRealtimeUploadTime?: number;
+  lastBatchUploadTime?: number;
+}
+
+type ClubLogLedgerStatus = 'realtime_ok' | 'duplicate' | 'modified' | 'batch_submitted';
+
+type ClubLogUploadLedger = Record<string, {
+  status: ClubLogLedgerStatus;
+  uploadedAt: number;
+  method: 'realtime' | 'batch';
+  qsoId?: string;
+  startTime: number;
+  callsign: string;
+}>;
+
+type RealtimeStatus = 'ok' | 'duplicate' | 'modified' | 'rejected' | 'failed' | 'forbidden';
+
+interface RealtimeResult {
+  status: RealtimeStatus;
+  message: string;
+  retryable: boolean;
+  httpStatus: number;
+}
+
+interface PreparedUpload {
+  allQsos: QSORecord[];
+  uploadableQsos: QSORecord[];
+  skippedCount: number;
+  blockedIssues: SyncUploadPreflightResult['issues'];
+}
+
+function normalizeLedgerPart(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+function qsoFingerprint(qso: QSORecord, fallbackCallsign: string): string {
+  const station = normalizeLedgerPart(qso.myCallsign || fallbackCallsign);
+  const call = normalizeLedgerPart(qso.callsign);
+  const frequency = Number.isFinite(qso.frequency) ? String(Math.round(qso.frequency)) : '';
+  const mode = normalizeLedgerPart(qso.mode);
+  const submode = normalizeLedgerPart(qso.submode);
+  return [station, call, String(qso.startTime || 0), frequency, mode, submode].join('|');
+}
+
+function secretsFor(config: ClubLogPluginConfig | null | undefined, apiKey?: string): string[] {
+  return [config?.password, config?.email, apiKey].filter((value): value is string => !!value);
+}
+
+function sanitizeResponseText(value: string, secrets: string[]): string {
+  return sanitizeSyncFailureText(value, secrets)
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+}
+
+function ensureUppercaseEor(adif: string): string {
+  return adif.replace(/<eor>\s*$/i, '<EOR>');
+}
+
+function isNetworkMessage(message: string): boolean {
+  return /fetch failed|network|timeout|aborted|ECONN|ENOTFOUND|EAI_AGAIN|ETIMEDOUT/i.test(message);
+}
+
+function forbiddenMessage(): string {
+  return 'Club Log returned 403 Forbidden. Check the developer API key, account email, application password, callsign ownership, and whether Club Log has temporarily blocked this IP after repeated failed requests.';
+}
+
+function dateRangeFilter(options?: Pick<SyncUploadOptions | SyncUploadPreflightOptions, 'since' | 'until'>) {
+  if (!options?.since && !options?.until) return undefined;
+  return {
+    start: options.since ?? 0,
+    end: options.until ?? Date.now(),
+  };
+}
+
+function missingQsoIssues(qso: QSORecord, boundCallsign: string): NonNullable<SyncUploadPreflightResult['issues']> {
+  const issues: NonNullable<SyncUploadPreflightResult['issues']> = [];
+  if (!qso.callsign?.trim()) {
+    issues.push({ code: 'clublog_qso_callsign_missing', severity: 'error', message: 'QSO callsign is required', qsoId: qso.id });
+  }
+  if (!Number.isFinite(qso.startTime) || qso.startTime <= 0) {
+    issues.push({ code: 'clublog_qso_time_missing', severity: 'error', message: 'QSO start time is required', qsoId: qso.id, qsoCallsign: qso.callsign });
+  }
+  if (!Number.isFinite(qso.frequency) || qso.frequency <= 0) {
+    issues.push({ code: 'clublog_qso_frequency_missing', severity: 'error', message: 'QSO frequency is required', qsoId: qso.id, qsoCallsign: qso.callsign });
+  }
+  if (!qso.mode?.trim()) {
+    issues.push({ code: 'clublog_qso_mode_missing', severity: 'error', message: 'QSO mode is required', qsoId: qso.id, qsoCallsign: qso.callsign });
+  }
+  if (qso.myCallsign && normalizeCallsign(qso.myCallsign) !== normalizeCallsign(boundCallsign)) {
+    issues.push({
+      code: 'clublog_qso_callsign_mismatch',
+      severity: 'error',
+      message: 'QSO station callsign does not match the selected logbook callsign',
+      detail: `${qso.myCallsign} != ${boundCallsign}`,
+      qsoId: qso.id,
+      qsoCallsign: qso.callsign,
+    });
+  }
+  return issues;
+}
+
+export class ClubLogSyncProvider implements LogbookSyncProvider {
+  readonly id = 'clublog';
+  readonly displayName = 'Club Log';
+  readonly color = 'warning' as const;
+  readonly accessScope = 'operator' as const;
+  readonly settingsPageId = 'settings';
+  readonly actions: SyncAction[] = [
+    { id: 'upload', label: 'Upload', icon: 'upload', pageId: 'upload-wizard' },
+  ];
+
+  constructor(private ctx: PluginContext) {}
+
+  private configKey(callsign: string): string {
+    return `${CONFIG_KEY_PREFIX}${normalizeCallsign(callsign)}`;
+  }
+
+  private ledgerKey(callsign: string): string {
+    return `${LEDGER_KEY_PREFIX}${normalizeCallsign(callsign)}`;
+  }
+
+  getConfig(callsign: string): ClubLogPluginConfig | null {
+    return this.ctx.store.global.get<ClubLogPluginConfig | undefined>(this.configKey(callsign)) ?? null;
+  }
+
+  setConfig(callsign: string, config: ClubLogPluginConfig): void {
+    this.ctx.store.global.set(this.configKey(callsign), config);
+  }
+
+  getApiKeyStatus(): { available: boolean } {
+    return { available: this.resolveApiKey().length > 0 };
+  }
+
+  private resolveApiKey(): string {
+    return process.env.TX5DR_CLUBLOG_API_KEY || BUILTIN_CLUBLOG_API_KEY || '';
+  }
+
+  private getLedger(callsign: string): ClubLogUploadLedger {
+    return this.ctx.store.global.get<ClubLogUploadLedger | undefined>(this.ledgerKey(callsign)) ?? {};
+  }
+
+  private setLedger(callsign: string, ledger: ClubLogUploadLedger): void {
+    this.ctx.store.global.set(this.ledgerKey(callsign), ledger);
+  }
+
+  private markUploaded(
+    callsign: string,
+    ledger: ClubLogUploadLedger,
+    qso: QSORecord,
+    status: ClubLogLedgerStatus,
+    method: 'realtime' | 'batch',
+  ): void {
+    ledger[qsoFingerprint(qso, callsign)] = {
+      status,
+      uploadedAt: Date.now(),
+      method,
+      qsoId: qso.id,
+      startTime: qso.startTime,
+      callsign: qso.callsign,
+    };
+  }
+
+  isConfigured(callsign: string): boolean {
+    const config = this.getConfig(callsign);
+    return !!(config?.email && config.password && this.resolveApiKey());
+  }
+
+  isAutoUploadEnabled(callsign: string): boolean {
+    const config = this.getConfig(callsign);
+    return !!(config?.email && config.password && config.autoUploadQSO && this.resolveApiKey());
+  }
+
+  async testConnection(callsign: string, overrideConfig?: ClubLogPluginConfig | null): Promise<SyncTestResult> {
+    const config = overrideConfig ?? this.getConfig(callsign);
+    const apiKey = this.resolveApiKey();
+    if (!config?.email || !config.password) {
+      const failure = this.createFailure('clublog_not_configured', 'Email and application password are required', {
+        operation: 'test_connection',
+        config,
+        apiKey,
+      });
+      return { success: false, message: failure.message, failures: [failure], details: { apiKeyAvailable: !!apiKey } };
+    }
+    if (!apiKey) {
+      const failure = this.createFailure('clublog_api_key_unavailable', 'Club Log API key is not available in this build', {
+        operation: 'test_connection',
+        config,
+      });
+      return { success: false, message: failure.message, failures: [failure], details: { apiKeyAvailable: false } };
+    }
+
+    try {
+      const response = await this.doFetch(CLUBLOG_REALTIME_URL, { method: 'HEAD', timeout: 10000 });
+      return {
+        success: response.ok || response.status === 405 || response.status === 400,
+        message: 'Club Log endpoint reachable. Credentials will be verified on first upload.',
+        details: { apiKeyAvailable: true, httpStatus: response.status },
+      };
+    } catch (error) {
+      this.ctx.log.error('Connection test failed', error);
+      const failure = this.errorFailure(error, 'test_connection', 'clublog_connection_failed', config, apiKey);
+      return { success: false, message: failure.message, failures: [failure], details: { apiKeyAvailable: true } };
+    }
+  }
+
+  async getUploadPreflight(callsign: string, options?: SyncUploadPreflightOptions): Promise<SyncUploadPreflightResult> {
+    const config = this.getConfig(callsign);
+    const apiKey = this.resolveApiKey();
+    const issues: NonNullable<SyncUploadPreflightResult['issues']> = [];
+
+    if (!config?.email || !config.password) {
+      issues.push({ code: 'clublog_not_configured', severity: 'error', message: 'Email and application password are required' });
+    }
+    if (!apiKey) {
+      issues.push({ code: 'clublog_api_key_unavailable', severity: 'error', message: 'Club Log API key is not available in this build' });
+    }
+
+    const prepared = await this.prepareUpload(callsign, options);
+    issues.push(...(prepared.blockedIssues ?? []));
+    return {
+      ready: issues.filter((issue) => issue.severity === 'error').length === 0 && prepared.uploadableQsos.length > 0,
+      pendingCount: prepared.allQsos.length,
+      uploadableCount: prepared.uploadableQsos.length,
+      blockedCount: prepared.blockedIssues?.length ?? 0,
+      issues: issues.length > 0 ? issues : undefined,
+      canSkipBlocked: (prepared.blockedIssues?.length ?? 0) > 0 && prepared.uploadableQsos.length > 0,
+      guidance: ['Batch uploads are queued by Club Log; check Club Log for final import results.'],
+    };
+  }
+
+  async upload(callsign: string, options?: SyncUploadOptions): Promise<SyncUploadResult> {
+    const config = this.getConfig(callsign);
+    const apiKey = this.resolveApiKey();
+    if (!config?.email || !config.password) {
+      return this.failureUploadResult(this.createFailure('clublog_not_configured', 'Club Log not configured', {
+        operation: 'upload',
+        config,
+        apiKey,
+      }));
+    }
+    if (!apiKey) {
+      return this.failureUploadResult(this.createFailure('clublog_api_key_unavailable', 'Club Log API key is not available in this build', {
+        operation: 'upload',
+        config,
+      }));
+    }
+
+    if (options?.trigger === 'auto' && options.records) {
+      return this.uploadRealtime(callsign, config, apiKey, options);
+    }
+
+    return this.uploadBatch(callsign, config, apiKey, options);
+  }
+
+  async download(_callsign: string): Promise<SyncDownloadResult> {
+    return {
+      downloaded: 0,
+      matched: 0,
+      updated: 0,
+      failures: [this.createFailure('clublog_download_unsupported', 'Club Log download sync is not supported', {
+        operation: 'download',
+      })],
+    };
+  }
+
+  private async uploadRealtime(
+    callsign: string,
+    config: ClubLogPluginConfig,
+    apiKey: string,
+    options: SyncUploadOptions,
+  ): Promise<SyncUploadResult> {
+    const ledger = this.getLedger(callsign);
+    const records = options.records ?? [];
+    let uploaded = 0;
+    let skipped = 0;
+    let failed = 0;
+    const failures: SyncFailure[] = [];
+
+    for (const qso of records) {
+      const key = qsoFingerprint(qso, callsign);
+      if (!options.includeAlreadyUploaded && ledger[key]) {
+        skipped++;
+        continue;
+      }
+
+      const issues = missingQsoIssues(qso, callsign);
+      if (issues.length > 0) {
+        failed++;
+        failures.push(...issues.map((issue) => this.createFailure(issue.code, issue.message, {
+          operation: 'preflight',
+          qsoId: issue.qsoId,
+          qsoCallsign: issue.qsoCallsign,
+          detail: issue.detail,
+          config,
+          apiKey,
+        })));
+        continue;
+      }
+
+      try {
+        const result = await this.uploadSingleRealtime(callsign, config, apiKey, qso);
+        if (result.status === 'ok' || result.status === 'modified') {
+          uploaded++;
+          this.markUploaded(callsign, ledger, qso, result.status === 'modified' ? 'modified' : 'realtime_ok', 'realtime');
+        } else if (result.status === 'duplicate') {
+          skipped++;
+          this.markUploaded(callsign, ledger, qso, 'duplicate', 'realtime');
+        } else {
+          failed++;
+          failures.push(this.createQsoFailure(qso, this.codeForRealtimeStatus(result.status), result.message, {
+            httpStatus: result.httpStatus,
+            retryable: result.retryable,
+            config,
+            apiKey,
+          }));
+          if (result.status === 'forbidden') break;
+        }
+      } catch (error) {
+        failed++;
+        failures.push(this.createQsoFailure(qso, 'clublog_upload_failed', error instanceof Error ? error.message : 'Upload failed', {
+          source: this.sourceForError(error),
+          retryable: this.isRetryableError(error),
+          config,
+          apiKey,
+        }));
+      }
+    }
+
+    if (uploaded > 0 || skipped > 0) {
+      this.setLedger(callsign, ledger);
+      this.setConfig(callsign, { ...config, lastRealtimeUploadTime: Date.now() });
+    }
+
+    return { uploaded, skipped, failed, failures: failures.length > 0 ? failures : undefined };
+  }
+
+  private async uploadBatch(
+    callsign: string,
+    config: ClubLogPluginConfig,
+    apiKey: string,
+    options?: SyncUploadOptions,
+  ): Promise<SyncUploadResult> {
+    this.emitUploadProgress(options, { stage: 'preparing', callsign, message: 'Preparing Club Log upload' });
+    const prepared = await this.prepareUpload(callsign, options);
+    const blockingIssues = prepared.blockedIssues ?? [];
+    if (blockingIssues.length > 0 && !options?.skipBlockedQsos) {
+      return {
+        submitted: 0,
+        uploaded: 0,
+        skipped: prepared.skippedCount,
+        failed: prepared.allQsos.length - prepared.skippedCount,
+        failures: blockingIssues.map((issue) => this.createFailure(issue.code, issue.message, {
+          operation: 'preflight',
+          qsoId: issue.qsoId,
+          qsoCallsign: issue.qsoCallsign,
+          detail: issue.detail,
+          config,
+          apiKey,
+        })),
+      };
+    }
+
+    const qsos = prepared.uploadableQsos;
+    this.emitUploadProgress(options, {
+      stage: 'prepared',
+      callsign,
+      pendingCount: prepared.allQsos.length,
+      uploadableCount: qsos.length,
+      blockedCount: blockingIssues.length,
+      skipped: prepared.skippedCount,
+      batchCount: qsos.length > 0 ? 1 : 0,
+    });
+
+    if (qsos.length === 0) {
+      this.emitUploadProgress(options, {
+        stage: 'finished',
+        callsign,
+        submitted: 0,
+        uploaded: 0,
+        skipped: prepared.skippedCount,
+        failed: 0,
+        failureCount: 0,
+      });
+      return { submitted: 0, uploaded: 0, skipped: prepared.skippedCount, failed: 0 };
+    }
+
+    try {
+      this.emitUploadProgress(options, {
+        stage: 'batch_uploading',
+        callsign,
+        batchIndex: 1,
+        batchCount: 1,
+        qsoCount: qsos.length,
+        skipped: prepared.skippedCount,
+      });
+      const responseSummary = await this.submitBatch(callsign, config, apiKey, qsos);
+      const ledger = this.getLedger(callsign);
+      for (const qso of qsos) {
+        this.markUploaded(callsign, ledger, qso, 'batch_submitted', 'batch');
+      }
+      this.setLedger(callsign, ledger);
+      this.setConfig(callsign, { ...config, lastBatchUploadTime: Date.now() });
+      this.ctx.log.info('Club Log batch upload accepted', { callsign, qsoCount: qsos.length, responseSummary });
+      this.emitUploadProgress(options, {
+        stage: 'batch_accepted',
+        callsign,
+        batchIndex: 1,
+        batchCount: 1,
+        qsoCount: qsos.length,
+        submitted: qsos.length,
+        uploaded: qsos.length,
+        skipped: prepared.skippedCount,
+      });
+      this.emitUploadProgress(options, {
+        stage: 'finished',
+        callsign,
+        submitted: qsos.length,
+        uploaded: qsos.length,
+        skipped: prepared.skippedCount,
+        failed: 0,
+        failureCount: 0,
+      });
+      return { submitted: qsos.length, uploaded: qsos.length, skipped: prepared.skippedCount, failed: 0 };
+    } catch (error) {
+      const failure = this.errorFailure(error, 'upload', 'clublog_batch_submit_failed', config, apiKey);
+      this.emitUploadProgress(options, {
+        stage: 'batch_failed',
+        callsign,
+        batchIndex: 1,
+        batchCount: 1,
+        qsoCount: qsos.length,
+        failed: qsos.length,
+        failureCount: 1,
+        message: failure.message,
+      });
+      this.emitUploadProgress(options, {
+        stage: 'finished',
+        callsign,
+        submitted: 0,
+        uploaded: 0,
+        skipped: prepared.skippedCount,
+        failed: qsos.length,
+        failureCount: 1,
+      });
+      return { submitted: 0, uploaded: 0, skipped: prepared.skippedCount, failed: qsos.length, failures: [failure] };
+    }
+  }
+
+  private async prepareUpload(
+    callsign: string,
+    options?: SyncUploadOptions | SyncUploadPreflightOptions,
+  ): Promise<PreparedUpload> {
+    const logbook = this.ctx.logbook.forCallsign(callsign);
+    const query: Parameters<typeof logbook.queryQSOs>[0] = {};
+    const timeRange = dateRangeFilter(options);
+    if (timeRange) query.timeRange = timeRange;
+    const allQsos = await logbook.queryQSOs(query);
+    const ledger = this.getLedger(callsign);
+    const uploadableQsos: QSORecord[] = [];
+    const blockedIssues: NonNullable<SyncUploadPreflightResult['issues']> = [];
+    let skippedCount = 0;
+
+    for (const qso of allQsos) {
+      const key = qsoFingerprint(qso, callsign);
+      if (!options?.includeAlreadyUploaded && ledger[key]) {
+        skippedCount++;
+        continue;
+      }
+      const issues = missingQsoIssues(qso, callsign);
+      if (issues.length > 0) {
+        blockedIssues.push(...issues);
+        continue;
+      }
+      uploadableQsos.push(qso);
+    }
+
+    return { allQsos, uploadableQsos, skippedCount, blockedIssues };
+  }
+
+  private async uploadSingleRealtime(
+    callsign: string,
+    config: ClubLogPluginConfig,
+    apiKey: string,
+    qso: QSORecord,
+  ): Promise<RealtimeResult> {
+    const adif = ensureUppercaseEor(convertQSOToADIF(qso, { includeStationCallsign: true }));
+    const body = new URLSearchParams({
+      email: config.email,
+      password: config.password,
+      callsign: normalizeCallsign(callsign),
+      adif,
+      api: apiKey,
+    });
+
+    this.ctx.log.debug('Uploading QSO to Club Log', { callsign: qso.callsign, mode: qso.mode, frequency: qso.frequency });
+    const response = await this.doFetch(CLUBLOG_REALTIME_URL, {
+      method: 'POST',
+      body,
+      timeout: CLUBLOG_REQUEST_TIMEOUT_MS,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+    const responseText = await response.text();
+    const summary = sanitizeResponseText(responseText, secretsFor(config, apiKey));
+    this.ctx.log.debug('Club Log realtime response', { status: response.status, body: summary });
+
+    if (response.status === 403) {
+      return { status: 'forbidden', message: forbiddenMessage(), retryable: false, httpStatus: response.status };
+    }
+    if (response.status >= 500) {
+      return { status: 'failed', message: summary || `HTTP ${response.status}`, retryable: true, httpStatus: response.status };
+    }
+    if (!response.ok) {
+      return {
+        status: response.status === 400 ? 'rejected' : 'failed',
+        message: summary || `HTTP ${response.status}`,
+        retryable: false,
+        httpStatus: response.status,
+      };
+    }
+    if (/QSO\s+Duplicate/i.test(responseText)) {
+      return { status: 'duplicate', message: summary || 'QSO Duplicate', retryable: false, httpStatus: response.status };
+    }
+    if (/QSO\s+Modified/i.test(responseText)) {
+      return { status: 'modified', message: summary || 'QSO Modified', retryable: false, httpStatus: response.status };
+    }
+    if (/QSO\s+OK/i.test(responseText)) {
+      return { status: 'ok', message: summary || 'QSO OK', retryable: false, httpStatus: response.status };
+    }
+    if (/QSO\s+Rejected/i.test(responseText)) {
+      return { status: 'rejected', message: summary || 'QSO Rejected', retryable: false, httpStatus: response.status };
+    }
+    return { status: 'failed', message: summary || 'Unexpected Club Log response', retryable: false, httpStatus: response.status };
+  }
+
+  private async submitBatch(callsign: string, config: ClubLogPluginConfig, apiKey: string, qsos: QSORecord[]): Promise<string> {
+    const adif = generateADIFFile(qsos, {
+      programId: 'TX5DR',
+      programVersion: '1.0',
+      includeStationCallsign: true,
+    });
+    const form = new FormData();
+    form.set('email', config.email);
+    form.set('password', config.password);
+    form.set('callsign', normalizeCallsign(callsign));
+    form.set('clear', '0');
+    form.set('api', apiKey);
+    form.set('file', new Blob([adif], { type: 'application/octet-stream' }), `tx5dr-clublog-${normalizeCallsign(callsign)}.adi`);
+
+    const response = await this.doFetch(CLUBLOG_BATCH_URL, {
+      method: 'POST',
+      body: form,
+      timeout: CLUBLOG_REQUEST_TIMEOUT_MS,
+    });
+    const responseText = await response.text();
+    const summary = sanitizeResponseText(responseText, secretsFor(config, apiKey));
+    if (response.status === 403) {
+      throw new ClubLogRemoteError(forbiddenMessage(), response.status, false);
+    }
+    if (!response.ok) {
+      throw new ClubLogRemoteError(summary || `HTTP ${response.status}`, response.status, response.status >= 500 || response.status === 429);
+    }
+    return summary;
+  }
+
+  private async doFetch(url: string, init: RequestInit & { timeout: number }): Promise<Response> {
+    if (!this.ctx.fetch) {
+      throw new Error('Network permission is required');
+    }
+    const { timeout, headers, ...rest } = init;
+    return this.ctx.fetch(url, {
+      ...rest,
+      headers: {
+        'User-Agent': CLUBLOG_USER_AGENT,
+        ...headers,
+      },
+      signal: AbortSignal.timeout(timeout),
+    });
+  }
+
+  private failureUploadResult(failure: SyncFailure): SyncUploadResult {
+    return { uploaded: 0, skipped: 0, failed: 0, failures: [failure] };
+  }
+
+  private codeForRealtimeStatus(status: RealtimeStatus): string {
+    if (status === 'forbidden') return 'clublog_upload_forbidden';
+    if (status === 'rejected') return 'clublog_upload_rejected';
+    return 'clublog_upload_failed';
+  }
+
+  private createFailure(
+    code: string,
+    message: string,
+    options: {
+      operation: SyncFailureOperation;
+      source?: SyncFailure['source'];
+      detail?: string;
+      httpStatus?: number;
+      retryable?: boolean;
+      qsoId?: string;
+      qsoCallsign?: string;
+      config?: ClubLogPluginConfig | null;
+      apiKey?: string;
+    },
+  ): SyncFailure {
+    return createSyncFailure({
+      code,
+      message,
+      source: options.source ?? 'provider',
+      operation: options.operation,
+      providerId: this.id,
+      detail: options.detail,
+      httpStatus: options.httpStatus,
+      retryable: options.retryable,
+      qsoId: options.qsoId,
+      qsoCallsign: options.qsoCallsign,
+      secrets: secretsFor(options.config, options.apiKey),
+    });
+  }
+
+  private createQsoFailure(
+    qso: QSORecord,
+    code: string,
+    message: string,
+    options: {
+      source?: SyncFailure['source'];
+      retryable?: boolean;
+      httpStatus?: number;
+      config: ClubLogPluginConfig;
+      apiKey: string;
+    },
+  ): SyncFailure {
+    return this.createFailure(code, message, {
+      operation: 'upload',
+      source: options.source ?? 'remote',
+      retryable: options.retryable,
+      httpStatus: options.httpStatus,
+      qsoId: qso.id,
+      qsoCallsign: qso.callsign,
+      config: options.config,
+      apiKey: options.apiKey,
+    });
+  }
+
+  private errorFailure(
+    error: unknown,
+    operation: SyncFailureOperation,
+    code: string,
+    config: ClubLogPluginConfig,
+    apiKey: string,
+  ): SyncFailure {
+    const remoteError = error instanceof ClubLogRemoteError ? error : null;
+    return errorToSyncFailure(error, {
+      code,
+      source: remoteError ? 'remote' : this.sourceForError(error),
+      operation,
+      providerId: this.id,
+      httpStatus: remoteError?.httpStatus,
+      retryable: remoteError?.retryable ?? this.isRetryableError(error),
+      secrets: secretsFor(config, apiKey),
+    });
+  }
+
+  private sourceForError(error: unknown): SyncFailure['source'] {
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    if (isNetworkMessage(message)) return 'network';
+    return 'provider';
+  }
+
+  private isRetryableError(error: unknown): boolean {
+    if (error instanceof ClubLogRemoteError) return error.retryable;
+    const message = error instanceof Error ? error.message : String(error ?? '');
+    return isNetworkMessage(message);
+  }
+
+  private emitUploadProgress(options: SyncUploadOptions | undefined, progress: SyncUploadProgress): void {
+    try {
+      options?.onProgress?.(progress);
+    } catch (error) {
+      this.ctx.log.warn('Club Log upload progress callback failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+class ClubLogRemoteError extends Error {
+  constructor(message: string, readonly httpStatus: number, readonly retryable: boolean) {
+    super(message);
+    this.name = 'ClubLogRemoteError';
+  }
+}

--- a/packages/builtin-plugins/src/clublog-sync/ui/settings.html
+++ b/packages/builtin-plugins/src/clublog-sync/ui/settings.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./settings/main.tsx"></script>
+</body>
+</html>

--- a/packages/builtin-plugins/src/clublog-sync/ui/settings/App.css
+++ b/packages/builtin-plugins/src/clublog-sync/ui/settings/App.css
@@ -1,0 +1,123 @@
+.container { padding: var(--tx5dr-spacing-sm) 0; }
+.section-title {
+  font-size: var(--tx5dr-font-size-lg);
+  font-weight: 600;
+  margin-bottom: var(--tx5dr-spacing-md);
+}
+.section-divider {
+  border: none;
+  border-top: 1px solid var(--tx5dr-border);
+  margin: var(--tx5dr-spacing-lg) 0;
+}
+.form-group { margin-bottom: var(--tx5dr-spacing-md); }
+.form-group label {
+  display: block;
+  font-size: var(--tx5dr-font-size-sm);
+  color: var(--tx5dr-text-secondary);
+  margin-bottom: var(--tx5dr-spacing-xs);
+}
+.form-group input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--tx5dr-bg-content);
+  color: var(--tx5dr-text);
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  font-family: var(--tx5dr-font);
+  font-size: var(--tx5dr-font-size-md);
+  outline: none;
+  box-sizing: border-box;
+}
+.form-group input:focus {
+  border-color: var(--tx5dr-primary);
+  box-shadow: 0 0 0 2px var(--tx5dr-focus-ring);
+}
+.form-group input[type="password"] {
+  font-family: var(--tx5dr-font-mono);
+  letter-spacing: 0.05em;
+}
+.hint {
+  font-size: var(--tx5dr-font-size-sm);
+  color: var(--tx5dr-text-secondary);
+  margin-top: var(--tx5dr-spacing-xs);
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--tx5dr-radius-sm);
+  font-family: var(--tx5dr-font);
+  font-size: var(--tx5dr-font-size-md);
+  cursor: pointer;
+}
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: var(--tx5dr-primary); color: #fff; }
+.btn-secondary { background: var(--tx5dr-bg-hover); color: var(--tx5dr-text); }
+.btn-row {
+  display: flex;
+  gap: var(--tx5dr-spacing-sm);
+  align-items: center;
+  margin-top: var(--tx5dr-spacing-sm);
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: var(--tx5dr-font-size-sm);
+}
+.chip-success { background: rgba(23,201,100,0.15); color: var(--tx5dr-success); }
+.chip-danger { background: rgba(243,18,96,0.15); color: var(--tx5dr-danger); }
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--tx5dr-spacing-sm) 0;
+}
+.toggle-label { font-size: var(--tx5dr-font-size-md); }
+.toggle-desc {
+  font-size: var(--tx5dr-font-size-sm);
+  color: var(--tx5dr-text-secondary);
+  margin-top: 2px;
+}
+.switch { position: relative; width: 44px; height: 24px; flex-shrink: 0; }
+.switch input { opacity: 0; width: 0; height: 0; }
+.switch .slider {
+  position: absolute;
+  inset: 0;
+  background: var(--tx5dr-bg-hover);
+  border-radius: 12px;
+  cursor: pointer;
+}
+.switch .slider::before {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  bottom: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+.switch input:checked + .slider { background: var(--tx5dr-primary); }
+.switch input:checked + .slider::before { transform: translateX(20px); }
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tx5dr-spacing-sm);
+  font-size: var(--tx5dr-font-size-sm);
+  color: var(--tx5dr-text-secondary);
+  padding: var(--tx5dr-spacing-xs) 0;
+}
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--tx5dr-border);
+  border-top-color: var(--tx5dr-primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/packages/builtin-plugins/src/clublog-sync/ui/settings/App.tsx
+++ b/packages/builtin-plugins/src/clublog-sync/ui/settings/App.tsx
@@ -1,0 +1,238 @@
+/// <reference types="@tx5dr/plugin-api/bridge" />
+import { useCallback, useEffect, useState } from 'react';
+import { useI18n } from '../../../_shared/ui/useI18n';
+import { useAutoResize } from '../../../_shared/ui/useAutoResize';
+import './App.css';
+
+interface ClubLogConfig {
+  email: string;
+  password: string;
+  autoUploadQSO: boolean;
+  lastRealtimeUploadTime?: number;
+  lastBatchUploadTime?: number;
+}
+
+const I18N: Record<string, Record<string, string>> = {
+  zh: {
+    connectionTitle: 'Club Log 连接设置',
+    emailLabel: 'Club Log 邮箱',
+    emailPlaceholder: 'your@example.com',
+    passwordLabel: 'Application Password',
+    passwordPlaceholder: '输入 Club Log Application Password',
+    passwordHint: '建议在 Club Log 中创建专用 Application Password，不要使用主密码。',
+    apiKeyLabel: '内置 API Key',
+    apiKeyReady: '可用',
+    apiKeyMissing: '当前构建未包含 API Key',
+    testBtn: '测试连接',
+    testing: '测试中...',
+    connected: 'Club Log 服务可访问；账号和密码会在首次上传时验证。',
+    connectionFailed: '连接失败',
+    syncTitle: '同步设置',
+    autoUpload: 'QSO 完成后自动上传',
+    autoUploadDesc: '通联完成时自动将新 QSO 实时上传到 Club Log',
+    lastRealtime: '上次实时上传',
+    lastBatch: '上次批量提交',
+    never: '从未',
+    saveBtn: '保存',
+    saving: '保存中...',
+    saved: '已保存',
+    saveFailed: '保存失败',
+    missingRequired: '请填写邮箱和 Application Password，并确保当前构建包含 Club Log API Key',
+  },
+  ja: {
+    connectionTitle: 'Club Log 接続設定',
+    emailLabel: 'Club Log メール',
+    emailPlaceholder: 'your@example.com',
+    passwordLabel: 'Application Password',
+    passwordPlaceholder: 'Club Log Application Password を入力してください',
+    passwordHint: 'Club Log で専用の Application Password を作成することを推奨します。',
+    apiKeyLabel: '組み込み API Key',
+    apiKeyReady: '利用可能',
+    apiKeyMissing: 'このビルドには API Key が含まれていません',
+    testBtn: '接続テスト',
+    testing: 'テスト中...',
+    connected: 'Club Log サービスに接続できます。アカウントとパスワードは初回アップロード時に検証されます。',
+    connectionFailed: '接続失敗',
+    syncTitle: '同期設定',
+    autoUpload: 'QSO 完了後に自動アップロード',
+    autoUploadDesc: '交信完了時に新しい QSO を Club Log にリアルタイムアップロードします',
+    lastRealtime: '前回リアルタイムアップロード',
+    lastBatch: '前回一括送信',
+    never: 'なし',
+    saveBtn: '保存',
+    saving: '保存中...',
+    saved: '保存しました',
+    saveFailed: '保存失敗',
+    missingRequired: 'メール、Application Password を入力し、このビルドに Club Log API Key が含まれていることを確認してください',
+  },
+  en: {
+    connectionTitle: 'Club Log Connection',
+    emailLabel: 'Club Log Email',
+    emailPlaceholder: 'your@example.com',
+    passwordLabel: 'Application Password',
+    passwordPlaceholder: 'Enter Club Log application password',
+    passwordHint: 'Use a dedicated Club Log application password instead of your main password.',
+    apiKeyLabel: 'Built-in API Key',
+    apiKeyReady: 'Available',
+    apiKeyMissing: 'Missing from this build',
+    testBtn: 'Test Connection',
+    testing: 'Testing...',
+    connected: 'Club Log endpoint is reachable. Your credentials will be verified on first upload.',
+    connectionFailed: 'Connection failed',
+    syncTitle: 'Sync Options',
+    autoUpload: 'Auto-upload after QSO',
+    autoUploadDesc: 'Upload new QSO records to Club Log as contacts are completed',
+    lastRealtime: 'Last realtime upload',
+    lastBatch: 'Last batch submit',
+    never: 'Never',
+    saveBtn: 'Save',
+    saving: 'Saving...',
+    saved: 'Saved',
+    saveFailed: 'Save failed',
+    missingRequired: 'Fill in email and application password, and make sure this build includes a Club Log API key',
+  },
+};
+
+function formatTime(value?: number, never = 'Never'): string {
+  return value ? new Date(value).toLocaleString() : never;
+}
+
+export function App() {
+  const t = useI18n(I18N);
+  const callsign = window.tx5dr.params.callsign ?? '';
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [autoUpload, setAutoUpload] = useState(false);
+  const [apiKeyAvailable, setApiKeyAvailable] = useState(false);
+  const [lastRealtimeUploadTime, setLastRealtimeUploadTime] = useState<number | undefined>();
+  const [lastBatchUploadTime, setLastBatchUploadTime] = useState<number | undefined>();
+  const [testing, setTesting] = useState(false);
+  const [testStatus, setTestStatus] = useState<{ type: 'success' | 'danger'; text: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<{ type: 'success' | 'danger'; text: string } | null>(null);
+
+  useAutoResize();
+
+  useEffect(() => {
+    window.tx5dr.invoke('getConfig', { callsign }).then((result: any) => {
+      const config = result?.config as ClubLogConfig | null;
+      setApiKeyAvailable(!!result?.apiKeyStatus?.available);
+      if (!config) return;
+      setEmail(config.email || '');
+      setPassword(config.password || '');
+      setAutoUpload(!!config.autoUploadQSO);
+      setLastRealtimeUploadTime(config.lastRealtimeUploadTime);
+      setLastBatchUploadTime(config.lastBatchUploadTime);
+    }).catch(() => {});
+  }, [callsign]);
+
+  const handleTest = useCallback(() => {
+    setTesting(true);
+    setTestStatus(null);
+    window.tx5dr.invoke('testConnectionDraft', {
+      callsign,
+      config: { email: email.trim(), password, autoUploadQSO: autoUpload },
+    }).then((result: any) => {
+      setTesting(false);
+      setApiKeyAvailable(!!result?.details?.apiKeyAvailable);
+      setTestStatus({
+        type: result.success ? 'success' : 'danger',
+        text: result.success ? t('connected') : (result.message || t('connectionFailed')),
+      });
+    }).catch((err: any) => {
+      setTesting(false);
+      setTestStatus({ type: 'danger', text: err.message || t('connectionFailed') });
+    });
+  }, [callsign, email, password, autoUpload, t]);
+
+  const handleSave = useCallback(() => {
+    if (!email.trim() || !password || !apiKeyAvailable) {
+      setSaveStatus({ type: 'danger', text: t('missingRequired') });
+      return;
+    }
+    setSaving(true);
+    setSaveStatus(null);
+    window.tx5dr.invoke('saveConfig', {
+      callsign,
+      config: { email: email.trim(), password, autoUploadQSO: autoUpload },
+    }).then((result: any) => {
+      setSaving(false);
+      setApiKeyAvailable(!!result?.apiKeyStatus?.available);
+      setSaveStatus({ type: 'success', text: t('saved') });
+      setTimeout(() => {
+        setSaveStatus(null);
+        window.tx5dr.requestClose();
+      }, 600);
+    }).catch((err: any) => {
+      setSaving(false);
+      setSaveStatus({ type: 'danger', text: `${t('saveFailed')}: ${err.message || ''}` });
+    });
+  }, [callsign, email, password, autoUpload, apiKeyAvailable, t]);
+
+  return (
+    <div className="container">
+      <div className="section-title">{t('connectionTitle')}</div>
+
+      <div className="form-group">
+        <label>{t('emailLabel')}</label>
+        <input
+          type="email"
+          placeholder={t('emailPlaceholder')}
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+      </div>
+
+      <div className="form-group">
+        <label>{t('passwordLabel')}</label>
+        <input
+          type="password"
+          placeholder={t('passwordPlaceholder')}
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        <div className="hint">{t('passwordHint')}</div>
+      </div>
+
+      <div className="status-row">
+        <span>{t('apiKeyLabel')}</span>
+        <span className={`chip ${apiKeyAvailable ? 'chip-success' : 'chip-danger'}`}>
+          {apiKeyAvailable ? t('apiKeyReady') : t('apiKeyMissing')}
+        </span>
+      </div>
+
+      <div className="btn-row">
+        <button className="btn btn-secondary" onClick={handleTest} disabled={testing || !email.trim() || !password}>
+          {testing && <span className="spinner" />}
+          {testing ? t('testing') : t('testBtn')}
+        </button>
+        {testStatus && <span className={`chip chip-${testStatus.type}`}>{testStatus.text}</span>}
+      </div>
+
+      <hr className="section-divider" />
+      <div className="section-title">{t('syncTitle')}</div>
+
+      <div className="toggle-row">
+        <div>
+          <div className="toggle-label">{t('autoUpload')}</div>
+          <div className="toggle-desc">{t('autoUploadDesc')}</div>
+        </div>
+        <label className="switch">
+          <input type="checkbox" checked={autoUpload} onChange={e => setAutoUpload(e.target.checked)} />
+          <span className="slider" />
+        </label>
+      </div>
+
+      <div className="status-row"><span>{t('lastRealtime')}:</span><span>{formatTime(lastRealtimeUploadTime, t('never'))}</span></div>
+      <div className="status-row"><span>{t('lastBatch')}:</span><span>{formatTime(lastBatchUploadTime, t('never'))}</span></div>
+
+      <div className="btn-row">
+        <button className="btn btn-primary" onClick={handleSave} disabled={saving}>
+          {saving && <span className="spinner" />}
+          {saving ? t('saving') : t('saveBtn')}
+        </button>
+        {saveStatus && <span className={`chip chip-${saveStatus.type}`}>{saveStatus.text}</span>}
+      </div>
+    </div>
+  );
+}

--- a/packages/builtin-plugins/src/clublog-sync/ui/settings/main.tsx
+++ b/packages/builtin-plugins/src/clublog-sync/ui/settings/main.tsx
@@ -1,0 +1,5 @@
+/// <reference types="@tx5dr/plugin-api/bridge" />
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/builtin-plugins/src/clublog-sync/ui/tsconfig.json
+++ b/packages/builtin-plugins/src/clublog-sync/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client", "@tx5dr/plugin-api/bridge"]
+  },
+  "include": ["./**/*"]
+}

--- a/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard.html
+++ b/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./upload-wizard/main.tsx"></script>
+</body>
+</html>

--- a/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/App.css
+++ b/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/App.css
@@ -1,0 +1,35 @@
+.container { padding: var(--tx5dr-spacing-sm) 0; }
+.description { color: var(--tx5dr-text-secondary); margin-bottom: var(--tx5dr-spacing-md); }
+.section-title { font-size: var(--tx5dr-font-size-lg); font-weight: 600; margin-bottom: var(--tx5dr-spacing-md); }
+.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--tx5dr-spacing-md); margin-bottom: var(--tx5dr-spacing-md); }
+.form-group label { display: block; color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); margin-bottom: var(--tx5dr-spacing-xs); }
+.form-group input { width: 100%; padding: 8px 12px; border: 1px solid var(--tx5dr-border); border-radius: var(--tx5dr-radius-sm); background: var(--tx5dr-bg-content); color: var(--tx5dr-text); box-sizing: border-box; }
+.toggle-row { display: flex; align-items: center; justify-content: space-between; gap: var(--tx5dr-spacing-md); margin: var(--tx5dr-spacing-md) 0; }
+.toggle-label { font-size: var(--tx5dr-font-size-md); }
+.toggle-desc { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); margin-top: 2px; }
+.switch { position: relative; width: 44px; height: 24px; flex-shrink: 0; }
+.switch input { opacity: 0; width: 0; height: 0; }
+.switch .slider { position: absolute; inset: 0; background: var(--tx5dr-bg-hover); border-radius: 12px; cursor: pointer; }
+.switch .slider::before { content: ''; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: #fff; border-radius: 50%; transition: transform 0.2s; }
+.switch input:checked + .slider { background: var(--tx5dr-primary); }
+.switch input:checked + .slider::before { transform: translateX(20px); }
+.stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--tx5dr-spacing-sm); margin: var(--tx5dr-spacing-md) 0; }
+.stat-card { padding: var(--tx5dr-spacing-md); border: 1px solid var(--tx5dr-border); border-radius: var(--tx5dr-radius-sm); background: var(--tx5dr-bg-content); }
+.stat-value { font-size: 1.4rem; font-weight: 700; }
+.stat-label { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); }
+.issue-list { margin: var(--tx5dr-spacing-md) 0; padding: 0; list-style: none; }
+.issue { padding: var(--tx5dr-spacing-sm); border: 1px solid var(--tx5dr-border); border-radius: var(--tx5dr-radius-sm); margin-bottom: var(--tx5dr-spacing-xs); }
+.issue-error { border-color: var(--tx5dr-danger); }
+.issue-warning { border-color: var(--tx5dr-warning); }
+.issue-detail { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); margin-top: 2px; }
+.btn-row { display: flex; align-items: center; gap: var(--tx5dr-spacing-sm); margin-top: var(--tx5dr-spacing-md); }
+.btn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 16px; border: none; border-radius: var(--tx5dr-radius-sm); font-family: var(--tx5dr-font); font-size: var(--tx5dr-font-size-md); cursor: pointer; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: var(--tx5dr-primary); color: #fff; }
+.btn-secondary { background: var(--tx5dr-bg-hover); color: var(--tx5dr-text); }
+.status { padding: var(--tx5dr-spacing-sm); border-radius: var(--tx5dr-radius-sm); background: var(--tx5dr-bg-content); color: var(--tx5dr-text-secondary); margin-top: var(--tx5dr-spacing-md); }
+.status-success { color: var(--tx5dr-success); }
+.status-danger { color: var(--tx5dr-danger); }
+.failure-list { margin: var(--tx5dr-spacing-md) 0 0; padding-left: 1.2rem; }
+.spinner { width: 16px; height: 16px; border: 2px solid var(--tx5dr-border); border-top-color: var(--tx5dr-primary); border-radius: 50%; animation: spin 0.6s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }

--- a/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/App.css
+++ b/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/App.css
@@ -1,35 +1,180 @@
-.container { padding: var(--tx5dr-spacing-sm) 0; }
-.description { color: var(--tx5dr-text-secondary); margin-bottom: var(--tx5dr-spacing-md); }
-.section-title { font-size: var(--tx5dr-font-size-lg); font-weight: 600; margin-bottom: var(--tx5dr-spacing-md); }
-.form-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--tx5dr-spacing-md); margin-bottom: var(--tx5dr-spacing-md); }
-.form-group label { display: block; color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); margin-bottom: var(--tx5dr-spacing-xs); }
-.form-group input { width: 100%; padding: 8px 12px; border: 1px solid var(--tx5dr-border); border-radius: var(--tx5dr-radius-sm); background: var(--tx5dr-bg-content); color: var(--tx5dr-text); box-sizing: border-box; }
-.toggle-row { display: flex; align-items: center; justify-content: space-between; gap: var(--tx5dr-spacing-md); margin: var(--tx5dr-spacing-md) 0; }
-.toggle-label { font-size: var(--tx5dr-font-size-md); }
-.toggle-desc { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); margin-top: 2px; }
-.switch { position: relative; width: 44px; height: 24px; flex-shrink: 0; }
+/* Club Log Upload Wizard — uses TX-5DR design tokens */
+.container {
+  box-sizing: border-box;
+  padding: var(--tx5dr-spacing-lg) var(--tx5dr-spacing-xl);
+}
+
+.description {
+  color: var(--tx5dr-text-secondary);
+  font-size: var(--tx5dr-font-size-md);
+  line-height: 1.45;
+  margin-bottom: var(--tx5dr-spacing-md);
+}
+
+.section-title {
+  font-size: var(--tx5dr-font-size-lg);
+  font-weight: 600;
+  margin: 0 0 var(--tx5dr-spacing-md);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--tx5dr-spacing-sm);
+  padding: var(--tx5dr-spacing-md);
+  background: var(--tx5dr-bg-content);
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  margin-bottom: var(--tx5dr-spacing-md);
+}
+
+.form-group label {
+  display: block;
+  color: var(--tx5dr-text-secondary);
+  font-size: var(--tx5dr-font-size-sm);
+  margin-bottom: var(--tx5dr-spacing-xs);
+}
+
+.form-group input[type="date"] {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  background: var(--tx5dr-bg);
+  color: var(--tx5dr-text);
+  box-sizing: border-box;
+  color-scheme: dark;
+  font-family: var(--tx5dr-font);
+  font-size: var(--tx5dr-font-size-md);
+  outline: none;
+}
+
+.form-group input[type="date"]:focus {
+  border-color: var(--tx5dr-primary);
+  box-shadow: 0 0 0 2px var(--tx5dr-focus-ring);
+}
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--tx5dr-spacing-md);
+  padding: var(--tx5dr-spacing-md);
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  background: var(--tx5dr-bg-content);
+  margin-bottom: var(--tx5dr-spacing-md);
+}
+
+.toggle-label {
+  color: var(--tx5dr-text);
+  font-size: var(--tx5dr-font-size-sm);
+  font-weight: 600;
+}
+
+.toggle-desc {
+  color: var(--tx5dr-text-secondary);
+  font-size: var(--tx5dr-font-size-sm);
+  line-height: 1.45;
+  margin-top: 2px;
+}
+
+.switch { position: relative; width: 44px; height: 24px; flex: 0 0 auto; }
 .switch input { opacity: 0; width: 0; height: 0; }
 .switch .slider { position: absolute; inset: 0; background: var(--tx5dr-bg-hover); border-radius: 12px; cursor: pointer; }
 .switch .slider::before { content: ''; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: #fff; border-radius: 50%; transition: transform 0.2s; }
 .switch input:checked + .slider { background: var(--tx5dr-primary); }
 .switch input:checked + .slider::before { transform: translateX(20px); }
-.stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: var(--tx5dr-spacing-sm); margin: var(--tx5dr-spacing-md) 0; }
-.stat-card { padding: var(--tx5dr-spacing-md); border: 1px solid var(--tx5dr-border); border-radius: var(--tx5dr-radius-sm); background: var(--tx5dr-bg-content); }
-.stat-value { font-size: 1.4rem; font-weight: 700; }
-.stat-label { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); }
-.issue-list { margin: var(--tx5dr-spacing-md) 0; padding: 0; list-style: none; }
-.issue { padding: var(--tx5dr-spacing-sm); border: 1px solid var(--tx5dr-border); border-radius: var(--tx5dr-radius-sm); margin-bottom: var(--tx5dr-spacing-xs); }
-.issue-error { border-color: var(--tx5dr-danger); }
-.issue-warning { border-color: var(--tx5dr-warning); }
-.issue-detail { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-sm); margin-top: 2px; }
-.btn-row { display: flex; align-items: center; gap: var(--tx5dr-spacing-sm); margin-top: var(--tx5dr-spacing-md); }
-.btn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 16px; border: none; border-radius: var(--tx5dr-radius-sm); font-family: var(--tx5dr-font); font-size: var(--tx5dr-font-size-md); cursor: pointer; }
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--tx5dr-spacing-sm);
+  margin: var(--tx5dr-spacing-md) 0;
+}
+
+.stat-card {
+  min-width: 0;
+  padding: var(--tx5dr-spacing-sm) var(--tx5dr-spacing-md);
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  background: var(--tx5dr-bg-content);
+}
+
+.stat-value { color: var(--tx5dr-text); font-size: 20px; font-weight: 700; }
+.stat-label { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-xs); }
+
+.issue-list {
+  max-height: 280px;
+  overflow: auto;
+  margin: var(--tx5dr-spacing-md) 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  background: var(--tx5dr-bg-content);
+}
+
+.issue {
+  padding: var(--tx5dr-spacing-sm) var(--tx5dr-spacing-md);
+  border-bottom: 1px solid var(--tx5dr-border);
+  word-break: break-word;
+}
+
+.issue:last-child { border-bottom: none; }
+.issue-error { color: var(--tx5dr-danger); }
+.issue-warning { color: var(--tx5dr-warning); }
+.issue-detail { color: var(--tx5dr-text-secondary); font-size: var(--tx5dr-font-size-xs); line-height: 1.45; margin-top: 4px; }
+
+.btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--tx5dr-spacing-md);
+  margin-top: var(--tx5dr-spacing-md);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border: none;
+  border-radius: var(--tx5dr-radius-sm);
+  font-family: var(--tx5dr-font);
+  font-size: var(--tx5dr-font-size-md);
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.15s, opacity 0.15s;
+}
+
 .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .btn-primary { background: var(--tx5dr-primary); color: #fff; }
-.btn-secondary { background: var(--tx5dr-bg-hover); color: var(--tx5dr-text); }
-.status { padding: var(--tx5dr-spacing-sm); border-radius: var(--tx5dr-radius-sm); background: var(--tx5dr-bg-content); color: var(--tx5dr-text-secondary); margin-top: var(--tx5dr-spacing-md); }
+.btn-primary:hover:not(:disabled) { background: var(--tx5dr-primary-hover); }
+.btn-secondary { background: var(--tx5dr-bg-content); color: var(--tx5dr-text); border: 1px solid var(--tx5dr-border); }
+
+.status {
+  padding: var(--tx5dr-spacing-md);
+  border: 1px solid var(--tx5dr-border);
+  border-radius: var(--tx5dr-radius-sm);
+  background: var(--tx5dr-bg-content);
+  color: var(--tx5dr-text-secondary);
+  line-height: 1.45;
+  margin-bottom: var(--tx5dr-spacing-md);
+  word-break: break-word;
+}
+
 .status-success { color: var(--tx5dr-success); }
 .status-danger { color: var(--tx5dr-danger); }
-.failure-list { margin: var(--tx5dr-spacing-md) 0 0; padding-left: 1.2rem; }
+.failure-list { max-height: 260px; overflow: auto; margin: var(--tx5dr-spacing-md) 0 0; padding-left: 1.2rem; }
 .spinner { width: 16px; height: 16px; border: 2px solid var(--tx5dr-border); border-top-color: var(--tx5dr-primary); border-radius: 50%; animation: spin 0.6s linear infinite; }
+
 @keyframes spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 520px) {
+  .container { padding: var(--tx5dr-spacing-md); }
+  .form-row { grid-template-columns: 1fr; }
+  .stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .btn-row { flex-direction: column; align-items: stretch; }
+}

--- a/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/App.tsx
+++ b/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/App.tsx
@@ -1,0 +1,377 @@
+/// <reference types="@tx5dr/plugin-api/bridge" />
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useI18n } from '../../../_shared/ui/useI18n';
+import { useAutoResize } from '../../../_shared/ui/useAutoResize';
+import './App.css';
+
+const I18N: Record<string, Record<string, string>> = {
+  zh: {
+    description: '批量上传会把 ADIF 文件提交到 Club Log 队列。Club Log 接受文件不代表已逐条导入完成，请稍后在 Club Log 网站查看最终结果。',
+    rangeTitle: '上传时间范围',
+    sinceDateLabel: '开始日期',
+    untilDateLabel: '截止日期',
+    includeUploaded: '包含已提交到 Club Log 的 QSO',
+    includeUploadedDesc: '忽略本地上传账本，重新提交匹配时间范围内的记录',
+    invalidRange: '开始日期不能晚于截止日期',
+    loading: '正在检查上传准备状态...',
+    pending: '待处理',
+    uploadable: '可上传',
+    skipped: '已跳过',
+    blocked: '被阻塞',
+    issueListTitle: '需要处理或跳过的 QSO',
+    readyTitle: '可以提交到 Club Log',
+    blockedTitle: '上传被阻塞',
+    noPending: '当前没有可提交的 QSO。',
+    refresh: '重新检查',
+    uploadAll: '批量提交到 Club Log',
+    skipAndUpload: '跳过阻塞 QSO 并提交',
+    uploading: '正在提交...',
+    success: '批量提交完成',
+    failed: '批量提交失败',
+    submitted: '已提交',
+    uploaded: '已标记提交',
+    failedCount: '失败',
+    errors: '错误',
+    retryable: '可重试',
+    progressPreparing: '正在准备上传记录...',
+    progressPrepared: '已准备 {uploadable} 条可上传 QSO',
+    progressUploadingBatch: '正在提交 {count} 条 QSO 到 Club Log',
+    progressAccepted: 'Club Log 已接受批量文件',
+    progressFailed: '批量提交失败',
+    progressFinished: '上传流程结束',
+    progressCounts: '已提交 {submitted}，已标记 {uploaded}，已跳过 {skipped}，失败 {failed}',
+  },
+  ja: {
+    description: '一括アップロードでは ADIF ファイルを Club Log のキューに送信します。ファイルの受付は各 QSO の最終インポート完了を意味しません。後で Club Log で結果を確認してください。',
+    rangeTitle: 'アップロード時間範囲',
+    sinceDateLabel: '開始日',
+    untilDateLabel: '終了日',
+    includeUploaded: 'Club Log に送信済みの QSO も含める',
+    includeUploadedDesc: 'ローカル送信記録を無視して、範囲内の記録を再送信します',
+    invalidRange: '開始日は終了日より後にできません',
+    loading: 'アップロード準備状態を確認しています...',
+    pending: '対象',
+    uploadable: 'アップロード可能',
+    skipped: 'スキップ済み',
+    blocked: 'ブロック',
+    issueListTitle: '処理またはスキップが必要な QSO',
+    readyTitle: 'Club Log に送信できます',
+    blockedTitle: 'アップロードがブロックされました',
+    noPending: '送信可能な QSO はありません。',
+    refresh: '再確認',
+    uploadAll: 'Club Log に一括送信',
+    skipAndUpload: 'ブロックされた QSO をスキップして送信',
+    uploading: '送信中...',
+    success: '一括送信完了',
+    failed: '一括送信失敗',
+    submitted: '送信済み',
+    uploaded: '送信マーク済み',
+    failedCount: '失敗',
+    errors: 'エラー',
+    retryable: '再試行可能',
+    progressPreparing: 'アップロード記録を準備しています...',
+    progressPrepared: '{uploadable} 件の QSO を準備しました',
+    progressUploadingBatch: '{count} 件の QSO を Club Log に送信しています',
+    progressAccepted: 'Club Log が一括ファイルを受け付けました',
+    progressFailed: '一括送信失敗',
+    progressFinished: 'アップロード処理が終了しました',
+    progressCounts: '送信 {submitted}、マーク済み {uploaded}、スキップ {skipped}、失敗 {failed}',
+  },
+  en: {
+    description: 'Batch upload submits an ADIF file to the Club Log queue. Acceptance does not mean each QSO has finished importing; check Club Log later for final results.',
+    rangeTitle: 'Upload date range',
+    sinceDateLabel: 'Start date',
+    untilDateLabel: 'End date',
+    includeUploaded: 'Include QSOs already submitted to Club Log',
+    includeUploadedDesc: 'Ignore the local upload ledger and resubmit records in the selected range',
+    invalidRange: 'Start date cannot be later than end date',
+    loading: 'Checking upload readiness...',
+    pending: 'Pending',
+    uploadable: 'Uploadable',
+    skipped: 'Skipped',
+    blocked: 'Blocked',
+    issueListTitle: 'QSOs to fix or skip',
+    readyTitle: 'Ready to submit to Club Log',
+    blockedTitle: 'Upload is blocked',
+    noPending: 'There are no QSOs to submit.',
+    refresh: 'Check again',
+    uploadAll: 'Submit batch to Club Log',
+    skipAndUpload: 'Skip blocked QSOs and submit',
+    uploading: 'Submitting...',
+    success: 'Batch submitted',
+    failed: 'Batch submit failed',
+    submitted: 'Submitted',
+    uploaded: 'Marked submitted',
+    failedCount: 'Failed',
+    errors: 'Errors',
+    retryable: 'Retryable',
+    progressPreparing: 'Preparing upload records...',
+    progressPrepared: 'Prepared {uploadable} uploadable QSOs',
+    progressUploadingBatch: 'Submitting {count} QSOs to Club Log',
+    progressAccepted: 'Club Log accepted the batch file',
+    progressFailed: 'Batch submit failed',
+    progressFinished: 'Upload flow finished',
+    progressCounts: 'Submitted {submitted}, marked {uploaded}, skipped {skipped}, failed {failed}',
+  },
+};
+
+interface PreflightIssue {
+  code: string;
+  severity: 'info' | 'warning' | 'error';
+  message: string;
+  detail?: string;
+  qsoId?: string;
+  qsoCallsign?: string;
+}
+
+interface PreflightResult {
+  ready: boolean;
+  pendingCount: number;
+  uploadableCount: number;
+  blockedCount: number;
+  issues?: PreflightIssue[];
+  canSkipBlocked?: boolean;
+}
+
+interface UploadFailure {
+  code: string;
+  message: string;
+  qsoId?: string;
+  qsoCallsign?: string;
+  httpStatus?: number;
+  retryable?: boolean;
+  detail?: string;
+}
+
+interface UploadResult {
+  submitted?: number;
+  uploaded?: number;
+  skipped?: number;
+  failed?: number;
+  failures?: UploadFailure[];
+}
+
+interface UploadProgress {
+  stage: string;
+  batchIndex?: number;
+  batchCount?: number;
+  qsoCount?: number;
+  uploadableCount?: number;
+  submitted?: number;
+  uploaded?: number;
+  skipped?: number;
+  failed?: number;
+  message?: string;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+function parseDate(value: string, endOfDay = false): number | undefined {
+  if (!value) return undefined;
+  const suffix = endOfDay ? 'T23:59:59.999Z' : 'T00:00:00.000Z';
+  return Date.parse(`${value}${suffix}`);
+}
+
+function progressText(progress: UploadProgress, t: (key: string, vars?: Record<string, string | number>) => string): string {
+  const vars = {
+    uploadable: progress.uploadableCount ?? 0,
+    count: progress.qsoCount ?? 0,
+    submitted: progress.submitted ?? 0,
+    uploaded: progress.uploaded ?? 0,
+    skipped: progress.skipped ?? 0,
+    failed: progress.failed ?? 0,
+  };
+  switch (progress.stage) {
+    case 'preparing': return t('progressPreparing');
+    case 'prepared': return t('progressPrepared', vars);
+    case 'batch_uploading': return t('progressUploadingBatch', vars);
+    case 'batch_accepted': return t('progressAccepted');
+    case 'batch_failed': return progress.message ? `${t('progressFailed')}: ${progress.message}` : t('progressFailed');
+    case 'finished': return t('progressFinished');
+    default: return progress.message || progress.stage;
+  }
+}
+
+export function App() {
+  const t = useI18n(I18N);
+  const callsign = window.tx5dr.params.callsign ?? '';
+  const today = useMemo(() => formatDate(new Date()), []);
+  const [sinceDate, setSinceDate] = useState('');
+  const [untilDate, setUntilDate] = useState(today);
+  const [includeAlreadyUploaded, setIncludeAlreadyUploaded] = useState(false);
+  const [preflight, setPreflight] = useState<PreflightResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState<UploadProgress[]>([]);
+  const [result, setResult] = useState<UploadResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useAutoResize();
+
+  const range = useMemo(() => {
+    const since = parseDate(sinceDate);
+    const until = parseDate(untilDate, true);
+    const valid = !since || !until || since <= until;
+    return { since, until, valid };
+  }, [sinceDate, untilDate]);
+
+  const refresh = useCallback(() => {
+    if (!range.valid) return;
+    setLoading(true);
+    setError(null);
+    window.tx5dr.invoke('getUploadPreflight', {
+      callsign,
+      since: range.since,
+      until: range.until,
+      includeAlreadyUploaded,
+    }).then((value: PreflightResult) => {
+      setPreflight(value);
+      setLoading(false);
+    }).catch((err: any) => {
+      setLoading(false);
+      setError(err.message || String(err));
+    });
+  }, [callsign, range.since, range.until, range.valid, includeAlreadyUploaded]);
+
+  useEffect(() => {
+    const off = window.tx5dr.onPush?.('uploadProgress', (value: UploadProgress) => {
+      setProgress(prev => [...prev, value]);
+    });
+    return () => { off?.(); };
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const performUpload = useCallback((skipBlockedQsos: boolean) => {
+    if (!range.valid) return;
+    setUploading(true);
+    setProgress([]);
+    setResult(null);
+    setError(null);
+    window.tx5dr.invoke('performUpload', {
+      callsign,
+      since: range.since,
+      until: range.until,
+      includeAlreadyUploaded,
+      skipBlockedQsos,
+    }).then((value: UploadResult) => {
+      setResult(value);
+      setUploading(false);
+      refresh();
+    }).catch((err: any) => {
+      setUploading(false);
+      setError(err.message || String(err));
+    });
+  }, [callsign, range.since, range.until, range.valid, includeAlreadyUploaded, refresh]);
+
+  const skippedCount = preflight ? Math.max(0, preflight.pendingCount - preflight.uploadableCount - preflight.blockedCount) : 0;
+  const issues = preflight?.issues ?? [];
+  const hasErrors = issues.some(issue => issue.severity === 'error');
+
+  return (
+    <div className="container">
+      <div className="description">{t('description')}</div>
+      <div className="section-title">{t('rangeTitle')}</div>
+
+      <div className="form-row">
+        <div className="form-group">
+          <label>{t('sinceDateLabel')}</label>
+          <input type="date" value={sinceDate} onChange={e => setSinceDate(e.target.value)} />
+        </div>
+        <div className="form-group">
+          <label>{t('untilDateLabel')}</label>
+          <input type="date" value={untilDate} onChange={e => setUntilDate(e.target.value)} />
+        </div>
+      </div>
+
+      {!range.valid && <div className="status status-danger">{t('invalidRange')}</div>}
+
+      <div className="toggle-row">
+        <div>
+          <div className="toggle-label">{t('includeUploaded')}</div>
+          <div className="toggle-desc">{t('includeUploadedDesc')}</div>
+        </div>
+        <label className="switch">
+          <input type="checkbox" checked={includeAlreadyUploaded} onChange={e => setIncludeAlreadyUploaded(e.target.checked)} />
+          <span className="slider" />
+        </label>
+      </div>
+
+      {loading && <div className="status"><span className="spinner" /> {t('loading')}</div>}
+      {error && <div className="status status-danger">{error}</div>}
+
+      {preflight && (
+        <>
+          <div className="stats">
+            <div className="stat-card"><div className="stat-value">{preflight.pendingCount}</div><div className="stat-label">{t('pending')}</div></div>
+            <div className="stat-card"><div className="stat-value">{preflight.uploadableCount}</div><div className="stat-label">{t('uploadable')}</div></div>
+            <div className="stat-card"><div className="stat-value">{skippedCount}</div><div className="stat-label">{t('skipped')}</div></div>
+            <div className="stat-card"><div className="stat-value">{preflight.blockedCount}</div><div className="stat-label">{t('blocked')}</div></div>
+          </div>
+
+          <div className={`status ${preflight.ready ? 'status-success' : hasErrors ? 'status-danger' : ''}`}>
+            {preflight.ready ? t('readyTitle') : preflight.pendingCount === 0 ? t('noPending') : t('blockedTitle')}
+          </div>
+
+          {issues.length > 0 && (
+            <>
+              <div className="section-title">{t('issueListTitle')}</div>
+              <ul className="issue-list">
+                {issues.map((issue, index) => (
+                  <li key={`${issue.code}-${issue.qsoId ?? index}`} className={`issue issue-${issue.severity}`}>
+                    <div>{issue.qsoCallsign ? `${issue.qsoCallsign}: ` : ''}{issue.message}</div>
+                    {issue.detail && <div className="issue-detail">{issue.detail}</div>}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          <div className="btn-row">
+            <button className="btn btn-secondary" onClick={refresh} disabled={loading || uploading}>{t('refresh')}</button>
+            <button className="btn btn-primary" onClick={() => performUpload(false)} disabled={!preflight.ready || uploading || preflight.uploadableCount === 0}>
+              {uploading && <span className="spinner" />}
+              {uploading ? t('uploading') : t('uploadAll')}
+            </button>
+            {preflight.canSkipBlocked && preflight.uploadableCount > 0 && (
+              <button className="btn btn-secondary" onClick={() => performUpload(true)} disabled={uploading}>{t('skipAndUpload')}</button>
+            )}
+          </div>
+        </>
+      )}
+
+      {progress.length > 0 && (
+        <div className="status">
+          {progress.map((item, index) => <div key={index}>{progressText(item, t)}</div>)}
+        </div>
+      )}
+
+      {result && (
+        <div className={`status ${(result.failed ?? 0) > 0 ? 'status-danger' : 'status-success'}`}>
+          <div>{(result.failed ?? 0) > 0 ? t('failed') : t('success')}</div>
+          <div>{t('progressCounts', {
+            submitted: result.submitted ?? 0,
+            uploaded: result.uploaded ?? 0,
+            skipped: result.skipped ?? 0,
+            failed: result.failed ?? 0,
+          })}</div>
+          {result.failures && result.failures.length > 0 && (
+            <ul className="failure-list">
+              {result.failures.map((failure, index) => (
+                <li key={index}>
+                  {failure.qsoCallsign ? `${failure.qsoCallsign}: ` : ''}{failure.message}
+                  {failure.httpStatus ? ` (HTTP ${failure.httpStatus})` : ''}
+                  {failure.retryable ? ` — ${t('retryable')}` : ''}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/main.tsx
+++ b/packages/builtin-plugins/src/clublog-sync/ui/upload-wizard/main.tsx
@@ -1,0 +1,5 @@
+/// <reference types="@tx5dr/plugin-api/bridge" />
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/packages/builtin-plugins/src/clublog-sync/ui/vite.config.ts
+++ b/packages/builtin-plugins/src/clublog-sync/ui/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  root: import.meta.dirname,
+  base: './',
+  build: {
+    outDir: resolve(import.meta.dirname, '..', '..', '..', 'dist', 'clublog-sync', 'ui'),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        settings: resolve(import.meta.dirname, 'settings.html'),
+        'upload-wizard': resolve(import.meta.dirname, 'upload-wizard.html'),
+      },
+    },
+  },
+});

--- a/packages/builtin-plugins/src/index.ts
+++ b/packages/builtin-plugins/src/index.ts
@@ -99,6 +99,13 @@ import {
 } from './lotw-sync/index.js';
 
 import {
+  clublogSyncPlugin,
+  clublogSyncLocales,
+  clublogSyncDirPath,
+  BUILTIN_CLUBLOG_SYNC_PLUGIN_NAME,
+} from './clublog-sync/index.js';
+
+import {
   qsoUdpBroadcastPlugin,
   qsoUdpBroadcastLocales,
   BUILTIN_QSO_UDP_BROADCAST_PLUGIN_NAME,
@@ -126,6 +133,7 @@ export {
   BUILTIN_WAVELOG_SYNC_PLUGIN_NAME,
   BUILTIN_QRZ_SYNC_PLUGIN_NAME,
   BUILTIN_LOTW_SYNC_PLUGIN_NAME,
+  BUILTIN_CLUBLOG_SYNC_PLUGIN_NAME,
   BUILTIN_AUTOCALL_IDLE_FREQUENCY_PLUGIN_NAME,
   BUILTIN_QSO_UDP_BROADCAST_PLUGIN_NAME,
   BUILTIN_NO_REPLY_MEMORY_FILTER_PLUGIN_NAME,
@@ -210,6 +218,12 @@ export const BUILTIN_PLUGINS: BuiltinPluginEntry[] = [
     locales: lotwSyncLocales,
     enabledByDefault: true,
     dirPath: lotwSyncDirPath,
+  },
+  {
+    definition: clublogSyncPlugin,
+    locales: clublogSyncLocales,
+    enabledByDefault: true,
+    dirPath: clublogSyncDirPath,
   },
   {
     definition: qsoUdpBroadcastPlugin,

--- a/packages/builtin-plugins/src/lotw-sync/provider.ts
+++ b/packages/builtin-plugins/src/lotw-sync/provider.ts
@@ -23,7 +23,6 @@ import type { QSORecord } from '@tx5dr/contracts';
 import {
   getBandFromFrequency,
   toLotwContactMode,
-  getLoTWLocationRule as getSharedLoTWLocationRule,
   normalizeLoTWStationLocation,
   suggestStationLocation,
   type LoTWLocationIssue,
@@ -74,24 +73,6 @@ interface LoTWUploadPreflightResponse extends SyncUploadPreflightResult {
   matchedCertificateIds: string[];
   locationSummary?: Record<string, unknown>;
   guidance: string[];
-}
-
-interface LoTWLocationRule {
-  requiresState: boolean;
-  requiresCounty: boolean;
-  stateLabel: string;
-  countyLabel: string;
-}
-
-/** DXCC location rules — determines which fields are required for upload signing. */
-function getLoTWLocationRule(dxccId?: number | null): LoTWLocationRule {
-  const shared = getSharedLoTWLocationRule(dxccId);
-  return {
-    requiresState: !!shared?.stateField,
-    requiresCounty: !!shared?.countyField,
-    stateLabel: shared?.stateLabel ?? 'State/Province',
-    countyLabel: shared?.countyLabel ?? 'County',
-  };
 }
 
 // ===== OIDs used in LoTW certificates =====

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -16,8 +16,9 @@
 
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { join, relative, extname } from 'path';
+import { fileURLToPath } from 'url';
 
-const ROOT = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const ROOT = fileURLToPath(new URL('..', import.meta.url)).replace(/\/$/, '');
 const STRICT = process.argv.includes('--strict');
 
 // ─── ANSI 颜色 ───────────────────────────────────────────────────────────────

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "globalEnv": [
+    "TX5DR_CLUBLOG_API_KEY"
+  ],
   "globalPassThroughEnv": [
     "PORT",
     "WEB_PORT",
@@ -19,7 +22,8 @@
     "TX5DR_DEBUG_VOICE_TX",
     "TX5DR_DEBUG_REALTIME_JITTER",
     "RTC_DATA_AUDIO_UDP_PORT",
-    "RTC_DATA_AUDIO_ICE_UDP_MUX"
+    "RTC_DATA_AUDIO_ICE_UDP_MUX",
+    "TX5DR_CLUBLOG_API_KEY"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary

- Add a built-in Club Log sync plugin for batch QSO upload and realtime auto-upload.
- Add Club Log settings and upload wizard UI modeled after existing WaveLog/LoTW plugin flows.
- Inject the Club Log developer API key through build/runtime environment instead of storing it in source.

## Details

- Registers `clublog-sync` as an enabled built-in utility plugin.
- Supports:
  - realtime upload through Club Log `realtime.php`
  - batch ADIF upload through Club Log `putlogs.php`
  - local per-callsign upload ledger to avoid resubmitting known QSOs
  - preflight checks for required QSO fields and station callsign mismatch
- Adds Club Log plugin UI:
  - settings page for Club Log email/application password and auto-upload toggle
  - upload wizard with date range, skipped/blocked counts, progress, and result display
- Adds build-time API key generation:
  - CI secret name: `CLUBLOG_API_KEY`
  - build/runtime env var: `TX5DR_CLUBLOG_API_KEY`
  - generated file is ignored by git
- Updates release workflows and Docker build to pass the Club Log API key secret.
- Fixes `check-i18n.mjs` path handling for URL-encoded non-ASCII project paths.
- Removes an unused LoTW helper that caused builtin plugin lint errors.

## Security

- The Club Log developer API key is not stored in source code.
- The generated API key module is ignored by `.gitignore`.
- Upload failures sanitize Club Log email, application password, and API key before surfacing errors.

## Test plan

- [x] `yarn workspace @tx5dr/builtin-plugins test src/clublog-sync/provider.test.ts`
- [x] `yarn workspace @tx5dr/builtin-plugins build`
- [x] `yarn workspace @tx5dr/builtin-plugins lint`
- [x] `yarn check:i18n`
- [x] Manually verified Club Log upload succeeds with `TX5DR_CLUBLOG_API_KEY`
- [x] Confirmed generated API key file is git-ignored and no real API key appears in tracked source

##Note
- Environment variables need to be added to the Action.