### PR TITLE
音频 RX 时间线重构 + ICOM 序列号精确丢包修正

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -43,7 +43,7 @@
     "fastify": "^5.8.4",
     "fastify-plugin": "^5.1.0",
     "hamlib": "0.7.2",
-    "icom-wlan-node": "0.6.3",
+    "icom-wlan-node": "^0.6.4",
     "mic": "^2.1.2",
     "node-datachannel": "0.32.3",
     "node-forge": "^1.4.0",

--- a/packages/server/src/audio/AudioBufferProvider.ts
+++ b/packages/server/src/audio/AudioBufferProvider.ts
@@ -4,6 +4,9 @@ import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('AudioBufferProvider');
 
+/** 读取窗口填充率低于该阈值时记录诊断日志（提示音频滞后/丢失） */
+const UNDERFILL_LOG_THRESHOLD = 0.95;
+
 /**
  * 基于环形缓冲区的音频缓冲区提供者实现
  */
@@ -62,27 +65,39 @@ export class RingBufferAudioProvider implements AudioBufferProvider {
         durationMs,
       });
     }
-    
-    // 对于完整时隙请求，确保有足够的时间已经过去
-    if (durationMs >= 10000) { // 如果请求的是长时间数据（如完整时隙）
-      if (timeSinceSlotStart < durationMs) {
-        // 对于完整时隙，我们需要等待足够的时间
-        const actualDurationMs = Math.max(0, Math.min(durationMs, timeSinceSlotStart));
-        return this.ringBuffer.readFromSlotStart(startMs, actualDurationMs);
-      }
-    }
-    
-    // 确保不会读取超过实际可用的数据
+
+    // 确保不会读取超过实际已经过去的时间（尚未到来的部分由读取层零填充）
     const actualDurationMs = Math.max(0, Math.min(durationMs, timeSinceSlotStart));
 
-    return this.ringBuffer.readFromSlotStart(startMs, actualDurationMs);
+    const read = this.ringBuffer.readByWallClock(startMs, actualDurationMs);
+    if (read.requestedSamples > 0 && read.filledRatio < UNDERFILL_LOG_THRESHOLD) {
+      logger.debug('decode/spectrum window under-filled', {
+        startMs,
+        durationMs,
+        actualDurationMs,
+        filledRatio: Number(read.filledRatio.toFixed(3)),
+        futureSamples: read.futureSamples,
+        evictedSamples: read.evictedSamples,
+      });
+    }
+    return read.pcm;
   }
-  
+
+  /**
+   * 按挂钟时间窗口读取（诊断/测试用，暴露填充率等元数据）
+   */
+  readByWallClock(startMs: number, durationMs: number) {
+    return this.ringBuffer.readByWallClock(startMs, durationMs);
+  }
+
   /**
    * 写入音频数据到缓冲区
+   * @param samples PCM 样本
+   * @param arrivalTimeMs 该 chunk 的到达挂钟时间（缺省取注入时钟），驱动采集时钟模型
+   * @param seq 线级序列号（仅 ICOM 提供），用于精确丢包检测/补静音
    */
