### PR TITLE
feat(server): 虚拟频率 (Fake It Split) — 透明 dial 平移

### DIFF
--- a/packages/contracts/src/schema/radio.schema.ts
+++ b/packages/contracts/src/schema/radio.schema.ts
@@ -227,6 +227,15 @@ export const DigitalModeRadioModePreferenceSchema = z.enum(['none', 'usb', 'usb-
 export const PttMethodSchema = z.enum(['cat', 'vox', 'dtr', 'rts']);
 
 /**
+ * 虚拟频率（Fake Frequency / "Fake It" Split）配置Schema
+ * 目标音频频率与滞回区间目前由服务端常量控制（~1500Hz），此处仅暴露开关，预留扩展位。
+ */
+export const FakeFrequencyConfigSchema = z.object({
+  enabled: z.boolean(),
+});
+export type FakeFrequencyConfig = z.infer<typeof FakeFrequencyConfigSchema>;
+
+/**
  * Hamlib配置Schema - 嵌套对象结构
  *
  * 设计理念：
@@ -257,6 +266,12 @@ export const HamlibConfigSchema = z.object({
   // 正值表示提前发射，负值表示延后发射
   // 范围限制：-1000~1000ms，适用于各种网络和设备延迟场景
   transmitCompensationMs: z.number().int().min(-1000).max(1000).optional(),
+
+  // 虚拟频率（Fake Frequency / WSJT-X "Fake It" Split）
+  // 启用后，发射时临时反向平移电台 dial 频率，使送进电台的音频载波保持在甜区(~1500Hz)，
+  // 而打到空中的实际 RF 位置与用户设定的发射频点完全一致。
+  // 用于规避部分电台在音频频率过高/过低时发射功率衰减的问题；对用户透明（接收 dial、TX 标记不变）。
+  fakeFrequency: FakeFrequencyConfigSchema.optional(),
 
   // PTT 方法（默认 'cat'，即 Hamlib RIG 类型）
   // 仅对 network 和 serial 连接类型有效，icom-wlan 固定使用 CI-V PTT

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -1000,6 +1000,20 @@ export const api = {
     );
   },
 
+  /**
+   * 设置虚拟频率（Fake Frequency）开关
+   */
+  async setFakeFrequency(enabled: boolean, apiBase?: string): Promise<{ success: boolean; enabled: boolean }> {
+    return apiRequest<{ success: boolean; enabled: boolean }>(
+      '/radio/fake-frequency',
+      {
+        method: 'POST',
+        body: JSON.stringify({ enabled }),
+      },
+      apiBase
+    );
+  },
+
   // ========== 模式管理API ==========
 
   /**
@@ -2415,6 +2429,7 @@ export const {
   ,getTunerStatus
   ,setTuner
   ,startTuning
+  ,setFakeFrequency
   // PSKReporter 函数
   ,getPSKReporterConfig
   ,updatePSKReporterConfig

--- a/packages/server/src/DigitalRadioEngine.ts
+++ b/packages/server/src/DigitalRadioEngine.ts
@@ -94,6 +94,7 @@ import { PhysicalPttMonitor } from './radio/PhysicalPttMonitor.js';
 import type { RigctldBridgeConfig, RigctldStatus } from '@tx5dr/contracts';
 import { RadioPowerController } from './radio/RadioPowerController.js';
 import { TuneToneController } from './radio/TuneToneController.js';
+import { buildRadioStatusPayload } from './radio/buildRadioStatusPayload.js';
 import type { RealtimeRxAudioRouter } from './realtime/RealtimeRxAudioRouter.js';
 import path from 'node:path';
 import { existsSync } from 'node:fs';
@@ -320,6 +321,15 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
         }
       },
       getKnownRadioFrequency: () => this.radioManager.getKnownFrequency(),
+      // 虚拟频率：启用且与 rig split 互斥（split 开启时本功能让步，避免双重 dial 操作）
+      getFakeFrequencyEnabled: () => {
+        try {
+          const enabled = !!this.radioManager?.getConfig()?.fakeFrequency?.enabled;
+          return enabled && !this.radioManager?.isSplitEnabled?.();
+        } catch {
+          return false;
+        }
+      },
       transmissionTracker: this.transmissionTracker,
       callsignTracker: this._callsignTracker,
     });
@@ -597,6 +607,44 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
   public getRadioManager(): PhysicalRadioManager {
     return this.radioManager;
+  }
+
+  /**
+   * 虚拟频率（Fake Frequency）开关：热更新 + 持久化到激活 Profile + 广播状态。
+   * 无需重启引擎——仅影响发射时编码/平移行为，引擎在编码时读取 radioManager 当前配置。
+   */
+  public async setFakeFrequencyEnabled(enabled: boolean): Promise<void> {
+    // 1. 热更新 radioManager 当前配置（编码时读取）
+    this.radioManager?.setFakeFrequencyEnabled(enabled);
+
+    // 2. 持久化到当前激活 Profile（合并 radio 配置，避免覆盖其他字段）
+    try {
+      const cfg = ConfigManager.getInstance();
+      const active = cfg.getActiveProfile();
+      if (active) {
+        await cfg.updateProfile(active.id, {
+          radio: { ...active.radio, fakeFrequency: { enabled } },
+        });
+      }
+    } catch (error) {
+      logger.error('Failed to persist fake frequency setting', error);
+    }
+
+    // 3. 广播最新电台状态，前端据 radioConfig.fakeFrequency 同步开关
+    try {
+      const radioManager = this.radioManager;
+      const radioInfo = await radioManager.getRadioInfo();
+      this.emit('radioStatusChanged', buildRadioStatusPayload({
+        connected: radioManager.isConnected(),
+        status: radioManager.getConnectionStatus(),
+        radioInfo,
+        radioConfig: radioManager.getConfig(),
+        reason: 'Fake frequency setting updated',
+        radioManager,
+      }));
+    } catch (error) {
+      logger.error('Failed to broadcast radio status after fake frequency update', error);
+    }
   }
 
   public getRadioPowerController(): RadioPowerController {

--- a/packages/server/src/audio/AudioMixer.ts
+++ b/packages/server/src/audio/AudioMixer.ts
@@ -9,6 +9,12 @@ export interface MixedAudio {
   sampleRate: number;
   duration: number;
   operatorIds: string[];
+  /**
+   * 虚拟频率：本时隙冻结的 dial 平移量（Hz）。
+   * 与音频载波同源（音频按 origFreq - shift 编码），随负载流转到 PTT 时点，
+   * 保证施加到电台的 dial 平移量恒等于编码所用 shift。0 表示不平移。
+   */
+  txDialShiftHz: number;
 }
 
 /**
@@ -36,6 +42,9 @@ export class AudioMixer extends EventEmitter {
   // 当前时隙信息
   private currentSlotStartMs: number = 0;
 
+  // 虚拟频率：本时隙冻结的 dial 平移量（Hz），由 addOperatorAudio 写入、随每个 MixedAudio 流转
+  private currentSlotTxDialShiftHz: number = 0;
+
   // 播放状态跟踪
   private playbackStartTimeMs: number = 0;
   private isPlaying: boolean = false;
@@ -61,7 +70,8 @@ export class AudioMixer extends EventEmitter {
     audioData: Float32Array,
     sampleRate: number,
     slotStartMs: number,
-    requestId?: string
+    requestId?: string,
+    txDialShiftHz: number = 0
   ): void {
     const existing = this.slotAudioCache.get(operatorId);
     const duration = audioData.length / sampleRate;
@@ -78,6 +88,8 @@ export class AudioMixer extends EventEmitter {
       this.clearSlotCache();
     }
     this.currentSlotStartMs = slotStartMs;
+    // 在 clearSlotCache 之后赋值（否则会被重置为 0）。同一时隙所有操作员共享同一冻结 shift。
+    this.currentSlotTxDialShiftHz = txDialShiftHz;
 
     // 存储/替换该操作员的音频
     const operatorAudio: OperatorSlotAudio = {
@@ -224,7 +236,8 @@ export class AudioMixer extends EventEmitter {
           audioData: single.samples,
           sampleRate: targetSampleRate,
           duration: single.samples.length / targetSampleRate,
-          operatorIds: [single.operatorId]
+          operatorIds: [single.operatorId],
+          txDialShiftHz: this.currentSlotTxDialShiftHz
         };
       }
 
@@ -258,7 +271,8 @@ export class AudioMixer extends EventEmitter {
         audioData: mixedSamples,
         sampleRate: targetSampleRate,
         duration: finalDuration,
-        operatorIds: validAudios.map(a => a.operatorId)
+        operatorIds: validAudios.map(a => a.operatorId),
+        txDialShiftHz: this.currentSlotTxDialShiftHz
       };
 
     } catch (error) {
@@ -327,6 +341,7 @@ export class AudioMixer extends EventEmitter {
     this.isPlaying = false;
     this.playbackStartTimeMs = 0;
     this.cumulativeOffsetMs = 0;  // 重置累计偏移量
+    this.currentSlotTxDialShiftHz = 0;  // 重置虚拟频率平移量
 
     if (this.mixingTimeout) {
       clearTimeout(this.mixingTimeout);

--- a/packages/server/src/decode/WSJTXEncodeWorkQueue.ts
+++ b/packages/server/src/decode/WSJTXEncodeWorkQueue.ts
@@ -18,6 +18,7 @@ export interface EncodeRequest {
   slotStartMs?: number; // 时隙开始时间戳
   timeSinceSlotStartMs?: number; // 从时隙开始到现在经过的时间（毫秒）
   requestId?: string; // 编码请求唯一ID（用于去重和追踪）
+  txDialShiftHz?: number; // 虚拟频率：本时隙冻结的 dial 平移量（Hz），随音频负载流转到 PTT 时点
 }
 
 export interface EncodeResult {

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -83,6 +83,8 @@ export interface RadioOperatorManagerOptions {
   getRadioFrequency?: () => Promise<number | null>;
   // 获取最近已知电台基频（Hz）；自动决策热路径使用它避免等待硬件I/O
   getKnownRadioFrequency?: () => number | null;
+  // 虚拟频率是否生效（已计入与 rig split 的互斥）；编码时据此决定是否平移音频载波
+  getFakeFrequencyEnabled?: () => boolean;
   callsignTracker?: CallsignContextTracker;
 }
 
@@ -103,7 +105,15 @@ export class RadioOperatorManager {
   private transmissionTracker: any; // TransmissionTracker实例
   private getRadioFrequency?: () => Promise<number | null>;
   private getKnownRadioFrequency?: () => number | null;
+  private getFakeFrequencyEnabled?: () => boolean;
   private callsignTracker?: CallsignContextTracker;
+
+  // 虚拟频率：当前时隙冻结的 dial 平移量（Hz）。按 slotStartMs 冻结，
+  // 保证同一时隙内中途加入的操作员复用同一 shift，与已编码音频匹配。
+  private currentSlotTxDialShift: { slotStartMs: number; shiftHz: number } | null = null;
+  // 虚拟频率常量：目标音频载波频率与滞回半宽（Hz）
+  private static readonly FAKE_FREQ_TARGET_HZ = 1500;
+  private static readonly FAKE_FREQ_HYSTERESIS_HZ = 200;
   // 插件管理器引用（延迟注入，引擎初始化完成后设置）
   private _pluginManager?: import('../plugin/PluginManager.js').PluginManager;
 
@@ -165,6 +175,7 @@ export class RadioOperatorManager {
     this.transmissionTracker = options.transmissionTracker;
     this.getRadioFrequency = options.getRadioFrequency;
     this.getKnownRadioFrequency = options.getKnownRadioFrequency;
+    this.getFakeFrequencyEnabled = options.getFakeFrequencyEnabled;
     this.callsignTracker = options.callsignTracker;
 
     // 监听发射请求
@@ -695,7 +706,16 @@ export class RadioOperatorManager {
         updates.frequency = clampedFreq;
         // 如果该操作员正在实际 PTT 发射，触发重编码和重混音
         if (this.activeTransmissionOperatorIds.has(operatorId)) {
-          this.checkAndTriggerTransmission(operatorId);
+          if (this.isFakeFrequencyCommittedForCurrentSlot()) {
+            // 虚拟频率已为本时隙提交 dial 平移：物理上 tone 期间不可移动 dial，
+            // 频率变更顺延到下一时隙（届时由 dial 吸收、音频回甜区）。仅更新 config，不重编码。
+            logger.debug('Deferring mid-slot frequency change to next slot (fake frequency committed)', {
+              operatorId,
+              clampedFreq,
+            });
+          } else {
+            this.checkAndTriggerTransmission(operatorId);
+          }
         }
       }
     }
@@ -969,6 +989,13 @@ export class RadioOperatorManager {
       logger.warn(`Duplicate transmit requests detected: ${requests.length} → ${uniqueRequests.length}`);
     }
 
+    // 虚拟频率：计算/复用本时隙统一的 dial 平移量（按 slotStartMs 冻结）
+    const fakeFrequencyEnabled = this.getFakeFrequencyEnabled?.() ?? false;
+    const slotShiftHz = this.resolveSlotTxDialShift(slotStartMs, uniqueRequests, fakeFrequencyEnabled);
+    if (slotShiftHz !== 0) {
+      logger.debug('Fake frequency active for slot', { slotStartMs, slotShiftHz });
+    }
+
     for (const request of uniqueRequests) {
       const operatorId = request.operatorId;
       const transmission = request.transmission;
@@ -1015,19 +1042,88 @@ export class RadioOperatorManager {
       // 记录该操作员的最新编码请求ID（用于丢弃过期编码结果）
       this.latestEncodeRequestIds.set(operatorId, requestId);
 
+      // 虚拟频率：编码音频载波归到甜区（origFreq - shift）；dial 将由发射管线反向平移 +shift，
+      // 使打到空中的绝对 RF 不变。clamp >=0 仅在操作员铺得极宽时兜底（极端情况下牺牲个别 RF 精度）。
+      const encodeFrequency = slotShiftHz !== 0
+        ? Math.max(0, Math.round(frequency - slotShiftHz))
+        : frequency;
+
+      // 多操作员物理限制：中途加入的操作员若远低于本时隙冻结的中心，frequency - shift 会 < 0
+      // 被钳位到 0，导致其空中 RF 偏移。单 VFO 无法对相距过远（铺宽 > ~1500Hz）的操作员分别居中。
+      // 初次整时隙计算因 freq∈[1,3000]、spread≤3000 → 恒 >=0，此告警只可能出现在极端中途加入。
+      if (slotShiftHz !== 0 && Math.round(frequency - slotShiftHz) < 0) {
+        logger.warn('Fake frequency clamp: operator audio below 0Hz under frozen slot shift, on-air RF will be offset', {
+          operatorId,
+          frequency,
+          slotShiftHz,
+        });
+      }
+
       // 提交到编码队列
       this.encodeQueue.push({
         operatorId,
         message: transmission,
-        frequency,
+        frequency: encodeFrequency,
         mode: currentMode.name === 'FT4' ? 'FT4' : 'FT8',
         slotStartMs: slotStartMs,
         timeSinceSlotStartMs: timeSinceSlotStartMs,
-        requestId
+        requestId,
+        txDialShiftHz: slotShiftHz
       });
 
       logger.debug(`Processed transmit request for operator ${operatorId}: "${transmission}", requestId=${requestId}`);
     }
+  }
+
+  /**
+   * 虚拟频率：计算/复用本时隙统一的 dial 平移量（Hz）。
+   * - 按 slotStartMs 冻结：同一时隙首次计算后固定，保证中途加入的操作员复用同一 shift，
+   *   与已编码音频及单次 dial 平移匹配（避免功能在时隙中途被切换导致 RF 错配）。
+   * - 多操作员：取所有发射操作员音频频率的 min/max 中心，把整团混音平移进甜区。
+   * - 滞回：中心已落在 [target±hysteresis] 内则不平移，避免每时隙来回切频。
+   */
+  private resolveSlotTxDialShift(
+    slotStartMs: number,
+    requests: TransmitRequest[],
+    enabled: boolean,
+  ): number {
+    if (this.currentSlotTxDialShift?.slotStartMs === slotStartMs) {
+      return this.currentSlotTxDialShift.shiftHz; // 本时隙已冻结
+    }
+
+    let shiftHz = 0;
+    if (enabled) {
+      const freqs = requests
+        .map((r) => this.operators.get(r.operatorId))
+        .filter((op): op is RadioOperator => !!op && op.isTransmitting)
+        .map((op) => op.config.frequency || 0)
+        .filter((f) => f > 0);
+
+      if (freqs.length > 0) {
+        const center = (Math.min(...freqs) + Math.max(...freqs)) / 2;
+        if (Math.abs(center - RadioOperatorManager.FAKE_FREQ_TARGET_HZ)
+            > RadioOperatorManager.FAKE_FREQ_HYSTERESIS_HZ) {
+          shiftHz = Math.round(center - RadioOperatorManager.FAKE_FREQ_TARGET_HZ);
+        }
+      }
+    }
+
+    this.currentSlotTxDialShift = { slotStartMs, shiftHz };
+    return shiftHz;
+  }
+
+  /**
+   * 虚拟频率：本时隙是否已提交 dial 平移计划（即已过 encodeStart、shift 已冻结）。
+   * 物理上 tone 期间不可移动 dial，因此一旦提交，发射中的频率变更必须顺延到下一时隙。
+   */
+  private isFakeFrequencyCommittedForCurrentSlot(): boolean {
+    if (!(this.getFakeFrequencyEnabled?.() ?? false)) {
+      return false;
+    }
+    const mode = this.getCurrentMode();
+    const now = this.clockSource.now();
+    const currentSlotStartMs = Math.floor(now / mode.slotMs) * mode.slotMs;
+    return this.currentSlotTxDialShift?.slotStartMs === currentSlotStartMs;
   }
 
   /**

--- a/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
+++ b/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
@@ -52,6 +52,7 @@ function createManager(options: {
   getRadioFrequency?: () => Promise<number | null>;
   getKnownRadioFrequency?: () => number | null;
   callsignTracker?: { getGrid: (callsign: string) => string | undefined };
+  getFakeFrequencyEnabled?: () => boolean;
 }) {
   const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
   const slotPackManager = {
@@ -88,6 +89,7 @@ function createManager(options: {
     getRadioFrequency: options.getRadioFrequency,
     getKnownRadioFrequency: options.getKnownRadioFrequency,
     callsignTracker: options.callsignTracker as any,
+    getFakeFrequencyEnabled: options.getFakeFrequencyEnabled,
   });
 
   return {
@@ -1484,5 +1486,162 @@ describe('RadioOperatorManager operator status payloads', () => {
     manager.emitOperatorStatusUpdate('op1');
 
     expect(statusSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('RadioOperatorManager fake frequency dial shift', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function addTxOperator(manager: RadioOperatorManager, id: string, frequency: number) {
+    await manager.addOperator({
+      id,
+      myCallsign: 'BG4IAJ',
+      myGrid: 'OM96',
+      frequency,
+      transmitCycles: [0],
+      mode: MODES.FT8,
+    });
+    const operator = manager.getOperatorById(id);
+    expect(operator).toBeDefined();
+    operator!.start();
+    return operator!;
+  }
+
+  function queueAndProcess(
+    manager: RadioOperatorManager,
+    eventEmitter: EventEmitter<DigitalRadioEngineEvents>,
+    operatorIds: string[],
+    slotStartMs: number,
+  ) {
+    for (const id of operatorIds) {
+      eventEmitter.emit('requestTransmit' as any, {
+        operatorId: id,
+        transmission: 'CQ BG4IAJ OM96',
+      });
+    }
+    manager.processPendingTransmissions(createSlotInfo(slotStartMs));
+  }
+
+  function mockConfigManager() {
+    return vi.spyOn(ConfigManager, 'getInstance').mockReturnValue({
+      updateOperatorConfig: vi.fn().mockResolvedValue(undefined),
+      getOperatorConfig: vi.fn(() => undefined),
+      getFT8Config: () => ({ maxSameTransmissionCount: 20 }),
+    } as any);
+  }
+
+  it('attaches the frozen shift to the encode request and centers a single operator', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+      getFakeFrequencyEnabled: () => true,
+    });
+    await addTxOperator(manager, 'op1', 2400);
+    manager.start();
+
+    queueAndProcess(manager, eventEmitter, ['op1'], 0);
+
+    expect(encodeQueue.push).toHaveBeenCalledTimes(1);
+    expect(encodeQueue.push.mock.calls[0][0]).toMatchObject({
+      operatorId: 'op1',
+      frequency: 1500, // 2400 - 900 → 甜区
+      txDialShiftHz: 900, // 2400 - 1500
+    });
+  });
+
+  it('uses the min/max center and shifts every operator by the same amount', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+      getFakeFrequencyEnabled: () => true,
+    });
+    await addTxOperator(manager, 'op1', 1200);
+    await addTxOperator(manager, 'op2', 2400);
+    manager.start();
+
+    queueAndProcess(manager, eventEmitter, ['op1', 'op2'], 0);
+
+    // center = (1200 + 2400) / 2 = 1800 → shift = 300，两操作员同量平移
+    expect(encodeQueue.push).toHaveBeenCalledTimes(2);
+    const byId: Record<string, any> = Object.fromEntries(
+      encodeQueue.push.mock.calls.map((c: any[]) => [c[0].operatorId, c[0]]),
+    );
+    expect(byId.op1).toMatchObject({ frequency: 900, txDialShiftHz: 300 });
+    expect(byId.op2).toMatchObject({ frequency: 2100, txDialShiftHz: 300 });
+  });
+
+  it('does not shift when the center is within the hysteresis band', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+      getFakeFrequencyEnabled: () => true,
+    });
+    await addTxOperator(manager, 'op1', 1550); // |1550 - 1500| = 50 <= 200 → 不平移
+    manager.start();
+
+    queueAndProcess(manager, eventEmitter, ['op1'], 0);
+
+    expect(encodeQueue.push.mock.calls[0][0]).toMatchObject({
+      operatorId: 'op1',
+      frequency: 1550,
+      txDialShiftHz: 0,
+    });
+  });
+
+  it('defers a mid-slot frequency change to the next slot once the shift is committed', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+      getFakeFrequencyEnabled: () => true,
+    });
+    mockConfigManager();
+    await addTxOperator(manager, 'op1', 2400);
+    manager.start();
+
+    queueAndProcess(manager, eventEmitter, ['op1'], 0); // 提交本时隙 shift
+    manager.updateActiveTransmissionOperators(['op1']);
+
+    const retrigger = vi.spyOn(manager as any, 'checkAndTriggerTransmission').mockImplementation(() => {});
+    await manager.updateOperatorContext('op1', { frequency: 1000 });
+
+    // 已提交：不重编码，仅更新 config 供下一时隙采纳
+    expect(retrigger).not.toHaveBeenCalled();
+    expect(manager.getOperatorById('op1')?.config.frequency).toBe(1000);
+  });
+
+  it('re-triggers immediately when fake frequency is disabled (no regression)', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+      getFakeFrequencyEnabled: () => false,
+    });
+    mockConfigManager();
+    await addTxOperator(manager, 'op1', 2400);
+    manager.start();
+
+    queueAndProcess(manager, eventEmitter, ['op1'], 0);
+    manager.updateActiveTransmissionOperators(['op1']);
+
+    const retrigger = vi.spyOn(manager as any, 'checkAndTriggerTransmission').mockImplementation(() => {});
+    await manager.updateOperatorContext('op1', { frequency: 1000 });
+
+    expect(retrigger).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/radio/PhysicalRadioManager.ts
+++ b/packages/server/src/radio/PhysicalRadioManager.ts
@@ -372,6 +372,16 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
   private _isPTTActive = false;
 
   /**
+   * 虚拟频率（Fake Frequency）发射期临时 dial 平移状态。
+   * 平移期间不更新 lastKnownFrequency，保证前端 dial 显示/TX 标记/广播保持用户视角；
+   * 同时作为频率监测的跳过条件，杜绝平移窗口被轮询拉回。
+   */
+  private txDialOffsetActive = false;
+  private txDialRestoreFrequency: number | null = null;
+  // 本次发射已提交的 dial 平移量（Hz）。一旦提交即锁定，tone 期间拒绝中途改写。
+  private txDialCurrentOffsetHz = 0;
+
+  /**
    * 当前连接会话的核心能力状态缓存。
    * 一旦明确判定为 unsupported，当前会话内不再重复访问底层连接。
    */
@@ -449,6 +459,18 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
    */
   getConfig(): HamlibConfig {
     return { ...this.currentConfig };
+  }
+
+  /**
+   * 虚拟频率：热更新当前配置中的开关（无需重启引擎/重连）。
+   * 编码时通过 getConfig().fakeFrequency 读取最新值。
+   */
+  setFakeFrequencyEnabled(enabled: boolean): void {
+    this.currentConfig = {
+      ...this.currentConfig,
+      fakeFrequency: { enabled },
+    };
+    logger.info(`Fake frequency ${enabled ? 'enabled' : 'disabled'}`);
   }
 
   /**
@@ -981,6 +1003,113 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       logger.error(`Failed to set frequency: ${(error as Error).message}`);
       this.handleConnectionError(error as Error);
       return false;
+    }
+  }
+
+  /**
+   * 是否处于虚拟频率发射期平移中。
+   * 作为频率监测/能力轮询的跳过条件，避免平移期间被误判为用户改频。
+   */
+  isTxDialOffsetActive(): boolean {
+    return this.txDialOffsetActive;
+  }
+
+  /**
+   * 电台 rig split 是否已开启（用于虚拟频率互斥判断）。
+   * 读取能力状态缓存，缺失时按未开启处理（best-effort，绝不抛错）。
+   */
+  isSplitEnabled(): boolean {
+    try {
+      const state = this.capabilityManager
+        .getCapabilityStates()
+        .find((capability) => capability.id === 'split_enabled');
+      return state?.value === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 虚拟频率：发射前临时把 dial 频率反向平移 offsetHz。
+   * 直接经连接层 critical queue 写入，**不更新 lastKnownFrequency**，保证对用户透明。
+   * 与 clearTxDialOffset() 成对调用（由 TransmissionPipeline 在 PTT 起停时驱动）。
+   */
+  async setTxDialOffset(offsetHz: number): Promise<boolean> {
+    if (!this.connection) {
+      logger.warn('Cannot apply TX dial offset: radio not connected');
+      return false;
+    }
+    if (this.isCoreCapabilityUnsupported('writeFrequency')) {
+      logger.debug('Skipping TX dial offset because write frequency is marked unsupported');
+      return false;
+    }
+    if (!Number.isFinite(offsetHz) || offsetHz === 0) {
+      return false;
+    }
+    // 幂等加锁：dial 是本次发射的物理提交，tone 期间不可移动。
+    // 中途切换/新操作员加入会二次进入 handleMixedAudioReady → 此处重入。
+    if (this.txDialOffsetActive) {
+      if (this.txDialCurrentOffsetHz !== offsetHz) {
+        logger.warn('Ignoring conflicting TX dial offset while one is already active', {
+          activeOffsetHz: this.txDialCurrentOffsetHz,
+          requestedOffsetHz: offsetHz,
+        });
+      }
+      return true;
+    }
+    const rxDial = this.lastKnownFrequency;
+    if (rxDial === null || rxDial <= 0) {
+      logger.warn('Cannot apply TX dial offset: RX dial frequency unknown');
+      return false;
+    }
+    const target = rxDial + offsetHz;
+    // 先置守卫，使频率监测在 PTT 真正激活前的窗口也跳过
+    this.txDialRestoreFrequency = rxDial;
+    this.txDialCurrentOffsetHz = offsetHz;
+    this.txDialOffsetActive = true;
+    try {
+      await this.connection.setFrequency(target);
+      logger.debug('TX dial offset applied', {
+        rxDialHz: rxDial,
+        offsetHz,
+        txDialHz: target,
+      });
+      return true;
+    } catch (error) {
+      this.txDialOffsetActive = false;
+      this.txDialRestoreFrequency = null;
+      this.txDialCurrentOffsetHz = 0;
+      logger.error(`Failed to apply TX dial offset: ${(error as Error).message}`);
+      return false;
+    }
+  }
+
+  /**
+   * 虚拟频率：发射结束后把 dial 频率恢复到接收频点。
+   * 兜底保证——即使恢复写入失败也清除平移守卫并记录 error，避免接收 dial 永久跑偏。
+   */
+  async clearTxDialOffset(): Promise<void> {
+    if (!this.txDialOffsetActive) {
+      return;
+    }
+    const restore = this.txDialRestoreFrequency;
+    // 释放守卫后走标准 setFrequency 恢复：重建 settle 窗口与频率写跟踪，
+    // 因恢复目标 == 原接收 dial == 当前 lastKnownFrequency，前端不会产生跳变。
+    this.txDialOffsetActive = false;
+    this.txDialRestoreFrequency = null;
+    this.txDialCurrentOffsetHz = 0;
+    if (restore === null || restore <= 0) {
+      return;
+    }
+    try {
+      const ok = await this.setFrequency(restore);
+      if (!ok) {
+        logger.error('Failed to restore RX dial after TX dial offset', { restoreHz: restore });
+      } else {
+        logger.debug('TX dial offset cleared, RX dial restored', { rxDialHz: restore });
+      }
+    } catch (error) {
+      logger.error(`Failed to restore RX dial after TX dial offset: ${(error as Error).message}`);
     }
   }
 
@@ -2758,6 +2887,11 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       return;
     }
 
+    if (this.txDialOffsetActive) {
+      // 虚拟频率平移窗口：dial 已被临时改动，跳过监测以免被误判为用户改频并拉回
+      return;
+    }
+
     if (this.connection.isCriticalOperationActive?.()) {
       logger.debug('Skipping frequency monitoring because a critical radio operation is in progress');
       return;
@@ -2827,7 +2961,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       .catch(() => undefined)
       .then(async () => {
         const connection = this.connection;
-        if (!connection || this._isPTTActive) {
+        if (!connection || this._isPTTActive || this.txDialOffsetActive) {
           return;
         }
 

--- a/packages/server/src/radio/__tests__/PhysicalRadioManager.test.ts
+++ b/packages/server/src/radio/__tests__/PhysicalRadioManager.test.ts
@@ -1557,4 +1557,51 @@ describe('PhysicalRadioManager', () => {
       vi.resetModules();
     }
   });
+
+  describe('fake frequency TX dial offset', () => {
+    it('applies the offset once and is idempotent for the same offset while active', async () => {
+      const setFrequency = vi.fn().mockResolvedValue(undefined);
+      asTestManager(manager).connection = { setFrequency };
+      asTestManager(manager).lastKnownFrequency = 7074000;
+
+      await expect(manager.setTxDialOffset(681)).resolves.toBe(true);
+      // tone 期间二次进入（中途切换/新操作员加入）相同 offset 不再写频
+      await expect(manager.setTxDialOffset(681)).resolves.toBe(true);
+
+      expect(setFrequency).toHaveBeenCalledTimes(1);
+      expect(setFrequency).toHaveBeenCalledWith(7074681);
+      expect(manager.isTxDialOffsetActive()).toBe(true);
+    });
+
+    it('rejects a conflicting offset while one is already active (dial is locked)', async () => {
+      const setFrequency = vi.fn().mockResolvedValue(undefined);
+      asTestManager(manager).connection = { setFrequency };
+      asTestManager(manager).lastKnownFrequency = 7074000;
+
+      await expect(manager.setTxDialOffset(681)).resolves.toBe(true);
+      // 不同 offset 被拒绝：dial 已为本次发射物理提交，不可中途改写
+      await expect(manager.setTxDialOffset(900)).resolves.toBe(true);
+
+      expect(setFrequency).toHaveBeenCalledTimes(1);
+      expect(setFrequency).toHaveBeenCalledWith(7074681);
+    });
+
+    it('restores the RX dial on clear and allows a fresh offset afterward', async () => {
+      const setFrequency = vi.fn().mockResolvedValue(undefined);
+      asTestManager(manager).connection = { setFrequency };
+      asTestManager(manager).lastKnownFrequency = 7074000;
+
+      await manager.setTxDialOffset(681);
+      await manager.clearTxDialOffset();
+
+      expect(manager.isTxDialOffsetActive()).toBe(false);
+      // 恢复写回原接收 dial
+      expect(setFrequency).toHaveBeenCalledWith(7074000);
+
+      // 下一次发射可重新提交新的 offset
+      setFrequency.mockClear();
+      await expect(manager.setTxDialOffset(900)).resolves.toBe(true);
+      expect(setFrequency).toHaveBeenCalledWith(7074900);
+    });
+  });
 });

--- a/packages/server/src/routes/radio.ts
+++ b/packages/server/src/routes/radio.ts
@@ -1259,4 +1259,11 @@ export async function radioRoutes(fastify: FastifyInstance) {
 
     return reply.send({ success: true });
   });
+
+  // 虚拟频率（Fake Frequency）快捷开关：热更新 + 持久化到激活 Profile
+  fastify.post('/fake-frequency', { preHandler: [requireAbility('execute', 'RadioControl')] }, async (req, reply) => {
+    const enabled = !!(req.body as { enabled?: boolean } | undefined)?.enabled;
+    await engine.setFakeFrequencyEnabled(enabled);
+    return reply.send({ success: true, enabled });
+  });
 }

--- a/packages/server/src/subsystems/TransmissionPipeline.ts
+++ b/packages/server/src/subsystems/TransmissionPipeline.ts
@@ -288,38 +288,45 @@ export class TransmissionPipeline {
   private async stopPTT(): Promise<void> {
     if (!this._isPTTActive) {
       logger.debug('PTT already stopped, skipping');
+      // 兜底清除可能残留的虚拟频率平移（如 startPTT 失败导致 PTT 未真正激活的场景）
+      await this.deps.radioManager.clearTxDialOffset();
       return;
     }
 
-    if (this.deps.radioManager.isConnected()) {
-      try {
-        await this.deps.radioManager.setPTT(false);
-        this._isPTTActive = false;
+    try {
+      if (this.deps.radioManager.isConnected()) {
+        try {
+          await this.deps.radioManager.setPTT(false);
+          this._isPTTActive = false;
 
+          this.deps.spectrumScheduler.setPTTActive(false);
+          this.deps.radioManager.setPTTActive(false);
+
+          this.deps.engineEmitter.emit('pttStatusChanged', {
+            isTransmitting: false,
+            operatorIds: []
+          });
+
+          this.deps.operatorManager.updateActiveTransmissionOperators([]);
+
+          logger.debug('PTT stopped');
+        } catch (error) {
+          logger.error(`PTT stop failed: ${error}`);
+          this._isPTTActive = false;
+          this.deps.spectrumScheduler.setPTTActive(false);
+          this.deps.radioManager.setPTTActive(false);
+          this.deps.operatorManager.updateActiveTransmissionOperators([]);
+        }
+      } else {
+        this._isPTTActive = false;
         this.deps.spectrumScheduler.setPTTActive(false);
         this.deps.radioManager.setPTTActive(false);
-
-        this.deps.engineEmitter.emit('pttStatusChanged', {
-          isTransmitting: false,
-          operatorIds: []
-        });
-
         this.deps.operatorManager.updateActiveTransmissionOperators([]);
-
-        logger.debug('PTT stopped');
-      } catch (error) {
-        logger.error(`PTT stop failed: ${error}`);
-        this._isPTTActive = false;
-        this.deps.spectrumScheduler.setPTTActive(false);
-        this.deps.radioManager.setPTTActive(false);
-        this.deps.operatorManager.updateActiveTransmissionOperators([]);
+        logger.debug('radio not connected, PTT state set to stopped');
       }
-    } else {
-      this._isPTTActive = false;
-      this.deps.spectrumScheduler.setPTTActive(false);
-      this.deps.radioManager.setPTTActive(false);
-      this.deps.operatorManager.updateActiveTransmissionOperators([]);
-      logger.debug('radio not connected, PTT state set to stopped');
+    } finally {
+      // 虚拟频率：PTT 关闭后恢复接收 dial（在 PTT 真正关闭之后执行，避免发射期间提前回频）
+      await this.deps.radioManager.clearTxDialOffset();
     }
   }
 
@@ -374,7 +381,7 @@ export class TransmissionPipeline {
     audioData: Float32Array;
     sampleRate: number;
     duration: number;
-    request?: { timeSinceSlotStartMs?: number; requestId?: string };
+    request?: { timeSinceSlotStartMs?: number; requestId?: string; txDialShiftHz?: number };
   }): Promise<void> {
     try {
       const request = result.request;
@@ -421,7 +428,8 @@ export class TransmissionPipeline {
         result.audioData,
         result.sampleRate,
         currentSlotStartMs,
-        requestId
+        requestId,
+        result.request?.txDialShiftHz ?? 0
       );
 
       this.deps.transmissionTracker.recordAudioAddedToMixer(result.operatorId);
@@ -499,6 +507,15 @@ export class TransmissionPipeline {
       }
 
       await this.deps.onBeforeStartPTT?.();
+
+      // 虚拟频率：在 PTT 之前临时把电台 dial 反向平移到本次发射的 shift。
+      // shift 与音频同源（随 mixedAudio 负载流转），保证施加到 dial 的平移量恒等于编码所用 shift。
+      // 音频已按 (origFreq - shift) 编码，dial +shift 后打到空中的绝对 RF 不变。
+      // clearTxDialOffset() 在 stopPTT 的 finally 中兜底恢复。
+      const txDialShiftHz = mixedAudio.txDialShiftHz ?? 0;
+      if (txDialShiftHz !== 0) {
+        await this.deps.radioManager.setTxDialOffset(txDialShiftHz);
+      }
 
       const startSequenceAt = Date.now();
       logger.info('starting PTT and audio playback in parallel', {

--- a/packages/server/src/subsystems/__tests__/TransmissionPipeline.test.ts
+++ b/packages/server/src/subsystems/__tests__/TransmissionPipeline.test.ts
@@ -35,6 +35,8 @@ function createPipeline(configType: 'icom-wlan' | 'hamlib') {
       setPTT,
       setPTTActive: vi.fn(),
       getConfig: vi.fn(() => ({ type: configType })),
+      setTxDialOffset: vi.fn(async () => true),
+      clearTxDialOffset: vi.fn(async () => undefined),
     },
     spectrumScheduler: {
       setPTTActive: vi.fn(),
@@ -62,6 +64,7 @@ function createPipeline(configType: 'icom-wlan' | 'hamlib') {
     audioData: new Float32Array(12000),
     sampleRate: 12000,
     duration: 1,
+    txDialShiftHz: 0,
   };
 
   return { pipeline, deps, audioDone, mixedAudio };
@@ -145,5 +148,60 @@ describe('TransmissionPipeline PTT release timing', () => {
     audioDone.resolve();
     await handling;
     await pipeline.forceStopPTT();
+  });
+});
+
+describe('TransmissionPipeline fake frequency dial offset', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('applies the slot dial offset before PTT and restores it after stop', async () => {
+    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('hamlib');
+    // shift 随音频负载流转：在 mixedAudio 上携带，PTT 时点据此平移 dial
+    mixedAudio.txDialShiftHz = 681;
+
+    const handling = (pipeline as unknown as {
+      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
+    }).handleMixedAudioReady(mixedAudio);
+
+    await vi.waitFor(() => {
+      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
+    });
+
+    // dial offset applied before PTT start, with the frozen slot shift
+    expect(deps.radioManager.setTxDialOffset).toHaveBeenCalledWith(681);
+    const offsetOrder = deps.radioManager.setTxDialOffset.mock.invocationCallOrder[0];
+    const pttOnOrder = deps.radioManager.setPTT.mock.invocationCallOrder[0];
+    expect(offsetOrder).toBeLessThan(pttOnOrder);
+
+    audioDone.resolve();
+    await handling;
+    await pipeline.forceStopPTT();
+
+    // dial restored after PTT stop
+    expect(deps.radioManager.clearTxDialOffset).toHaveBeenCalled();
+  });
+
+  it('does not touch the dial when the slot shift is zero', async () => {
+    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('hamlib');
+    mixedAudio.txDialShiftHz = 0;
+
+    const handling = (pipeline as unknown as {
+      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
+    }).handleMixedAudioReady(mixedAudio);
+
+    await vi.waitFor(() => {
+      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
+    });
+
+    expect(deps.radioManager.setTxDialOffset).not.toHaveBeenCalled();
+
+    audioDone.resolve();
+    await handling;
+    await pipeline.forceStopPTT();
+
+    // clear is still called as an idempotent safety net
+    expect(deps.radioManager.clearTxDialOffset).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/radio/control/RadioControl.tsx
+++ b/packages/web/src/components/radio/control/RadioControl.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {Select, SelectItem, Switch, Button, Slider, Popover, PopoverTrigger, PopoverContent, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Input, Spinner, Alert, Tabs, Tab, Tooltip, Card, CardBody} from "@heroui/react";
 import { addToast } from '@heroui/toast';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCog, faChevronDown, faVolumeUp, faHeadphones, faMicrophone, faRadio, faSlidersH, faTowerBroadcast, faPowerOff, faCircleInfo, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCog, faChevronDown, faVolumeUp, faHeadphones, faMicrophone, faRadio, faSlidersH, faTowerBroadcast, faPowerOff, faCircleInfo, faTriangleExclamation, faRightLeft } from '@fortawesome/free-solid-svg-icons';
 import { useConnection, useProfiles, useRadioErrors, useCapabilityState, useRadioConnectionState, useRadioModeState, usePTTState, useAudioSidecarState, useRadioState, useOperators } from '../../../store/radioStore';
 import type { AudioSidecarStatusPayload } from '@tx5dr/contracts';
 import { AudioSidecarStatus } from '@tx5dr/contracts';
@@ -2468,6 +2468,39 @@ export const RadioControl: React.FC<RadioControlProps> = ({ onOpenRadioSettings,
                     <TunerCapabilitySurface />
                   </PopoverContent>
                 </Popover>
+              </ToolbarIconTooltip>
+            )}
+            {/* 虚拟频率快捷开关：已连接且具备电台控制权限时露出 */}
+            {connection.state.isConnected
+              && canControlRadio
+              && radioConnection.radioConfig?.type
+              && radioConnection.radioConfig.type !== 'none' && (
+              <ToolbarIconTooltip
+                label={radioConnection.radioConfig?.fakeFrequency?.enabled
+                  ? t('fakeFrequency.tooltipOn')
+                  : t('fakeFrequency.tooltipOff')}
+              >
+                <Button
+                  isIconOnly
+                  variant="light"
+                  size="sm"
+                  className={`min-w-unit-6 min-w-6 w-6 h-6 ${
+                    radioConnection.radioConfig?.fakeFrequency?.enabled
+                      ? 'text-success'
+                      : 'text-default-400'
+                  }`}
+                  aria-label={t('fakeFrequency.toggle')}
+                  onPress={async () => {
+                    const next = !radioConnection.radioConfig?.fakeFrequency?.enabled;
+                    try {
+                      await api.setFakeFrequency(next);
+                    } catch (error) {
+                      addToast({ title: t('fakeFrequency.toggleFailed'), color: 'danger', timeout: 3000 });
+                    }
+                  }}
+                >
+                  <FontAwesomeIcon icon={faRightLeft} className="text-xs" />
+                </Button>
               </ToolbarIconTooltip>
             )}
           </div>

--- a/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
+++ b/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
@@ -4,7 +4,7 @@ import { localizeHamlibConfigText } from '../../../utils/hamlibConfigTextMap';
 
 const logger = createLogger('RadioDeviceSettings');
 import { useTranslation } from 'react-i18next';
-import { Input, Select, SelectItem, Autocomplete, AutocompleteItem, Tabs, Tab, Card, CardBody, Divider, Button, Chip, Tooltip, Accordion, AccordionItem } from '@heroui/react';
+import { Input, Select, SelectItem, Autocomplete, AutocompleteItem, Tabs, Tab, Card, CardBody, Divider, Button, Chip, Tooltip, Accordion, AccordionItem, Switch } from '@heroui/react';
 import { api, ApiError } from '@tx5dr/core';
 import type { CWKeyActiveLevel, DigitalModeRadioModePreference, HamlibConfig, HamlibConfigField, PttMethod, RigConfigSchemaResponse } from '@tx5dr/contracts';
 
@@ -451,6 +451,24 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
             </SelectItem>
           ))}
         </Select>
+      </CardBody>
+    </Card>
+  );
+
+  const renderFakeFrequencyToggle = () => (
+    <Card shadow="none" radius="lg" classNames={{ base: 'border border-divider bg-content1' }}>
+      <CardBody className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1">
+            <h4 className="font-semibold text-default-900">{t('radio.fakeFrequencyTitle')}</h4>
+            <p className="text-sm text-default-600">{t('radio.fakeFrequencyDesc')}</p>
+          </div>
+          <Switch
+            isSelected={!!config.fakeFrequency?.enabled}
+            onValueChange={(enabled) => updateConfig({ fakeFrequency: { enabled } })}
+            size="sm"
+          />
+        </div>
       </CardBody>
     </Card>
   );
@@ -1718,6 +1736,8 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
         </div>
 
         {renderDigitalModeRadioModePreference()}
+
+        {config.type !== 'none' && renderFakeFrequencyToggle()}
 
         {/* 状态提示 */}
         <div className="flex justify-end">

--- a/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
+++ b/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { Button, Input, Popover, PopoverContent, PopoverTrigger, Slider, Switch, Tab, Tabs, Tooltip } from '@heroui/react';
 import { addToast } from '@heroui/toast';
 import { ArrowsPointingOutIcon, ChevronDownIcon, ChevronUpIcon, Cog6ToothIcon, MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import type { EngineMode, SpectrumFrame, SpectrumKind, SpectrumSessionVoiceState, SystemStatus } from '@tx5dr/contracts';
-import { getBandFromFrequency } from '@tx5dr/core';
-import { useConnection, useCurrentOperatorId, useOperators, useProfiles, usePTTState, useRadioConnectionState, useRadioModeState, useSpectrum, useSplitState } from '../../../store/radioStore';
+import { api, getBandFromFrequency } from '@tx5dr/core';
+import { useConnection, useCurrentOperatorId, useOperators, useProfiles, usePTTState, useRadioConnectionState, useRadioModeState, useRadioState, useCapabilityState, useCapabilityDescriptor, useSpectrum, useSplitState } from '../../../store/radioStore';
 import { useAbility, useCan } from '../../../store/authStore';
 import { createLogger } from '../../../utils/logger';
 import { setPreferredSpectrumKind } from '../../../utils/spectrumPreferences';
@@ -58,6 +58,12 @@ const SPECTRUM_HISTORY_LIMITS = {
   'openwebrx-sdr': 40,
 } satisfies Partial<Record<SpectrumKind, number>>;
 const SETTINGS_STORAGE_KEY = 'spectrum-range-settings';
+// 虚拟频率低功率弱警告相关常量
+const FAKE_FREQ_COMFORT_MIN_HZ = 500;   // 发射音频甜区下界（baseband Hz）
+const FAKE_FREQ_COMFORT_MAX_HZ = 2300;  // 发射音频甜区上界（baseband Hz）
+const FAKE_FREQ_OUTPUT_LOW_RATIO = 0.25;   // 实测输出/量程 低于此比例视为功率偏低
+const FAKE_FREQ_OUTPUT_LOW_PERCENT = 25;   // 无瓦数时按百分比判断
+const FAKE_FREQ_SETTING_LOW_RATIO = 0.5;   // RF 功率设置低于量程一半视为用户主动 QRP，不提示
 const OPENWEBRX_VIEWPORT_STORAGE_KEY = 'openwebrx-spectrum-viewports';
 const AUDIO_SOURCE: SpectrumKind = 'audio';
 const RADIO_SDR_SOURCE: SpectrumKind = 'radio-sdr';
@@ -819,6 +825,62 @@ const CollapsedSpectrumBar: React.FC<CollapsedSpectrumBarProps> = ({
   );
 };
 
+/**
+ * 虚拟频率低功率弱警告判定器：订阅高频 meterData 等，计算需要提示的操作员集合，
+ * 仅在结果集变化时通过 onChange 回写，避免高频 meter 刷新拖累整个频谱子树重渲染。
+ * 本组件不渲染任何内容。
+ */
+const FakeFreqLowPowerWatcher: React.FC<{
+  active: boolean;
+  onChange: (ids: string[]) => void;
+}> = ({ active, onChange }) => {
+  const { state: radioState } = useRadioState();
+  const { pttStatus } = usePTTState();
+  const txFrequencies = useTxFrequencies();
+  const rfPowerState = useCapabilityState('rf_power');
+  const rfPowerDescriptor = useCapabilityDescriptor('rf_power');
+  const lastKeyRef = useRef<string>('');
+
+  const ids = useMemo(() => {
+    if (!active) return [];
+    if (!pttStatus.isTransmitting || pttStatus.operatorIds.length === 0) return [];
+
+    // 实测输出功率是否偏低
+    const power = radioState.meterData?.power;
+    if (!power) return [];
+    let outputLow = false;
+    if (power.watts != null && power.maxWatts != null && power.maxWatts > 0) {
+      outputLow = power.watts / power.maxWatts < FAKE_FREQ_OUTPUT_LOW_RATIO;
+    } else if (power.percent != null) {
+      outputLow = power.percent < FAKE_FREQ_OUTPUT_LOW_PERCENT;
+    }
+    if (!outputLow) return [];
+
+    // 电台 RF 功率设置被用户主动调低（QRP）则不提示
+    if (typeof rfPowerState?.value === 'number' && rfPowerDescriptor?.range) {
+      const { min, max } = rfPowerDescriptor.range;
+      if (max > min && (rfPowerState.value - min) / (max - min) < FAKE_FREQ_SETTING_LOW_RATIO) return [];
+    }
+
+    // 仅对发射音频确实偏离甜区的操作员提示
+    return txFrequencies
+      .filter((tx) => pttStatus.operatorIds.includes(tx.operatorId)
+        && (tx.frequency < FAKE_FREQ_COMFORT_MIN_HZ || tx.frequency > FAKE_FREQ_COMFORT_MAX_HZ))
+      .map((tx) => tx.operatorId);
+  }, [active, pttStatus.isTransmitting, pttStatus.operatorIds, radioState.meterData,
+    rfPowerState?.value, rfPowerDescriptor?.range, txFrequencies]);
+
+  useEffect(() => {
+    const key = ids.join(',');
+    if (key !== lastKeyRef.current) {
+      lastKeyRef.current = key;
+      onChange(ids);
+    }
+  }, [ids, onChange]);
+
+  return null;
+};
+
 export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
   className = '',
   height = 200,
@@ -840,6 +902,7 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
   const { pttStatus } = usePTTState();
   const { splitEnabled, splitTxFrequency } = useSplitState();
   const canSetFrequency = useCan('execute', 'RadioFrequency');
+  const canControlRadio = useCan('execute', 'RadioControl');
   const ability = useAbility();
   const canWriteFrequency = canWriteRadioFrequency(canSetFrequency, radioConnection.coreCapabilities);
   const canWriteTargetFrequency = useCallback((frequency: number) => (
@@ -907,6 +970,22 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
   const rxFrequencies = useTargetRxFrequencies();
   const txFrequencies = useTxFrequencies();
   const { currentOperatorId } = useCurrentOperatorId();
+
+  // 虚拟频率弱警告：判定逻辑放在独立的 FakeFreqLowPowerWatcher 中订阅高频 meterData，
+  // 仅当结果集变化时才回写到这里，避免每次 meter 刷新都重渲染整个频谱子树。
+  const fakeFrequencyEnabled = radioConnection.radioConfig?.fakeFrequency?.enabled ?? false;
+  // 仅内存态：刷新网页后重置，会再次提示（不持久化到 localStorage）
+  const [lowPowerHintDismissed, setLowPowerHintDismissed] = useState<boolean>(false);
+  const [lowPowerWarningOperatorIds, setLowPowerWarningOperatorIds] = useState<string[]>([]);
+
+  const handleEnableFakeFrequency = useCallback(() => {
+    void api.setFakeFrequency(true).catch((error) => {
+      logger.error('Failed to enable fake frequency from low-power hint', error);
+    });
+  }, []);
+  const handleDismissLowPowerHint = useCallback(() => {
+    setLowPowerHintDismissed(true);
+  }, []);
   const effectiveSelectedKind = selectedKind ?? capabilities?.defaultKind ?? AUDIO_SOURCE;
   const activeSpectrumKind = subscribedKind ?? effectiveSelectedKind;
   const isAudioSpectrumSelected = effectiveSelectedKind === AUDIO_SOURCE;
@@ -1965,6 +2044,10 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
       onWheel={isOpenWebRXSdrSelected && canOpenWebRXLocalViewportZoom ? handleOpenWebRXWheel : undefined}
       onMouseDown={isOpenWebRXSdrSelected && canOpenWebRXLocalViewportPan ? handleOpenWebRXMouseDown : undefined}
     >
+      <FakeFreqLowPowerWatcher
+        active={canControlRadio && !fakeFrequencyEnabled && !lowPowerHintDismissed}
+        onChange={setLowPowerWarningOperatorIds}
+      />
       <WebGLWaterfall
         key={waterfallViewKey}
         controller={streamController}
@@ -1993,6 +2076,9 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
         presetMarkers={presetMarkers}
         rxFrequencies={displaySpectrumMarkers.rxFrequencies}
         txFrequencies={displaySpectrumMarkers.txFrequencies}
+        lowPowerWarningOperatorIds={lowPowerWarningOperatorIds}
+        onEnableFakeFrequency={handleEnableFakeFrequency}
+        onDismissLowPowerWarning={handleDismissLowPowerHint}
         onTxFrequencyChange={displayTxFrequencyChange}
         onTxBandOverlayFrequencyChange={voiceOverlayIsInteractive ? (_id, frequency) => void handleRadioSdrFrequencyGesture(frequency) : undefined}
         onFrequencyBandOverlayPreviewChange={isAudioSpectrumSelected ? onFrequencyBandOverlayPreviewChange : undefined}

--- a/packages/web/src/components/radio/spectrum/WebGLWaterfall.tsx
+++ b/packages/web/src/components/radio/spectrum/WebGLWaterfall.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useEffect, useLayoutEffect, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
-import { Popover, PopoverTrigger, PopoverContent } from '@heroui/react';
+import { Popover, PopoverTrigger, PopoverContent, Button } from '@heroui/react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
 import { createLogger } from '../../../utils/logger';
 import type { SpectrumAxis, SpectrumRenderBatch, SpectrumStreamController } from '../../../spectrum/SpectrumStreamController';
@@ -141,6 +143,12 @@ interface WebGLWaterfallProps {
   showCycleMarkers?: boolean;
   /** 数字模式周期长度（毫秒），例如 FT8=15000、FT4=7500 */
   cycleSlotMs?: number | null;
+  /** 需要显示"低功率—可开启虚拟频率"弱警告的操作员 ID（由上层根据实测功率判断） */
+  lowPowerWarningOperatorIds?: string[];
+  /** 弱警告 popover 中点击"一键开启虚拟频率" */
+  onEnableFakeFrequency?: () => void;
+  /** 弱警告 popover 中点击"不再提示" */
+  onDismissLowPowerWarning?: () => void;
 }
 
 const FREQUENCY_GESTURE_DRAG_THRESHOLD_PX = 4;
@@ -623,8 +631,13 @@ export const WebGLWaterfall: React.FC<WebGLWaterfallProps> = ({
   themeId = DEFAULT_SPECTRUM_THEME_ID,
   showCycleMarkers = false,
   cycleSlotMs = null,
+  lowPowerWarningOperatorIds = [],
+  onEnableFakeFrequency,
+  onDismissLowPowerWarning,
 }) => {
   const { t } = useTranslation('common');
+  const { t: tRadio } = useTranslation('radio');
+  const [hoveredWarningOperatorId, setHoveredWarningOperatorId] = React.useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const cycleMarkerLayerRef = useRef<HTMLDivElement>(null);
@@ -3367,6 +3380,64 @@ export const WebGLWaterfall: React.FC<WebGLWaterfallProps> = ({
                   <div className="text-sm font-semibold">{callsign}</div>
                   <div className="text-xs text-default-400">
                     {frequency} Hz
+                  </div>
+                </div>
+              </PopoverContent>
+            </Popover>
+          );
+        })}
+
+        {/* 虚拟频率弱警告：实测发射功率偏低的操作员，在其 TX 标记上方常驻一个小黄色感叹号；hover 展开详细说明与操作 */}
+        {lowPowerWarningOperatorIds.length > 0 && txFrequencies.map(({ operatorId, frequency }) => {
+          if (!lowPowerWarningOperatorIds.includes(operatorId)) return null;
+          // 与 TX 标记一致：拖动/冷却期使用本地覆盖频率，使警告图标实时跟随
+          const isOverridden = localFrequencyOverride?.operatorId === operatorId &&
+            (draggingOperatorId === operatorId || cooldownOperatorId === operatorId);
+          const displayFrequency = isOverridden ? localFrequencyOverride!.frequency : frequency;
+          const position = getMarkerPosition(displayFrequency);
+          if (position === null) return null;
+          const isOpen = hoveredWarningOperatorId === operatorId;
+          return (
+            <Popover
+              key={`tx-warn-${operatorId}`}
+              placement="top"
+              isOpen={isOpen}
+              onOpenChange={(open) => { if (!open) setHoveredWarningOperatorId(null); }}
+            >
+              <PopoverTrigger>
+                <div
+                  className="absolute z-10 pointer-events-auto cursor-help"
+                  style={{ left: `${position}%`, bottom: '1.5rem', transform: 'translateX(-50%)' }}
+                  onMouseEnter={() => setHoveredWarningOperatorId(operatorId)}
+                  onMouseLeave={() => setHoveredWarningOperatorId(null)}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  aria-label={tRadio('fakeFrequency.lowPowerTitle')}
+                >
+                  <FontAwesomeIcon icon={faTriangleExclamation} className="text-warning text-[10px] drop-shadow" />
+                </div>
+              </PopoverTrigger>
+              <PopoverContent
+                onMouseEnter={() => setHoveredWarningOperatorId(operatorId)}
+                onMouseLeave={() => setHoveredWarningOperatorId(null)}
+              >
+                <div className="px-3 py-3 max-w-[240px] space-y-2">
+                  <div className="text-xs font-semibold text-default-900">{tRadio('fakeFrequency.lowPowerTitle')}</div>
+                  <div className="text-xs text-default-500">{tRadio('fakeFrequency.lowPowerHint')}</div>
+                  <div className="flex gap-2 justify-end">
+                    <Button
+                      size="sm"
+                      variant="light"
+                      onPress={() => { setHoveredWarningOperatorId(null); onDismissLowPowerWarning?.(); }}
+                    >
+                      {tRadio('fakeFrequency.dontRemind')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      color="primary"
+                      onPress={() => { setHoveredWarningOperatorId(null); onEnableFakeFrequency?.(); }}
+                    >
+                      {tRadio('fakeFrequency.enableNow')}
+                    </Button>
                   </div>
                 </div>
               </PopoverContent>

--- a/packages/web/src/i18n/locales/en/radio.json
+++ b/packages/web/src/i18n/locales/en/radio.json
@@ -297,6 +297,16 @@
     "toneBusy": "The transmitter is already active, so tone tune cannot start.",
     "toneStartFailed": "Failed to start tone tune"
   },
+  "fakeFrequency": {
+    "toggle": "Fake Frequency",
+    "tooltipOn": "Fake Frequency: on (keeps TX audio carrier in the radio's sweet spot)",
+    "tooltipOff": "Fake Frequency: off (click to enable, avoids power roll-off at high/low audio)",
+    "toggleFailed": "Failed to toggle Fake Frequency",
+    "lowPowerTitle": "Low TX power",
+    "lowPowerHint": "Your TX audio is away from the center band, where some radios output noticeably less power. Enabling Fake Frequency keeps the audio carrier in the sweet spot during TX while the actual on-air position stays the same.",
+    "enableNow": "Enable now",
+    "dontRemind": "Don't remind me"
+  },
   "error": {
     "unknown": "An unknown error occurred",
     "connectionFailed": "Radio connection failed",

--- a/packages/web/src/i18n/locales/en/settings.json
+++ b/packages/web/src/i18n/locales/en/settings.json
@@ -192,6 +192,8 @@
       "usb": "USB (upper sideband)",
       "usb-data": "USB-DATA (upper sideband data)"
     },
+    "fakeFrequencyTitle": "Fake Frequency",
+    "fakeFrequencyDesc": "Keep the transmit audio carrier in the radio's sweet spot (~1500 Hz) during TX and shift the dial frequency the opposite way, so the actual on-air position stays the same. Avoids reduced TX power on radios that roll off at high/low audio frequencies; fully transparent to the receive display and your set TX frequency.",
     "serialTitle": "Hamlib Direct Radio Settings",
     "refreshPortsTooltip": "Refresh port list",
     "serialDesc": "Connect directly through Hamlib. Depending on the model, this may use a serial port, server address, or device path.",

--- a/packages/web/src/i18n/locales/zh/radio.json
+++ b/packages/web/src/i18n/locales/zh/radio.json
@@ -297,6 +297,16 @@
     "toneBusy": "当前正在发射，无法启动单音调谐。",
     "toneStartFailed": "启动单音调谐失败"
   },
+  "fakeFrequency": {
+    "toggle": "虚拟频率",
+    "tooltipOn": "虚拟频率：已开启（发射音频载波保持在最佳频段）",
+    "tooltipOff": "虚拟频率：已关闭（点击开启，避免高/低频发射功率衰减）",
+    "toggleFailed": "切换虚拟频率失败",
+    "lowPowerTitle": "发射功率偏低",
+    "lowPowerHint": "当前发射音频偏离中心频段，部分电台在此处发射功率会明显下降。开启「虚拟频率」可在发射时自动将音频载波保持在最佳频段，实际发射位置不变。",
+    "enableNow": "一键开启",
+    "dontRemind": "不再提示"
+  },
   "power": {
     "on": {
       "label": "开机",

--- a/packages/web/src/i18n/locales/zh/settings.json
+++ b/packages/web/src/i18n/locales/zh/settings.json
@@ -192,6 +192,8 @@
       "usb": "USB（上边带）",
       "usb-data": "USB-DATA（上边带数据）"
     },
+    "fakeFrequencyTitle": "虚拟频率",
+    "fakeFrequencyDesc": "发射时自动将音频载波保持在最佳频段（约 1500Hz），并反向平移电台频率，使实际发射位置不变。可规避部分电台在音频频率过高/过低时发射功率衰减的问题；对接收显示与发射频点完全透明。",
     "serialTitle": "Hamlib 直连电台设置",
     "refreshPortsTooltip": "刷新串口列表",
     "serialDesc": "通过 Hamlib 直连电台，具体型号可能使用串口、服务器地址或设备路径。",


### PR DESCRIPTION
## 概述

对齐 **WSJT-X "Split Operation: Fake It" / JTDX 虚拟频率**：发射时临时把电台 dial 反向平移，使送进电台的音频载波保持在甜区（~1500Hz），而打到空中的实际 RF 与用户设定的发射频点完全一致。解决部分电台在音频频率过高/过低时发射功率衰减的问题。

平移对用户**完全透明**：接收 dial 显示、瀑布 TX 红标、WSJT-X `dialFrequency`/`txDf` 广播全程保持用户视角不变。

## 核心机制（capture-at-encode，shift 与音频负载同源）

- **编码时刻冻结** 本时隙统一 shift（多操作员取 min/max 中心，单 VFO 整体居中），音频按 `origFreq - shift` 编码。
- shift 随 `EncodeRequest → MixedAudio.txDialShiftHz` 流转，PTT 时据此反向平移 dial（不污染 `lastKnownFrequency`），PTT 停止 `finally` 兜底恢复。
- **不变量**：`onAirRF = (rxDial + shift) + (userFreq - shift) = rxDial + userFreq`，结构上保证 dial 平移量恒等于编码 shift。

## 运行时变更处理（物理正确，与 WSJT-X 一致）

FT8 的 12.64s tone 期间**不可移动 dial**（否则信号作废），因此：

- 发射进行中改 TX 频率 / 切虚拟频率开关 → **延迟到下一时隙静默生效**（当前 tone 原样发完，下一时隙由 dial 吸收变更、音频回甜区）。
- `setTxDialOffset` **幂等加锁**：本次发射的 dial 一旦提交即锁定，拒绝中途改写（中途切换/新操作员加入二次进入时安全）。
- 多操作员铺宽超出单 VFO 可居中范围时显式 `warn`，不静默钳错。

## 露出方式

- Profile 设置项 + RadioControl 工具栏快捷开关（状态同步）。
- 瀑布图低功率弱提示：实际发射且功率计偏低、且非 QRP、且音频偏离甜区时，TX 标记上方显示黄色感叹号，hover 后可「一键开启」/「不再提示」（仅内存态）。
- 写操作受 `execute:RadioControl` 权限保护。

## 测试

- 新增/更新单元测试：`TransmissionPipeline`（dial 偏移时序）、`PhysicalRadioManager`（+3 幂等锁）、`RadioOperatorManager`（+5 shift 计算 / 多操作员居中 / 滞回 / 改频延迟 / 关闭无回归）。
- `yarn workspace @tx5dr/server build` ✅、`lint` ✅、受影响 4 套件 **97 passed**、全量 **61 文件全绿 0 失败**。

## 验证建议（实机）

IC-705 WLAN 与 Hamlib 各一：开启功能后 2400Hz 发射，确认发射期间 dial 临时升约 +900、送机音频回 ~1500Hz、前端 dial 与 TX 红标停在原位不抖、结束后 dial 恢复；发射中改频/切开关确认延迟到下一时隙；多操作员 1200/2400Hz 同发确认整团居中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)