-  writeAudio(samples: Float32Array): void {
-    this.ringBuffer.write(samples);
+  writeAudio(samples: Float32Array, arrivalTimeMs?: number, seq?: number): void {
+    this.ringBuffer.write(samples, arrivalTimeMs, seq);
   }
   
   /**

--- a/packages/server/src/audio/AudioStreamManager.ts
+++ b/packages/server/src/audio/AudioStreamManager.ts
@@ -7,6 +7,7 @@ import { ConfigManager } from '../config/config-manager.js';
 import { AudioDeviceManager } from './audio-device-manager.js';
 import { performance } from 'node:perf_hooks';
 import type { IcomWlanAudioAdapter } from './IcomWlanAudioAdapter.js';
+import type { AudioFrameMeta } from '../radio/connections/IRadioConnection.js';
 import type { OpenWebRXAudioAdapter } from '../openwebrx/OpenWebRXAudioAdapter.js';
 import { createLogger } from '../utils/logger.js';
 import type { VoiceTxFrameMeta, VoiceTxProcessedFrameStats } from '../voice/VoiceTxDiagnostics.js';
@@ -394,12 +395,13 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         this.usingIcomWlanInput = true;
         this.icomWlanAudioAdapter.startReceiving();
 
-        // 订阅音频数据
-        this.icomWlanAudioAdapter.on('audioData', (samples: Float32Array) => {
+        // 订阅音频数据（携带线级 seq/timestamp 供 RingBuffer 精确丢包检测）
+        this.icomWlanAudioAdapter.on('audioData', (samples: Float32Array, meta?: AudioFrameMeta) => {
           void this.ingestInputSamples(
             samples,
             this.icomWlanAudioAdapter?.getSampleRate() ?? DEFAULT_INPUT_PROCESSING_SAMPLE_RATE,
             'icom-wlan',
+            meta,
           );
         });
 
@@ -1081,8 +1083,16 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
     samples: Float32Array,
     sampleRate: number,
     sourceKind: NativeAudioInputSourceKind,
+    meta?: AudioFrameMeta,
   ): Promise<void> {
     if (samples.length === 0) return;
+
+    // 在源 chunk 进入时刻取一次到达时间；重采样是异步的，须用源到达时间而非重采样完成时间，
+    // 以避免重采样耗时被错误计入采集时钟模型。
+    // 注意：锚点统一使用校准时钟 this.now()，不用 meta.timestampMs（库侧未经 NTP 校准，
+    // 直接当锚点会引入 = 校准偏移量的恒定窗口偏移）。meta.seq 用于精确丢包检测。
+    const arrivalTimeMs = this.now();
+    const seq = meta?.seq;
 
     const sourceSampleRate = Number.isFinite(sampleRate) && sampleRate > 0
       ? Math.floor(sampleRate)
@@ -1091,7 +1101,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
 
     const targetSampleRate = this.inputProcessingSampleRate;
     if (sourceSampleRate === targetSampleRate) {
-      this.writeProcessedInputAudio(samples, targetSampleRate);
+      this.writeProcessedInputAudio(samples, targetSampleRate, arrivalTimeMs, seq);
       return;
     }
 
@@ -1106,7 +1116,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         });
         return;
       }
-      this.writeProcessedInputAudio(resampled, targetSampleRate);
+      this.writeProcessedInputAudio(resampled, targetSampleRate, arrivalTimeMs, seq);
     } catch (error) {
       logger.error('audio input resample error', {
         sourceSampleRate,
@@ -1118,8 +1128,8 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
     }
   }
 
-  private writeProcessedInputAudio(samples: Float32Array, sampleRate: number): void {
-    this.audioProvider.writeAudio(samples);
+  private writeProcessedInputAudio(samples: Float32Array, sampleRate: number, arrivalTimeMs?: number, seq?: number): void {
+    this.audioProvider.writeAudio(samples, arrivalTimeMs, seq);
     this.emit('audioData', samples, sampleRate);
   }
 

--- a/packages/server/src/audio/IcomWlanAudioAdapter.ts
+++ b/packages/server/src/audio/IcomWlanAudioAdapter.ts
@@ -1,22 +1,24 @@
 import { EventEmitter } from 'eventemitter3';
 import { IcomWlanConnection } from '../radio/connections/IcomWlanConnection.js';
-import { RingBufferAudioProvider } from './AudioBufferProvider.js';
+import type { AudioFrameMeta } from '../radio/connections/IRadioConnection.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('IcomWlanAudioAdapter');
 
 export interface IcomWlanAudioAdapterEvents {
-  'audioData': (samples: Float32Array) => void;
+  'audioData': (samples: Float32Array, meta?: AudioFrameMeta) => void;
   'error': (error: Error) => void;
 }
 
 /**
  * ICOM WLAN 音频适配器
  * 负责音频数据的接收和发送（零重采样优化：ICOM 原生 12kHz）
+ *
+ * 注意：本适配器只负责协议转换（PCM16 ↔ Float32）并通过 'audioData' 事件转发，
+ * RX 时间线的环形缓冲区统一由 AudioStreamManager 维护（见 ingestInputSamples）。
  */
 export class IcomWlanAudioAdapter extends EventEmitter<IcomWlanAudioAdapterEvents> {
   private icomConnection: IcomWlanConnection;
-  private audioProvider: RingBufferAudioProvider;
   private icomSampleRate: number; // ICOM 采样率（12kHz）
   private isReceiving = false;
 
@@ -24,9 +26,6 @@ export class IcomWlanAudioAdapter extends EventEmitter<IcomWlanAudioAdapterEvent
     super();
     this.icomConnection = icomConnection;
     this.icomSampleRate = icomConnection.getAudioSampleRate(); // 12000
-
-    // 创建音频缓冲区提供者（使用 ICOM 原生采样率 12kHz）
-    this.audioProvider = new RingBufferAudioProvider(this.icomSampleRate, this.icomSampleRate * 5);
 
     logger.info(`Initialized with ICOM native sample rate ${this.icomSampleRate}Hz (zero-resample optimization)`);
   }
@@ -70,16 +69,14 @@ export class IcomWlanAudioAdapter extends EventEmitter<IcomWlanAudioAdapterEvent
   /**
    * 处理 ICOM 音频帧（零重采样优化）
    */
-  private handleAudioFrame(pcm16: Buffer): void {
+  private handleAudioFrame(pcm16: Buffer, meta?: AudioFrameMeta): void {
     try {
       // 将 PCM16 Buffer 转换为 Float32Array
       const samples12kHz = this.pcm16ToFloat32(pcm16);
 
-      // 直接存储到环形缓冲区（ICOM 原生 12kHz，无需重采样）
-      this.audioProvider.writeAudio(samples12kHz);
-
-      // 发出事件
-      this.emit('audioData', samples12kHz);
+      // 转发给 AudioStreamManager 统一写入 RX 时间线（ICOM 原生 12kHz，无需重采样）
+      // 透传线级 seq/timestamp 供 RingBuffer 做精确丢包检测
+      this.emit('audioData', samples12kHz, meta);
 
     } catch (error) {
       logger.error('Failed to process audio frame', error);
@@ -123,24 +120,10 @@ export class IcomWlanAudioAdapter extends EventEmitter<IcomWlanAudioAdapterEvent
   }
 
   /**
-   * 获取音频缓冲区提供者
-   */
-  getAudioProvider(): RingBufferAudioProvider {
-    return this.audioProvider;
-  }
-
-  /**
    * 获取接收状态
    */
   isReceivingAudio(): boolean {
     return this.isReceiving;
-  }
-
-  /**
-   * 清空音频缓冲区
-   */
-  clearBuffer(): void {
-    this.audioProvider.clear();
   }
 
   /**

--- a/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
+++ b/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
@@ -154,6 +154,30 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     await manager.stopStream();
   });
 
+  it('threads ICOM wire-level seq into the ring buffer for packet-loss detection', async () => {
+    const adapter = Object.assign(new EventEmitter(), {
+      sendAudio: vi.fn().mockResolvedValue(undefined),
+      getSampleRate: vi.fn().mockReturnValue(12000),
+      startReceiving: vi.fn(),
+      stopReceiving: vi.fn(),
+    });
+    const manager = new AudioStreamManager();
+    manager.setIcomWlanAudioAdapter(adapter as never);
+
+    await manager.startStream();
+    // 连续两个 seq 包 → lastSeq 推进、无丢包
+    adapter.emit('audioData', new Float32Array([0.1, 0.2]), { seq: 10, timestampMs: 1 });
+    adapter.emit('audioData', new Float32Array([0.3, 0.4]), { seq: 11, timestampMs: 2 });
+    // 跳过 seq 12 → 丢 1 包
+    adapter.emit('audioData', new Float32Array([0.5, 0.6]), { seq: 13, timestampMs: 3 });
+
+    const status = manager.getAudioProvider().getStatus() as unknown as { lastSeq: number; lostPackets: number };
+    expect(status.lastSeq).toBe(13);
+    expect(status.lostPackets).toBe(1);
+
+    await manager.stopStream();
+  });
+
   it('resamples ICOM input through the unified audioData pipeline when CW processing rate is 9600 Hz', async () => {
     const adapter = Object.assign(new EventEmitter(), {
       sendAudio: vi.fn().mockResolvedValue(undefined),

--- a/packages/server/src/audio/__tests__/AudioStreamManager.rtaudio-output.test.ts
+++ b/packages/server/src/audio/__tests__/AudioStreamManager.rtaudio-output.test.ts
@@ -638,13 +638,14 @@ describe('AudioStreamManager RtAudio output diagnostics', () => {
     );
   });
 
-  it('labels RingBuffer overflow logs as RX/input buffer overflow', () => {
+  it('logs sliding-window eviction at debug (not warn) for the RX/input buffer', () => {
     const ringBuffer = new RingBuffer(12000, 10);
 
     ringBuffer.write(new Float32Array(200).fill(0.1));
 
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      'RX/input ring buffer overflow',
+    // 满缓冲淘汰最旧样本是正常稳态，记为 debug 避免误导性 WARN 噪声
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      'RX/input ring buffer evicted oldest samples (sliding window full)',
       expect.objectContaining({
         bufferKind: 'rx-input',
         droppedSamples: 80,

--- a/packages/server/src/audio/__tests__/RingBuffer.test.ts
+++ b/packages/server/src/audio/__tests__/RingBuffer.test.ts
@@ -10,22 +10,27 @@ function readFloats(buffer: ArrayBuffer): number[] {
   return Array.from(new Float32Array(buffer), value => Number(value.toFixed(3)));
 }
 
-describe('RingBuffer latest-window reads', () => {
-  it('anchors provider reads to the latest written sample when sample production leads wall clock', async () => {
-    let now = 0;
+// 模型约定：chunk 的到达时间对应其“末尾样本”的采集时刻，
+// 因此 write(samples, arrival) 把样本映射到挂钟区间 [arrival - 时长, arrival)。
+describe('RingBuffer wall-clock addressed reads', () => {
+  it('positions the decode window by wall clock (samples land at their captured time)', async () => {
+    let now = 1000;
     const provider = new RingBufferAudioProvider(10, 10_000, () => now);
+    // 10 个样本 @10Hz = 1000ms；到达 t=1000 → 映射到挂钟 [0,1000)
     provider.writeAudio(floats([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]));
 
-    now = 500;
+    now = 1500;
     const buffer = await provider.getBuffer(0, 500);
 
-    expect(readFloats(buffer)).toEqual([0.6, 0.7, 0.8, 0.9, 1]);
+    // 请求挂钟 [0,500) → 最早的 5 个样本（按采集时间对齐），而非最新尾部
+    expect(readFloats(buffer)).toEqual([0.1, 0.2, 0.3, 0.4, 0.5]);
   });
 
   it('reports a full buffer when writeIndex catches readIndex exactly at capacity', () => {
     const ringBuffer = new RingBuffer(10, 1000, () => 0);
 
-    ringBuffer.write(floats([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]));
+    // 显式到达 t=1000 → 样本映射到挂钟 [0,1000)
+    ringBuffer.write(floats([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]), 1000);
 
     expect(ringBuffer.getStatus()).toMatchObject({
       availableSamples: 10,
@@ -36,34 +41,74 @@ describe('RingBuffer latest-window reads', () => {
     expect(readFloats(ringBuffer.readFromSlotStart(0, 1000))).toEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]);
   });
 
-  it('anchors producer clock on first audio write instead of construction time', () => {
-    let now = 0;
-    const ringBuffer = new RingBuffer(1000, 1000, () => now);
+  it('anchors the capture clock on first audio write (chunk end aligns to arrival)', () => {
+    const ringBuffer = new RingBuffer(1000, 1000, () => 0);
 
-    now = 5000;
-    ringBuffer.write(floats([0.1, 0.2, 0.3, 0.4, 0.5]));
+    // 100 个样本 @1000Hz = 100ms；到达 t=5000 → 首样本(序号0)对应挂钟 4900
+    ringBuffer.write(new Float32Array(100), 5000);
 
     expect(ringBuffer.getStatus()).toMatchObject({
-      startTimestamp: 5000,
-      totalSamplesWritten: 5,
-      wallClockSamples: 0,
-      producerLeadMs: 5,
-    });
-
-    now = 5005;
-    expect(ringBuffer.getStatus()).toMatchObject({
-      wallClockSamples: 5,
-      producerLeadMs: 0,
+      totalSamplesWritten: 100,
+      anchorWallMs: 4900,
+      anchorSampleIndex: 0,
+      modelErrMs: 0,
     });
   });
 
-  it('drops the oldest samples on overflow and keeps the newest tail', () => {
+  it('drops the oldest samples on overflow and keeps the newest tail addressable by wall clock', () => {
     const ringBuffer = new RingBuffer(10, 500, () => 0);
 
-    ringBuffer.write(floats([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]));
+    // size=5（10Hz × 500ms）；写 7 个 @10Hz=700ms，到达 t=700 → 映射挂钟 [0,700)
+    // 物理保留最新 5 个（绝对序号 [2,7) ↔ 挂钟 [200,700)）
+    ringBuffer.write(floats([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]), 700);
 
     expect(ringBuffer.getAvailableSamples()).toBe(5);
-    expect(readFloats(ringBuffer.readFromSlotStart(0, 500))).toEqual([0.3, 0.4, 0.5, 0.6, 0.7]);
+    expect(readFloats(ringBuffer.readFromSlotStart(200, 500))).toEqual([0.3, 0.4, 0.5, 0.6, 0.7]);
+  });
+
+  it('zero-fills the not-yet-arrived tail and reports a partial filledRatio', () => {
+    const ringBuffer = new RingBuffer(10, 10_000, () => 0);
+    // 3 个样本 @10Hz=300ms，到达 t=300 → 映射挂钟 [0,300)
+    ringBuffer.write(floats([0.1, 0.2, 0.3]), 300);
+
+    // 请求 [0,500) → 前 3 个命中，后 2 个落在未来 → 零填充
+    const read = ringBuffer.readByWallClock(0, 500);
+    expect(readFloats(read.pcm)).toEqual([0.1, 0.2, 0.3, 0, 0]);
+    expect(read.presentSamples).toBe(3);
+    expect(read.futureSamples).toBe(2);
+    expect(read.filledRatio).toBeCloseTo(0.6, 5);
+  });
+
+  it('absorbs arrival jitter without shifting the window (clamped anchor step)', () => {
+    const ringBuffer = new RingBuffer(1000, 10_000, () => 0);
+    // 稳定写入：每 100ms 到达 100 个样本（=1000Hz），到达 t=100,200,...,500
+    for (let chunk = 1; chunk <= 5; chunk++) {
+      ringBuffer.write(new Float32Array(100), chunk * 100);
+    }
+    const anchorBefore = ringBuffer.getStatus().anchorWallMs as number;
+
+    // 一个迟到 40ms 的 chunk（应到 t=600，实到 t=640）
+    ringBuffer.write(new Float32Array(100), 640);
+    const status = ringBuffer.getStatus();
+
+    // 锚点单步移动被钳制（≤MAX_STEP_MS=5ms），一次抖动不会整窗拉偏，也不触发重锚
+    expect(Math.abs((status.anchorWallMs as number) - anchorBefore)).toBeLessThanOrEqual(5 + 1e-6);
+    expect(status.resyncCount).toBe(0);
+  });
+
+  it('resyncs the timeline after a large stall instead of staying misaligned', () => {
+    const ringBuffer = new RingBuffer(1000, 10_000, () => 0);
+    ringBuffer.write(new Float32Array(100), 100);  // 挂钟 [0,100)
+    ringBuffer.write(new Float32Array(100), 200);  // 挂钟 [100,200)
+
+    // 网络停顿 ~3s 后恢复：误差远超 RESYNC_THRESHOLD → 重锚
+    ringBuffer.write(new Float32Array(100).fill(0.5), 3200);
+
+    const status = ringBuffer.getStatus();
+    expect(status.resyncCount).toBe(1);
+    // 重锚后最新 chunk 对齐到达时间：读其挂钟区间应命中真实数据而非全零
+    const read = ringBuffer.readByWallClock(3100, 100);
+    expect(read.presentSamples).toBeGreaterThan(0);
   });
 
   it('readNext consumes stored samples and pads underruns with silence', () => {
@@ -77,5 +122,80 @@ describe('RingBuffer latest-window reads', () => {
 
     expect(readFloats(ringBuffer.readNext(1))).toEqual([0.4]);
     expect(ringBuffer.getAvailableSamples()).toBe(1);
+  });
+});
+
+// 1000Hz → 1 样本=1ms；每包 100 样本=100ms。write(samples, arrival, seq)。
+describe('RingBuffer seq-based packet-loss handling', () => {
+  const pkt = (v: number) => new Float32Array(100).fill(v);
+
+  it('appends contiguous seq packets without inserting silence', () => {
+    const rb = new RingBuffer(1000, 10_000, () => 0);
+    rb.write(pkt(0.1), 100, 10);
+    rb.write(pkt(0.2), 200, 11);
+
+    expect(rb.getStatus()).toMatchObject({
+      totalSamplesWritten: 200,
+      lostPackets: 0,
+      dupPackets: 0,
+      lastSeq: 11,
+    });
+  });
+
+  it('fills exactly one packet of silence at the correct position when a seq is lost', () => {
+    const rb = new RingBuffer(1000, 10_000, () => 0);
+    rb.write(pkt(0.1), 100, 10); // wall [0,100)
+    // seq 11 lost; seq 12 arrives at t=300
+    rb.write(pkt(0.2), 300, 12); // delta=2 → 1 lost → insert 100 silence then packet
+
+    const s = rb.getStatus();
+    expect(s.lostPackets).toBe(1);
+    expect(s.totalSamplesWritten).toBe(300); // 100 + 100 silence + 100
+    expect(s.lastSeq).toBe(12);
+
+    // lost interval [100,200) is silence; recovered packet sits at [200,300)
+    expect(readFloats(rb.readByWallClock(100, 100).pcm).every(v => v === 0)).toBe(true);
+    const recovered = rb.readByWallClock(200, 100);
+    expect(recovered.presentSamples).toBe(100);
+    expect(Number(new Float32Array(recovered.pcm)[0].toFixed(3))).toBe(0.2);
+  });
+
+  it('drops duplicate and reordered-old packets (no timeline perturbation)', () => {
+    const rb = new RingBuffer(1000, 10_000, () => 0);
+    rb.write(pkt(0.1), 100, 10);
+    rb.write(pkt(0.2), 200, 11);
+    rb.write(pkt(0.9), 250, 11); // duplicate seq → drop
+    rb.write(pkt(0.8), 260, 10); // reordered-old seq → drop
+
+    expect(rb.getStatus()).toMatchObject({
+      totalSamplesWritten: 200,
+      dupPackets: 2,
+      lastSeq: 11,
+    });
+  });
+
+  it('handles 16-bit seq wraparound (0xffff → 0) as contiguous', () => {
+    const rb = new RingBuffer(1000, 10_000, () => 0);
+    rb.write(pkt(0.1), 100, 0xffff);
+    rb.write(pkt(0.2), 200, 0x0000); // wrap → delta=1
+
+    expect(rb.getStatus()).toMatchObject({
+      totalSamplesWritten: 200,
+      lostPackets: 0,
+      lastSeq: 0,
+    });
+  });
+
+  it('resyncs instead of flooding silence on an oversized seq jump', () => {
+    const rb = new RingBuffer(1000, 10_000, () => 0);
+    rb.write(pkt(0.1), 100, 10);
+    rb.write(pkt(0.2), 200, 11);
+    // long stall: seq jumps far beyond MAX_GAP_FILL and arrival is consistently far ahead
+    rb.write(pkt(0.3), 200_000, 2011);
+
+    const s = rb.getStatus();
+    expect(s.resyncCount).toBe(1);
+    expect(s.lastSeq).toBe(2011);
+    expect(s.totalSamplesWritten).toBe(300); // no silence flood, just the 3 real packets
   });
 });

--- a/packages/server/src/audio/ringBuffer.ts
+++ b/packages/server/src/audio/ringBuffer.ts
@@ -2,13 +2,66 @@ import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('RingBuffer');
 const OVERFLOW_LOG_INTERVAL_MS = 5000;
+/** 漂移日志阈值/节流（仅用于诊断，纠偏由时钟模型闭环完成） */
 const CLOCK_DRIFT_WARNING_THRESHOLD_MS = 250;
 const CLOCK_DRIFT_LOG_INTERVAL_MS = 5000;
-export type AudioClock = () => number;
+const RESYNC_LOG_INTERVAL_MS = 5000;
 
 /**
- * 环形缓冲区 - 用于存储连续的 PCM 音频数据
- * 支持多线程安全的读写操作
+ * 采集时钟模型常量。
+ * - OFFSET_GAIN / MAX_STEP_MS：漏积分纠偏。每次写入按误差的一小步纠正锚点，
+ *   单次幅度被 MAX_STEP_MS 钳制，使抖动尖峰几乎不移动窗口，而缓慢漂移会被逐步吸收。
+ * - RESYNC_THRESHOLD_MS：误差超过此值视为时间线断裂（停顿/丢包/NTP 跳变），
+ *   直接重锚以立即重对齐，避免漏积分在大阶跃下收敛过慢导致长时间错位。
+ */
+const OFFSET_GAIN = 0.05;
+const MAX_STEP_MS = 5;
+const RESYNC_THRESHOLD_MS = 500;
+
+/**
+ * seq 丢包补偿常量（仅当写入携带线级序列号时生效，目前为 ICOM WLAN）。
+ * - MAX_GAP_FILL_MS：单次 seq 跳变最多补这么多静音；超过则视为长停顿/失步，改走重锚而非灌满静音。
+ * - DUP_WINDOW：seq 回退落在该窗口内视为重复/迟到乱序包，直接丢弃（不重排）。
+ * - SEQ_MODULO：协议线级序列号为 16 位，0xffff 后回绕到 0。
+ */
+const MAX_GAP_FILL_MS = 1000;
+const DUP_WINDOW = 256;
+const SEQ_MODULO = 0x10000;
+const LOSS_LOG_INTERVAL_MS = 5000;
+
+export type AudioClock = () => number;
+
+/** readByWallClock 的返回结构（pcm 仍为裸 ArrayBuffer，供解码 worker 直接使用） */
+export interface WallClockReadResult {
+  pcm: ArrayBuffer;
+  /** 实际填入的真实采样占请求总量的比例（1=完全命中，0=全部零填充） */
+  filledRatio: number;
+  requestedSamples: number;
+  presentSamples: number;
+  /** 落在未来（尚未到达）而零填充的采样数 */
+  futureSamples: number;
+  /** 落在过去（已被环形缓冲逐出）而零填充的采样数 */
+  evictedSamples: number;
+  /** 请求窗口起点对应的绝对采样序号 */
+  startSampleIndex: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * 环形缓冲区 - 存储连续 PCM 音频，并维护“绝对采样序号 ↔ 挂钟采集时间”的权威映射。
+ *
+ * 核心思想：
+ * - `totalSamplesWritten` 是永不回绕的绝对采样序号，是权威位置；物理上只保留最近 `size` 个。
+ * - 一个平滑采集时钟模型把绝对采样序号映射到挂钟时间：
+ *     wallTimeOf(index) = anchorWallMs + (index - anchorSampleIndex) / estimatedRate * 1000
+ *   每次写入用 chunk 到达时间对锚点做漏积分纠偏（抗抖动），大误差时重锚（应对断裂）。
+ * - 读取（readByWallClock）按挂钟时间换算到绝对采样区间并精确返回，缺失部分零填充。
+ *   这使解码窗口的位置不受瞬时到达延迟影响，从架构上解决“整窗偏移导致 FT8 解不出”。
+ *
+ * 单线程使用（音频回调/事件在同一执行上下文），无需加锁。
  */
 export class RingBuffer {
   private buffer: Float32Array;
@@ -18,80 +71,191 @@ export class RingBuffer {
   private size: number;
   private sampleRate: number;
   private maxDurationMs: number;
-  private startTimestamp: number; // 缓冲区开始时间戳
-  private totalSamplesWritten = 0; // 总写入样本数
-  private lastWriteTimestamp: number; // 最后写入时间戳
+  private totalSamplesWritten = 0; // 绝对采样序号（含写入的所有到达样本）
+
+  // --- 平滑采集时钟模型 ---
+  private anchorWallMs: number | null = null; // 绝对序号 anchorSampleIndex 对应的挂钟时间
+  private anchorSampleIndex = 0;               // 固定为 0：映射以绝对序号 0 为基准
+  private estimatedRate: number;               // 平滑有效采样率（速率环初期禁用，恒等于 sampleRate）
+  private lastErrMs = 0;                        // 最近一次写入的模型误差（诊断用）
+  private resyncCount = 0;                      // 重锚次数（诊断用）
+
+  // --- seq 丢包检测（仅 ICOM 提供 seq 时启用）---
+  private lastSeq: number | null = null;        // 上一个已接受的线级序列号
+  private lostPackets = 0;                       // 累计判定丢失的包数（诊断用）
+  private dupPackets = 0;                        // 累计丢弃的重复/乱序包数（诊断用）
+
+  // --- 日志节流 ---
   private lastOverflowLogAt = 0;
   private suppressedOverflowSamples = 0;
   private lastClockDriftLogAt = 0;
+  private lastResyncLogAt = 0;
+  private lastLossLogAt = 0;
+
   private readonly now: AudioClock;
-  
+
   constructor(sampleRate: number, maxDurationMs: number = 60000, now: AudioClock = Date.now) {
     this.sampleRate = sampleRate;
     this.maxDurationMs = maxDurationMs;
     this.now = now;
+    this.estimatedRate = sampleRate;
     this.size = Math.floor((sampleRate * maxDurationMs) / 1000);
     this.buffer = new Float32Array(this.size);
-    this.startTimestamp = this.now();
-    this.lastWriteTimestamp = this.startTimestamp;
   }
-  
-  /**
-   * 写入音频数据
-   * @param samples PCM 样本数据
-   */
-  write(samples: Float32Array): void {
-    const writeTimestamp = this.now();
-    let inputOffset = 0;
 
-    if (this.totalSamplesWritten === 0) {
-      this.startTimestamp = writeTimestamp;
-      this.lastWriteTimestamp = writeTimestamp;
+  /**
+   * 写入音频数据。
+   * @param samples PCM 样本
+   * @param arrivalTimeMs 该 chunk 的到达挂钟时间（缺省取当前注入时钟）。用于驱动采集时钟模型。
+   * @param seq 线级序列号（仅 ICOM 提供）。提供时用于精确丢包检测：seq 跳变补等量静音，
+   *            重复/乱序丢弃，超大跳变改走重锚。不提供时退化为纯到达时间模型（声卡/openwebrx）。
+   */
+  write(samples: Float32Array, arrivalTimeMs: number = this.now(), seq?: number): void {
+    const n = samples.length;
+    if (n === 0) {
+      return;
     }
 
-    // 在写入前一次性检查可用空间
+    // seq 连续性处理：决定本包是丢弃、需要前置补静音、还是正常写入。
+    let silenceSamples = 0;
+    if (seq !== undefined) {
+      const decision = this.evaluateSeq(seq, n);
+      if (decision.action === 'drop') {
+        this.dupPackets += 1;
+        return; // 重复/迟到乱序包：不写、不推进时钟模型
+      }
+      if (decision.action === 'gap') {
+        silenceSamples = decision.lostCount * n; // 每包样本数一致（ICOM 零重采样）
+        this.lostPackets += decision.lostCount;
+        this.logLossIfNeeded(decision.lostCount, seq, arrivalTimeMs);
+      }
+      this.lastSeq = seq;
+    }
+
+    // 把“补静音 + 本包”视为同一到达时刻的一次逻辑写入：projectedTotal 与（因丢包而前移的）
+    // arrival 同步增长，errMs≈0，漏积分几乎不动；超大跳变（未补静音）则由模型走重锚。
+    this.updateClockModel(silenceSamples + n, arrivalTimeMs);
+    if (silenceSamples > 0) {
+      this.writePhysical(new Float32Array(silenceSamples), arrivalTimeMs);
+    }
+    this.writePhysical(samples, arrivalTimeMs);
+  }
+
+  /**
+   * 评估线级序列号的连续性（纯函数，不改状态）。
+   * @returns ok=正常追加；drop=重复/乱序应丢弃；gap=丢了 lostCount 个包需前置补静音。
+   */
+  private evaluateSeq(seq: number, perPacketSamples: number): { action: 'ok' | 'drop' | 'gap'; lostCount: number } {
+    if (this.lastSeq === null) {
+      return { action: 'ok', lostCount: 0 }; // 首包
+    }
+    const delta = (seq - this.lastSeq + SEQ_MODULO) % SEQ_MODULO;
+    if (delta === 1) {
+      return { action: 'ok', lostCount: 0 };
+    }
+    if (delta === 0 || delta > SEQ_MODULO - DUP_WINDOW) {
+      return { action: 'drop', lostCount: 0 }; // 同号或小幅回退：重复/迟到乱序
+    }
+    const lostCount = delta - 1;
+    const gapMs = (lostCount * perPacketSamples * 1000) / this.sampleRate;
+    if (gapMs > MAX_GAP_FILL_MS) {
+      // 跳变过大（长停顿/seq 失步）：不灌大量静音，交给到达时间模型重锚
+      return { action: 'ok', lostCount: 0 };
+    }
+    return { action: 'gap', lostCount };
+  }
+
+  private logLossIfNeeded(lostCount: number, seq: number, now: number): void {
+    if (now - this.lastLossLogAt < LOSS_LOG_INTERVAL_MS) {
+      return;
+    }
+    logger.warn('RX/input audio packet loss (gap filled with silence)', {
+      bufferKind: 'rx-input',
+      lostThisGap: lostCount,
+      totalLostPackets: this.lostPackets,
+      dupPackets: this.dupPackets,
+      seq,
+      sampleRate: this.sampleRate,
+    });
+    this.lastLossLogAt = now;
+  }
+
+  /**
+   * 用本次到达的 chunk 更新采集时钟模型（漏积分纠偏 + 大误差重锚）。
+   * 必须在物理写入推进 totalSamplesWritten 之前调用。
+   */
+  private updateClockModel(incomingSamples: number, arrivalTimeMs: number): void {
+    if (this.anchorWallMs === null) {
+      // 首次写入：chunk 到达时间对应其“末尾样本”的采集时刻（缓冲填满才回调），
+      // 故绝对序号 0（首样本）对应 arrival - chunk时长。否则稳态下每次写入都会出现
+      // +一个 chunk 的恒定误差，使漏积分持续误纠偏。
+      this.anchorWallMs = arrivalTimeMs - (incomingSamples / this.estimatedRate) * 1000;
+      this.anchorSampleIndex = 0;
+      this.estimatedRate = this.sampleRate;
+      this.lastErrMs = 0;
+      return;
+    }
+
+    // predicted = 截至 arrivalTimeMs 按模型“应已采集”的绝对样本数
+    const predicted = this.anchorSampleIndex
+      + ((arrivalTimeMs - this.anchorWallMs) * this.estimatedRate) / 1000;
+    // 写完本 chunk 后的绝对样本数（chunk 末尾样本对应 ~arrivalTimeMs）
+    const projectedTotal = this.totalSamplesWritten + incomingSamples;
+    const errSamples = projectedTotal - predicted;
+    const errMs = (errSamples / this.estimatedRate) * 1000;
+    this.lastErrMs = errMs;
+
+    if (Math.abs(errMs) > RESYNC_THRESHOLD_MS) {
+      // 时间线断裂（停顿/丢包/时钟跳变）：重锚使 chunk 末尾对齐到达时间，立即重对齐。
+      this.anchorWallMs = arrivalTimeMs - (projectedTotal / this.estimatedRate) * 1000;
+      this.anchorSampleIndex = 0;
+      this.resyncCount += 1;
+      this.logResyncIfNeeded(errMs, arrivalTimeMs);
+      return;
+    }
+
+    // 漏积分：向“消除当前误差”的方向小步移动锚点，单步幅度受 MAX_STEP_MS 钳制（抗抖动）。
+    // errMs>0 表示样本多于时间预期 → 需增大 predicted → 减小 anchorWallMs。
+    const correctionMs = clamp(errMs * OFFSET_GAIN, -MAX_STEP_MS, MAX_STEP_MS);
+    this.anchorWallMs -= correctionMs;
+    this.logClockDriftIfNeeded(errMs, arrivalTimeMs);
+  }
+
+  /** 物理写入：维护环形缓冲与绝对计数，沿用“溢出丢弃最旧”策略。 */
+  private writePhysical(samples: Float32Array, arrivalTimeMs: number): void {
+    let inputOffset = 0;
     const freeSpace = this.size - this.storedSamples;
 
-    // 如果单次写入超过容量，只保留输入块的最新尾部，并清掉旧内容。
     if (samples.length >= this.size) {
+      // 单次写入超过容量：只保留输入块最新尾部，清掉旧内容。
       const droppedSamples = this.storedSamples + samples.length - this.size;
       if (droppedSamples > 0) {
-        this.logOverflow(droppedSamples, writeTimestamp);
+        this.logOverflow(droppedSamples, arrivalTimeMs);
       }
       inputOffset = samples.length - this.size;
       this.readIndex = this.writeIndex;
       this.storedSamples = 0;
     } else if (samples.length > freeSpace) {
-      // 空间不足时丢弃最旧的已存样本，确保新样本保持实时。
+      // 空间不足：丢弃最旧的已存样本，保持新样本实时。
       const needToDrop = samples.length - freeSpace;
-      this.logOverflow(needToDrop, writeTimestamp);
+      this.logOverflow(needToDrop, arrivalTimeMs);
       this.readIndex = (this.readIndex + needToDrop) % this.size;
       this.storedSamples = Math.max(0, this.storedSamples - needToDrop);
     }
 
-    // 批量写入所有样本
+    // inputOffset 部分虽未物理保留，但仍是已到达样本，须计入绝对时间线。
     this.totalSamplesWritten += inputOffset;
     for (let i = inputOffset; i < samples.length; i++) {
       const sample = samples[i] || 0;
-
-      // 检查样本有效性
       if (isNaN(sample) || !isFinite(sample)) {
-        // 无效样本，用0替换
         this.buffer[this.writeIndex] = 0;
       } else {
-        // 限制样本范围到 [-1, 1]
-        const clampedSample = Math.max(-1, Math.min(1, sample));
-        this.buffer[this.writeIndex] = clampedSample;
+        this.buffer[this.writeIndex] = Math.max(-1, Math.min(1, sample));
       }
-
       this.writeIndex = (this.writeIndex + 1) % this.size;
-      this.totalSamplesWritten++;
+      this.totalSamplesWritten += 1;
       this.storedSamples = Math.min(this.size, this.storedSamples + 1);
     }
-
-    // 更新最后写入时间（用于计算时间偏移）
-    this.lastWriteTimestamp = writeTimestamp;
-    this.logClockDriftIfNeeded(writeTimestamp);
   }
 
   private logOverflow(droppedSamples: number, now: number): void {
@@ -99,8 +263,10 @@ export class RingBuffer {
     if (now - this.lastOverflowLogAt < OVERFLOW_LOG_INTERVAL_MS) {
       return;
     }
-
-    logger.warn('RX/input ring buffer overflow', {
+    // 满缓冲后每次写入都会淘汰等量最旧样本，这是 60s 滑动窗口的正常稳态（解码只用最近 ~15s，
+    // 被淘汰的是更早的历史），不是数据丢失。降为 debug 避免误导性噪声；真正的问题由
+    // 丢包(seq)/重锚/漂移等专用告警反映。
+    logger.debug('RX/input ring buffer evicted oldest samples (sliding window full)', {
       bufferKind: 'rx-input',
       droppedSamples,
       suppressedDroppedSamples: this.suppressedOverflowSamples - droppedSamples,
@@ -112,90 +278,116 @@ export class RingBuffer {
     this.suppressedOverflowSamples = 0;
   }
 
-  private getWallClockSamples(now = this.now()): number {
-    const elapsedMs = Math.max(0, now - this.startTimestamp);
-    return Math.floor((this.sampleRate * elapsedMs) / 1000);
-  }
-
-  private getProducerLeadMs(now = this.now()): number {
-    if (this.sampleRate <= 0) {
-      return 0;
-    }
-    const wallClockSamples = this.getWallClockSamples(now);
-    return ((this.totalSamplesWritten - wallClockSamples) / this.sampleRate) * 1000;
-  }
-
-  private logClockDriftIfNeeded(now: number): void {
-    const producerLeadMs = this.getProducerLeadMs(now);
-    if (Math.abs(producerLeadMs) < CLOCK_DRIFT_WARNING_THRESHOLD_MS) {
+  private logClockDriftIfNeeded(errMs: number, now: number): void {
+    if (Math.abs(errMs) < CLOCK_DRIFT_WARNING_THRESHOLD_MS) {
       return;
     }
     if (now - this.lastClockDriftLogAt < CLOCK_DRIFT_LOG_INTERVAL_MS) {
       return;
     }
-
     logger.warn('RX/input audio sample clock drift detected', {
       bufferKind: 'rx-input',
-      producerLeadMs: Number(producerLeadMs.toFixed(1)),
+      modelErrMs: Number(errMs.toFixed(1)),
       totalSamplesWritten: this.totalSamplesWritten,
-      wallClockSamples: this.getWallClockSamples(now),
       availableSamples: this.getAvailableSamples(),
       sampleRate: this.sampleRate,
     });
     this.lastClockDriftLogAt = now;
   }
-  
-  /**
-   * 读取指定时间范围的音频数据
-   * @param startMs 开始时间戳（毫秒）
-   * @param durationMs 持续时间（毫秒）
-   * @returns PCM 音频数据
-   */
-  read(startMs: number, durationMs: number): ArrayBuffer {
-    void startMs;
-    return this.readLatest(durationMs);
-  }
-  
-  /**
-   * 基于时隙开始时间读取累积音频数据
-   * @param slotStartMs 时隙开始时间戳（毫秒）
-   * @param durationMs 从时隙开始到现在的累积时长（毫秒）
-   * @returns PCM 音频数据
-   */
-  readFromSlotStart(slotStartMs: number, durationMs: number): ArrayBuffer {
-    void slotStartMs;
-    return this.readLatest(durationMs);
+
+  private logResyncIfNeeded(errMs: number, now: number): void {
+    if (now - this.lastResyncLogAt < RESYNC_LOG_INTERVAL_MS) {
+      return;
+    }
+    logger.warn('RX/input audio timeline resynced (gap/stall/clock-step)', {
+      bufferKind: 'rx-input',
+      modelErrMs: Number(errMs.toFixed(1)),
+      resyncCount: this.resyncCount,
+      totalSamplesWritten: this.totalSamplesWritten,
+      sampleRate: this.sampleRate,
+    });
+    this.lastResyncLogAt = now;
   }
 
-  private readLatest(durationMs: number): ArrayBuffer {
-    const sampleCount = Math.floor((this.sampleRate * Math.max(0, durationMs)) / 1000);
-    const result = new Float32Array(sampleCount);
+  /** 挂钟时间 → 绝对采样序号（采集时钟模型的核心映射）。 */
+  private sampleIndexAtWall(wallMs: number): number {
+    if (this.anchorWallMs === null) {
+      return 0;
+    }
+    return this.anchorSampleIndex + ((wallMs - this.anchorWallMs) * this.estimatedRate) / 1000;
+  }
 
-    // 以最新写入位置为窗口结尾读取，避免样本时钟和墙钟漂移导致越读越旧。
-    const samplesToRead = Math.min(sampleCount, this.storedSamples);
-    const outputOffset = sampleCount - samplesToRead;
-    const startIndex = (this.writeIndex - samplesToRead + this.size) % this.size;
+  /** 绝对采样序号 → 物理槽位（仅对处于保留区间内的序号有效）。 */
+  private physicalIndex(absIndex: number): number {
+    const offsetFromWrite = this.totalSamplesWritten - absIndex;
+    return ((this.writeIndex - offsetFromWrite) % this.size + this.size) % this.size;
+  }
 
-    for (let i = 0; i < samplesToRead; i++) {
-      const bufferIndex = (startIndex + i) % this.size;
-      const value = this.buffer[bufferIndex];
-      result[outputOffset + i] = (value !== undefined && !isNaN(value)) ? value : 0;
+  /**
+   * 按挂钟时间窗口读取音频。已到达的样本放到窗口内正确相对位置，
+   * 落在未来（未到达）或过去（已逐出）的部分零填充。不等待。
+   */
+  readByWallClock(startMs: number, durationMs: number): WallClockReadResult {
+    const requestedSamples = Math.floor((this.sampleRate * Math.max(0, durationMs)) / 1000);
+    const result = new Float32Array(requestedSamples);
+
+    if (requestedSamples === 0 || this.anchorWallMs === null || this.storedSamples === 0) {
+      return {
+        pcm: result.buffer,
+        filledRatio: requestedSamples === 0 ? 1 : 0,
+        requestedSamples,
+        presentSamples: 0,
+        futureSamples: this.anchorWallMs === null ? requestedSamples : 0,
+        evictedSamples: 0,
+        startSampleIndex: 0,
+      };
     }
 
-    return result.buffer;
+    const startIdx = Math.round(this.sampleIndexAtWall(startMs));
+    const endIdx = startIdx + requestedSamples;
+
+    // 物理保留的绝对序号区间 [lo, hi)
+    const hi = this.totalSamplesWritten;
+    const lo = this.totalSamplesWritten - this.storedSamples;
+
+    const copyStart = Math.max(startIdx, lo);
+    const copyEnd = Math.min(endIdx, hi);
+
+    let presentSamples = 0;
+    for (let a = copyStart; a < copyEnd; a++) {
+      const value = this.buffer[this.physicalIndex(a)];
+      result[a - startIdx] = (value !== undefined && !isNaN(value)) ? value : 0;
+      presentSamples += 1;
+    }
+
+    const evictedSamples = Math.max(0, Math.min(endIdx, lo) - startIdx);
+    const futureSamples = Math.max(0, endIdx - Math.max(startIdx, hi));
+
+    return {
+      pcm: result.buffer,
+      filledRatio: requestedSamples > 0 ? presentSamples / requestedSamples : 1,
+      requestedSamples,
+      presentSamples,
+      futureSamples,
+      evictedSamples,
+      startSampleIndex: startIdx,
+    };
   }
-  
+
   /**
-   * 连续读取音频数据（流式播放专用）
-   * 自动推进读指针，确保音频连续
-   * @param sampleCount 要读取的样本数
-   * @returns PCM 音频数据
+   * 基于时隙开始时间读取（解码路径）。委托给 readByWallClock 做挂钟寻址。
+   */
+  readFromSlotStart(slotStartMs: number, durationMs: number): ArrayBuffer {
+    return this.readByWallClock(slotStartMs, durationMs).pcm;
+  }
+
+  /**
+   * 连续读取音频数据（流式播放专用，如 OpenWebRX 预览）。
+   * 自动推进读指针，确保音频连续；不影响 readByWallClock 的随机寻址。
    */
   readNext(sampleCount: number): ArrayBuffer {
     const result = new Float32Array(sampleCount);
     const available = this.getAvailableSamples();
-
-    // 读取可用的样本（如果不足，剩余部分填充静音）
     const samplesToRead = Math.min(sampleCount, available);
 
     for (let i = 0; i < samplesToRead; i++) {
@@ -204,7 +396,6 @@ export class RingBuffer {
     }
     this.storedSamples = Math.max(0, this.storedSamples - samplesToRead);
 
-    // 如果缓冲区不足，剩余部分填充静音
     for (let i = samplesToRead; i < sampleCount; i++) {
       result[i] = 0;
     }
@@ -212,36 +403,34 @@ export class RingBuffer {
     return result.buffer;
   }
 
-  /**
-   * 获取当前可用的样本数量
-   */
+  /** 获取当前可用的样本数量 */
   getAvailableSamples(): number {
     return this.storedSamples;
   }
-  
-  /**
-   * 清空缓冲区
-   */
+
+  /** 清空缓冲区（重置物理状态与采集时钟模型；下次写入重新锚定） */
   clear(): void {
     this.writeIndex = 0;
     this.readIndex = 0;
     this.storedSamples = 0;
     this.totalSamplesWritten = 0;
     this.buffer.fill(0);
-    this.startTimestamp = this.now();
-    this.lastWriteTimestamp = this.startTimestamp;
+    this.anchorWallMs = null;
+    this.anchorSampleIndex = 0;
+    this.estimatedRate = this.sampleRate;
+    this.lastErrMs = 0;
+    this.lastSeq = null;
+    this.lostPackets = 0;
+    this.dupPackets = 0;
     this.lastOverflowLogAt = 0;
     this.suppressedOverflowSamples = 0;
     this.lastClockDriftLogAt = 0;
+    this.lastResyncLogAt = 0;
+    this.lastLossLogAt = 0;
   }
-  
-  /**
-   * 获取缓冲区状态信息
-   */
+
+  /** 获取缓冲区状态信息（含采集时钟模型诊断） */
   getStatus() {
-    const now = this.now();
-    const wallClockSamples = this.getWallClockSamples(now);
-    const producerLeadMs = this.getProducerLeadMs(now);
     return {
       size: this.size,
       writeIndex: this.writeIndex,
@@ -250,11 +439,15 @@ export class RingBuffer {
       availableSamples: this.getAvailableSamples(),
       sampleRate: this.sampleRate,
       maxDurationMs: this.maxDurationMs,
-      startTimestamp: this.startTimestamp,
       totalSamplesWritten: this.totalSamplesWritten,
-      wallClockSamples,
-      producerLeadMs,
-      uptimeMs: now - this.startTimestamp
+      anchorWallMs: this.anchorWallMs,
+      anchorSampleIndex: this.anchorSampleIndex,
+      estimatedRate: this.estimatedRate,
+      modelErrMs: this.lastErrMs,
+      resyncCount: this.resyncCount,
+      lastSeq: this.lastSeq,
+      lostPackets: this.lostPackets,
+      dupPackets: this.dupPackets,
     };
   }
 }

--- a/packages/server/src/openwebrx/OpenWebRXAudioAdapter.ts
+++ b/packages/server/src/openwebrx/OpenWebRXAudioAdapter.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from 'eventemitter3';
 import { OpenWebRXClient } from '@openwebrx-js/api';
 import type { OpenWebRXSpectrumFrame, ServerConfig, Profile } from '@openwebrx-js/api';
 import type { OpenWebRXStationConfig } from '@tx5dr/contracts';
-import { RingBufferAudioProvider } from '../audio/AudioBufferProvider.js';
 import { createLogger } from '../utils/logger.js';
 import { OpenWebRXProfileService } from './OpenWebRXProfileService.js';
 
@@ -39,7 +38,6 @@ export interface OpenWebRXAudioAdapterEvents {
 export class OpenWebRXAudioAdapter extends EventEmitter<OpenWebRXAudioAdapterEvents> {
   private client: OpenWebRXClient;
   private stationConfig: OpenWebRXStationConfig;
-  private audioProvider: RingBufferAudioProvider;
   private isReceiving = false;
   private _isConnected = false;
 
@@ -71,8 +69,6 @@ export class OpenWebRXAudioAdapter extends EventEmitter<OpenWebRXAudioAdapterEve
       url: stationConfig.url,
       outputRate: INTERNAL_SAMPLE_RATE,
     });
-
-    this.audioProvider = new RingBufferAudioProvider(INTERNAL_SAMPLE_RATE, INTERNAL_SAMPLE_RATE * 5);
 
     // Bind handlers
     this.boundHandleAudio = this.handleAudioFrame.bind(this);
@@ -203,13 +199,6 @@ export class OpenWebRXAudioAdapter extends EventEmitter<OpenWebRXAudioAdapterEve
   }
 
   /**
-   * Get the audio provider (RingBuffer) for AudioStreamManager integration
-   */
-  getAudioProvider(): RingBufferAudioProvider {
-    return this.audioProvider;
-  }
-
-  /**
    * Get connection status
    */
   isConnected(): boolean {
@@ -278,13 +267,6 @@ export class OpenWebRXAudioAdapter extends EventEmitter<OpenWebRXAudioAdapterEve
 
   isDigitalDetailSpectrumEnabled(): boolean {
     return this.digitalDetailSpectrumMode !== null;
-  }
-
-  /**
-   * Clear audio buffer
-   */
-  clearBuffer(): void {
-    this.audioProvider.clear();
   }
 
   /**
@@ -398,10 +380,7 @@ export class OpenWebRXAudioAdapter extends EventEmitter<OpenWebRXAudioAdapterEve
         samples[i] = pcm16[i] / 32768.0;
       }
 
-      // Write to ring buffer
-      this.audioProvider.writeAudio(samples);
-
-      // Emit event
+      // Forward to AudioStreamManager which owns the unified RX timeline ring buffer
       this.emit('audioData', samples);
     } catch (error) {
       logger.error('Failed to process audio frame', error);

--- a/packages/server/src/radio/connections/IRadioConnection.ts
+++ b/packages/server/src/radio/connections/IRadioConnection.ts
@@ -10,6 +10,16 @@ import type { HamlibConfig, LevelMeterReading, MeterCapabilities, TunerCapabilit
 import type { RadioIoQueueSnapshot } from './RadioIoQueue.js';
 
 /**
+ * 音频帧线级元数据（目前由 ICOM WLAN 提供）。
+ * - seq：协议线级序列号（16 位，0xffff 回绕），用于上层精确丢包检测。
+ * - timestampMs：RX 到达时间（未校准 Date.now()），仅用于诊断，不作同步基准。
+ */
+export interface AudioFrameMeta {
+  seq?: number;
+  timestampMs?: number;
+}
+
+/**
  * 电台连接类型
  */
 export enum RadioConnectionType {
@@ -156,8 +166,9 @@ export interface IRadioConnectionEvents {
 
   /**
    * 音频帧（仅 ICOM WLAN）
+   * @param meta 可选的线级元数据：seq（线级序列号，用于丢包检测）、timestampMs（RX 到达时间，诊断用）
    */
-  audioFrame: (pcm16: Buffer) => void;
+  audioFrame: (pcm16: Buffer, meta?: AudioFrameMeta) => void;
 
   /**
    * 数值表数据

--- a/packages/server/src/radio/connections/IcomWlanConnection.ts
+++ b/packages/server/src/radio/connections/IcomWlanConnection.ts
@@ -1920,8 +1920,8 @@ export class IcomWlanConnection
 
     // 音频数据
     this.rig.events.on('audio', (frame) => {
-      // 转发音频帧给上层
-      this.emit('audioFrame', frame.pcm16);
+      // 转发音频帧给上层，并携带线级 seq 与 RX 到达时间用于丢包检测/诊断
+      this.emit('audioFrame', frame.pcm16, { seq: frame.seq, timestampMs: frame.timestampMs });
     });
 
     this.rig.events.on('scopeFrame', (frame) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6575,7 +6575,7 @@ __metadata:
     fastify: "npm:^5.8.4"
     fastify-plugin: "npm:^5.1.0"
     hamlib: "npm:0.7.2"
-    icom-wlan-node: "npm:0.6.3"
+    icom-wlan-node: "npm:^0.6.4"
     mic: "npm:^2.1.2"
     node-datachannel: "npm:0.32.3"
     node-forge: "npm:^1.4.0"
@@ -12746,10 +12746,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"icom-wlan-node@npm:0.6.3":
-  version: 0.6.3
-  resolution: "icom-wlan-node@npm:0.6.3"
-  checksum: 10c0/f110d8a8084a711ea99ca3736e68e6bedfcc509d5311d739392000b94d9fdbacda83c21e119b30fd05940e7be4f64c6f6ee6b100b6c13e75954e155055d2c88a
+"icom-wlan-node@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "icom-wlan-node@npm:0.6.4"
+  checksum: 10c0/4c3ca85443914768eec9e23ce7645c2f63526b87823e60013070d6fe9b5925ca5fa16c72a92d2edf14a13c5b0e8114a0faed6814dd6677f242e812e88e079396
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 背景

FT8 解码窗口由**挂钟时间**决定，但原 RX 环形缓冲区读取**忽略请求时间窗**、只取"最新 N 毫秒"——这在 ICOM WLAN 网络抖动/滞后、声卡性能下降、采样时钟漂移时会让整个解码窗口偏移，导致 FT8 解码"断崖"。本 PR 从架构上解决，并利用协议线级序列号做真正的丢包修正。

## 改动

### 核心：`ringBuffer.ts` 按挂钟时间寻址
- 维护"绝对采样序号 ↔ 挂钟采集时间"权威映射；`readByWallClock` 精确返回请求窗口，未到达/已逐出部分零填充并报告 `filledRatio`。解码窗口不再受瞬时到达延迟影响。
- 平滑采集时钟模型：逐包**漏积分**纠偏（钳制步长、抗抖动）+ 大误差**重锚**（应对停顿/时钟跳变）。
- **基于 ICOM 线级序列号的精确丢包修正**（依赖 `icom-wlan-node ≥ 0.6.4`）：seq 跳变在正确位置补等量静音保持对齐；重复/乱序丢弃；超大跳变回退重锚。诊断：`lostPackets`/`dupPackets`/`modelErrMs`/`resyncCount`。
- 非 ICOM 源（声卡/openwebrx）维持纯到达时间模型。

### 透传链路
- `AudioFrameMeta { seq, timestampMs }` 从 `IcomWlanConnection` → 适配器 → `AudioStreamManager.ingestInputSamples` → `writeAudio`。
- **时钟域**：锚点用校准 `this.now()`，库的 `timestampMs` 仅诊断，避免引入 = NTP 偏移量的窗口漂移。

### 顺手清理（消除重复造轮子/统一数据流）
- 删除 `IcomWlanAudioAdapter` / `OpenWebRXAudioAdapter` 内**死的重复** `RingBufferAudioProvider`（RX 时间线统一由 `AudioStreamManager` 维护）。
- 删 `getBuffer` 的 `>=10000` 冗余分支与忽略时间参数的误导性 `read()` API。
- 满 60s 缓冲的滑窗淘汰日志 `warn → debug`（正常稳态，非数据丢失）。

### 依赖
- `icom-wlan-node` `0.6.3 → ^0.6.4`（库侧透传音频 `seq` + RX 到达时间，配套已发布）。

## 测试
- 新增 RingBuffer 用例：挂钟对齐 / 抖动钳制 / 停顿重锚 / seq 丢包补静音 / 重复丢弃 / 16 位回绕 / 填充率；AudioStreamManager seq 透传。
- `yarn build` 12/12 ✓，`lint` 0 error ✓，server `test` 1110 passed ✓。

## 实机验证（无天线）
本地 ICOM WLAN 实测日志确认：seq 按 50 包/秒递增（=20ms/包@12kHz，真实线级序列号），~0.06% 丢包被逐包静音补齐，`dupPackets=0`、重锚 0、漂移 0；解码跑正确的 13.5/14.7s 窗口（`frameCount=0` 因无天线只有底噪，符合预期）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)