### PR TITLE
[codex] Add TCI SunSDR portal integration

### DIFF
--- a/packages/contracts/src/schema/__tests__/audio.schema.test.ts
+++ b/packages/contracts/src/schema/__tests__/audio.schema.test.ts
@@ -7,6 +7,7 @@ import {
   AudioDeviceSettingsResponseSchema,
   AudioOutputChannelModeSchema,
   AudioOutputSampleFormatSchema,
+  AudioSettingsResolveRequestSchema,
   AudioSettingsResolveResponseSchema,
 } from '../audio.schema.js';
 
@@ -160,5 +161,17 @@ describe('audio device resolution schemas', () => {
         },
       }).deviceResolution.input.status).toBe(status);
     }
+  });
+
+  it('accepts TCI as a radio-audio resolution request context', () => {
+    const parsed = AudioSettingsResolveRequestSchema.parse({
+      radioType: 'tci',
+      audio: {
+        inputDeviceName: 'TCI Audio',
+        outputDeviceName: 'TCI Audio',
+      },
+    });
+
+    expect(parsed.radioType).toBe('tci');
   });
 });

--- a/packages/contracts/src/schema/__tests__/radio-power-support.test.ts
+++ b/packages/contracts/src/schema/__tests__/radio-power-support.test.ts
@@ -23,4 +23,18 @@ describe('radio power support', () => {
       }),
     ).not.toThrow();
   });
+
+  it('does not expose physical power controls for TCI radios', () => {
+    const decision = decidePowerSupport({
+      type: 'tci',
+      tci: { host: '127.0.0.1', port: 40001, receiver: 0, trx: 0, vfo: 0, audioEnabled: true, audioSampleRate: 12000 },
+    });
+
+    expect(decision).toMatchObject({
+      canPowerOn: false,
+      canPowerOff: false,
+      supportedStates: [],
+      reason: 'model-unsupported',
+    });
+  });
 });

--- a/packages/contracts/src/schema/__tests__/radio.schema.test.ts
+++ b/packages/contracts/src/schema/__tests__/radio.schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DigitalModeRadioModePreferenceSchema, HamlibConfigSchema, PresetFrequencySchema } from '../radio.schema.js';
+import { DigitalModeRadioModePreferenceSchema, HamlibConfigSchema, PresetFrequencySchema, RadioInfoSchema } from '../radio.schema.js';
 
 describe('HamlibConfigSchema digital mode radio mode preference', () => {
   it('accepts legacy configs without a digital mode radio mode preference', () => {
@@ -17,6 +17,35 @@ describe('HamlibConfigSchema digital mode radio mode preference', () => {
 
   it('rejects invalid FT8/FT4 radio mode preferences', () => {
     expect(() => HamlibConfigSchema.parse({ type: 'none', digitalModeRadioMode: 'lsb-data' })).toThrow();
+  });
+});
+
+describe('HamlibConfigSchema TCI connection', () => {
+  it('accepts TCI configs and applies SunSDR defaults', () => {
+    const parsed = HamlibConfigSchema.parse({
+      type: 'tci',
+      tci: {},
+    });
+
+    expect(parsed.tci).toMatchObject({
+      host: '127.0.0.1',
+      port: 40001,
+      receiver: 0,
+      trx: 0,
+      vfo: 0,
+      audioEnabled: true,
+      audioSampleRate: 12000,
+    });
+  });
+
+  it('accepts TCI as a reported radio connection type', () => {
+    const parsed = RadioInfoSchema.parse({
+      manufacturer: 'Expert Electronics',
+      model: 'SunSDR',
+      connectionType: 'tci',
+    });
+
+    expect(parsed.connectionType).toBe('tci');
   });
 });
 

--- a/packages/contracts/src/schema/audio.schema.ts
+++ b/packages/contracts/src/schema/audio.schema.ts
@@ -69,7 +69,7 @@ export const AudioDeviceSettingsResponseSchema = z.object({
 
 export const AudioSettingsResolveRequestSchema = z.object({
   audio: AudioDeviceSettingsSchema,
-  radioType: z.enum(['none', 'network', 'serial', 'icom-wlan']).optional(),
+  radioType: z.enum(['none', 'network', 'serial', 'icom-wlan', 'tci']).optional(),
 });
 
 export const AudioSettingsResolveResponseSchema = z.object({

--- a/packages/contracts/src/schema/radio-power-support.ts
+++ b/packages/contracts/src/schema/radio-power-support.ts
@@ -111,6 +111,9 @@ export function decidePowerSupport(
       // ICOM WLAN 的 CI-V-over-UDP 通道在电台关机后无法维持；即便已连接
       // 发送 powerstat(off) 也不能可靠恢复。整体不暴露电源控制。
       return { canPowerOn: false, canPowerOff: false, supportedStates: [], reason: 'model-unsupported' };
+    case 'tci':
+      // TCI/ExpertSDR does not expose a safe physical power-on path here.
+      return { canPowerOn: false, canPowerOff: false, supportedStates: [], reason: 'model-unsupported' };
     case 'serial': {
       if (!rigInfo) {
         return { canPowerOn: false, canPowerOff: false, supportedStates: [], reason: 'model-unsupported' };

--- a/packages/contracts/src/schema/radio.schema.ts
+++ b/packages/contracts/src/schema/radio.schema.ts
@@ -193,6 +193,20 @@ export const IcomWlanConfigSchema = z.object({
   dataMode: z.boolean().optional().default(true),
 });
 
+
+/**
+ * TCI / SunSDR 连接配置Schema
+ */
+export const TciConfigSchema = z.object({
+  host: z.string().default('127.0.0.1'),
+  port: z.number().int().min(1).max(65535).default(40001),
+  receiver: z.number().int().min(0).default(0),
+  trx: z.number().int().min(0).default(0),
+  vfo: z.number().int().min(0).default(0),
+  audioEnabled: z.boolean().optional().default(true),
+  audioSampleRate: z.number().int().min(8000).max(48000).optional().default(12000),
+});
+
 /**
  * 串口连接配置Schema
  */
@@ -245,13 +259,16 @@ export type FakeFrequencyConfig = z.infer<typeof FakeFrequencyConfigSchema>;
  * - 根据 type 字段读取对应的配置对象
  */
 export const HamlibConfigSchema = z.object({
-  type: z.enum(['none', 'network', 'serial', 'icom-wlan']),
+  type: z.enum(['none', 'network', 'serial', 'icom-wlan', 'tci']),
 
   // 网络模式配置
   network: NetworkConfigSchema.optional(),
 
   // ICOM WLAN 模式配置
   icomWlan: IcomWlanConfigSchema.optional(),
+
+  // TCI / SunSDR 模式配置
+  tci: TciConfigSchema.optional(),
 
   // 串口模式配置
   serial: SerialConnectionConfigSchema.optional(),
@@ -334,7 +351,7 @@ export const RadioInfoSchema = z.object({
   /** Hamlib 电台型号 ID (serial/network 模式使用，icom-wlan 模式可选) */
   rigModel: z.number().optional(),
   /** 连接类型 */
-  connectionType: z.enum(['serial', 'network', 'icom-wlan']),
+  connectionType: z.enum(['serial', 'network', 'icom-wlan', 'tci']),
   /** 固件版本 (如果可获取) */
   firmwareVersion: z.string().optional(),
   /** 序列号 (如果可获取) */
@@ -493,6 +510,7 @@ export type HamlibConfigFieldType = z.infer<typeof HamlibConfigFieldTypeSchema>;
 export type HamlibConfigField = z.infer<typeof HamlibConfigFieldSchema>;
 export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
 export type IcomWlanConfig = z.infer<typeof IcomWlanConfigSchema>;
+export type TciConfig = z.infer<typeof TciConfigSchema>;
 export type SerialConnectionConfig = z.infer<typeof SerialConnectionConfigSchema>;
 export type HamlibSpectrumConfig = z.infer<typeof HamlibSpectrumConfigSchema>;
 export type DigitalModeRadioModePreference = z.infer<typeof DigitalModeRadioModePreferenceSchema>;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,7 +51,7 @@
     "onnxruntime-node": "^1.26.0",
     "rubato-fft-node": "^0.1.0",
     "serialport": "^13.0.0",
-    "tci-client-node": "portal:../../../tci-client-node",
+    "tci-client-node": "^0.1.0",
     "wav": "^1.0.2",
     "wsjtx-lib": "2.1.3",
     "xstate": "^5.23.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,7 +51,7 @@
     "onnxruntime-node": "^1.26.0",
     "rubato-fft-node": "^0.1.0",
     "serialport": "^13.0.0",
-    "tci-client-node": "^0.1.0",
+    "tci-client-node": "^0.1.1",
     "wav": "^1.0.2",
     "wsjtx-lib": "2.1.3",
     "xstate": "^5.23.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,7 +51,7 @@
     "onnxruntime-node": "^1.26.0",
     "rubato-fft-node": "^0.1.0",
     "serialport": "^13.0.0",
-    "tci-client-node": "^0.1.1",
+    "tci-client-node": "^0.1.2",
     "wav": "^1.0.2",
     "wsjtx-lib": "2.1.3",
     "xstate": "^5.23.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,6 +51,7 @@
     "onnxruntime-node": "^1.26.0",
     "rubato-fft-node": "^0.1.0",
     "serialport": "^13.0.0",
+    "tci-client-node": "portal:../../../tci-client-node",
     "wav": "^1.0.2",
     "wsjtx-lib": "2.1.3",
     "xstate": "^5.23.0",

--- a/packages/server/src/audio/AudioStreamManager.ts
+++ b/packages/server/src/audio/AudioStreamManager.ts
@@ -7,6 +7,7 @@ import { ConfigManager } from '../config/config-manager.js';
 import { AudioDeviceManager } from './audio-device-manager.js';
 import { performance } from 'node:perf_hooks';
 import type { IcomWlanAudioAdapter } from './IcomWlanAudioAdapter.js';
+import type { TciAudioAdapter } from './TciAudioAdapter.js';
 import type { AudioFrameMeta } from '../radio/connections/IRadioConnection.js';
 import type { OpenWebRXAudioAdapter } from '../openwebrx/OpenWebRXAudioAdapter.js';
 import { createLogger } from '../utils/logger.js';
@@ -28,12 +29,13 @@ const INPUT_RING_BUFFER_DURATION_MS = 60_000;
 const ICOM_WLAN_TX_CHUNK_SIZE = 1200;
 const ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS = 150;
 const ICOM_WLAN_TX_MAX_WAIT_SLICE_MS = 20;
+const TCI_AUDIO_DEVICE_NAME = 'TCI Audio';
 const RTAUDIO_TX_CONSUME_WATCHDOG_MS = 750;
 const RTAUDIO_TX_DRAIN_TIMEOUT_FLOOR_MS = 1000;
 const RTAUDIO_TX_WATCHDOG_MIN_SUBMITTED_CHUNKS = 3;
 const RTAUDIO_OUTPUT_WARNING_LOG_WINDOW_MS = 5000;
 
-export type NativeAudioInputSourceKind = 'audio-device' | 'icom-wlan' | 'openwebrx';
+export type NativeAudioInputSourceKind = 'audio-device' | 'icom-wlan' | 'tci' | 'openwebrx';
 
 export interface NativeAudioInputFrame {
   samples: Float32Array;
@@ -234,6 +236,11 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
   private usingIcomWlanInput = false; // 是否使用 ICOM WLAN 输入
   private usingIcomWlanOutput = false; // 是否使用 ICOM WLAN 输出
 
+  // TCI / SunSDR 音频适配器（外部注入）
+  private tciAudioAdapter: TciAudioAdapter | null = null;
+  private usingTciInput = false;
+  private usingTciOutput = false;
+
   // OpenWebRX 音频适配器（外部注入）
   private openwebrxAudioAdapter: OpenWebRXAudioAdapter | null = null;
   private usingOpenWebRXInput = false;
@@ -305,6 +312,14 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
   setIcomWlanAudioAdapter(adapter: IcomWlanAudioAdapter | null): void {
     this.icomWlanAudioAdapter = adapter;
     logger.info(`ICOM WLAN audio adapter ${adapter ? 'set' : 'cleared'}`);
+  }
+
+  /**
+   * 设置 TCI 音频适配器（由 DigitalRadioEngine 注入）
+   */
+  setTciAudioAdapter(adapter: TciAudioAdapter | null): void {
+    this.tciAudioAdapter = adapter;
+    logger.info(`TCI audio adapter ${adapter ? 'set' : 'cleared'}`);
   }
 
   /**
@@ -415,6 +430,46 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         this.isStreaming = true;
         logger.info('ICOM WLAN audio input started', {
           sourceSampleRate: this.icomWlanAudioAdapter.getSampleRate(),
+          processingSampleRate: this.inputProcessingSampleRate,
+        });
+        this.emit('started');
+        return;
+      }
+
+      // 检测是否为 TCI 虚拟设备
+      if (deviceId === 'tci-input' || audioConfig.inputDeviceName === TCI_AUDIO_DEVICE_NAME) {
+        logger.info('TCI virtual input device detected');
+
+        if (!this.tciAudioAdapter) {
+          logger.warn('TCI audio adapter not set, skipping audio stream start');
+          this.deviceId = 'tci-input';
+          this.activeInputDeviceName = TCI_AUDIO_DEVICE_NAME;
+          this.usingTciInput = false;
+          this.isStreaming = true;
+          this.emit('started');
+          return;
+        }
+
+        this.usingTciInput = true;
+        this.tciAudioAdapter.startReceiving();
+        this.tciAudioAdapter.on('audioData', (samples: Float32Array, meta?: AudioFrameMeta) => {
+          void this.ingestInputSamples(
+            samples,
+            this.tciAudioAdapter?.getSampleRate() ?? DEFAULT_INPUT_PROCESSING_SAMPLE_RATE,
+            'tci',
+            meta,
+          );
+        });
+        this.tciAudioAdapter.on('error', (error: Error) => {
+          logger.error('TCI audio error', error);
+          this.emit('error', error);
+        });
+
+        this.deviceId = 'tci-input';
+        this.activeInputDeviceName = TCI_AUDIO_DEVICE_NAME;
+        this.isStreaming = true;
+        logger.info('TCI audio input started', {
+          sourceSampleRate: this.tciAudioAdapter.getSampleRate(),
           processingSampleRate: this.inputProcessingSampleRate,
         });
         this.emit('started');
@@ -553,6 +608,15 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         this.icomWlanAudioAdapter.removeAllListeners('error');
         this.usingIcomWlanInput = false;
         logger.info('ICOM WLAN audio input stopped');
+      }
+
+      // 停止 TCI 音频输入
+      if (this.usingTciInput && this.tciAudioAdapter) {
+        this.tciAudioAdapter.stopReceiving();
+        this.tciAudioAdapter.removeAllListeners('audioData');
+        this.tciAudioAdapter.removeAllListeners('error');
+        this.usingTciInput = false;
+        logger.info('TCI audio input stopped');
       }
 
       // 停止 OpenWebRX 音频输入
@@ -793,6 +857,23 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         }
       }
 
+      // 检测是否为 TCI 虚拟设备
+      if (outputDeviceId === 'tci-output' || audioConfig.outputDeviceName === TCI_AUDIO_DEVICE_NAME) {
+        logger.info('TCI virtual output device detected');
+
+        if (!this.tciAudioAdapter) {
+          logger.warn('TCI audio adapter not set, falling back to default audio device');
+          outputDeviceId = undefined;
+        } else {
+          this.usingTciOutput = true;
+          this.outputDeviceId = 'tci-output';
+          this.activeOutputDeviceName = TCI_AUDIO_DEVICE_NAME;
+          this.isOutputting = true;
+          logger.info('TCI audio output started');
+          return;
+        }
+      }
+
       if (isAndroidAudioDeviceId(outputDeviceId) || configuredOutputDeviceName?.startsWith('[Android]') || (isAndroidBridgeRuntime() && (!configuredOutputDeviceName || isLegacyAndroidAudioDeviceName('output', configuredOutputDeviceName)))) {
         const audioDeviceManager = AudioDeviceManager.getInstance();
         const androidDevice = audioDeviceManager.resolveAndroidDeviceForStream(
@@ -983,7 +1064,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
    * 停止音频输出流
    */
   async stopOutput(): Promise<void> {
-    if (!this.isOutputting && !this.rtAudioOutput && !this.usingIcomWlanOutput) {
+    if (!this.isOutputting && !this.rtAudioOutput && !this.usingIcomWlanOutput && !this.usingTciOutput) {
       logger.warn('audio output is not running');
       return;
     }
@@ -997,6 +1078,11 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       if (this.usingIcomWlanOutput) {
         this.usingIcomWlanOutput = false;
         logger.info('ICOM WLAN audio output stopped');
+      }
+
+      if (this.usingTciOutput) {
+        this.usingTciOutput = false;
+        logger.info('TCI audio output stopped');
       }
 
       if (this.usingAndroidOutput) {
@@ -1709,10 +1795,15 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
     const playbackId = ++this.playbackSequence;
     const diagnosticContext = options.diagnosticContext ?? {};
 
-    // 检查是否使用 ICOM WLAN 输出（零重采样优化）
-    if (this.usingIcomWlanOutput && this.icomWlanAudioAdapter) {
-      const icomWlanAudioAdapter = this.icomWlanAudioAdapter;
-      logger.info('playing audio via ICOM WLAN output (zero-resample)', {
+    const radioAudioOutput = this.usingIcomWlanOutput && this.icomWlanAudioAdapter
+      ? { label: 'ICOM WLAN', kind: 'icom-wlan' as const, adapter: this.icomWlanAudioAdapter }
+      : this.usingTciOutput && this.tciAudioAdapter
+        ? { label: 'TCI', kind: 'tci' as const, adapter: this.tciAudioAdapter }
+        : null;
+
+    if (radioAudioOutput) {
+      const radioAudioAdapter = radioAudioOutput.adapter;
+      logger.info(`playing audio via ${radioAudioOutput.label} output (zero-resample)`, {
         playbackId,
         ...diagnosticContext,
         samples: audioData.length,
@@ -1721,19 +1812,15 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         volumeGain: this.volumeGain.toFixed(2),
       });
 
-      // 设置播放状态
       this.playing = true;
       this.playbackStartTime = playStartTime;
       this.currentPlaybackKind = playbackKind;
       this.shouldStopPlayback = false;
 
       const playbackPromise = (async () => {
-        // 分块发送音频，支持实时音量调整
-        // 块大小：1200样本（≈100ms @ 12kHz），并维持少量预缓冲避免 ICOM 侧 underrun。
         const chunkSize = ICOM_WLAN_TX_CHUNK_SIZE;
         const totalChunks = Math.ceil(audioData.length / chunkSize);
-
-        logger.debug(`ICOM WLAN chunked send: ${totalChunks} chunks, chunkSize=${chunkSize}, targetLeadMs=${ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS}`);
+        logger.debug(`${radioAudioOutput.label} chunked send: ${totalChunks} chunks, chunkSize=${chunkSize}, targetLeadMs=${ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS}`);
 
         const chunkStartTime = Date.now();
         const hrStart = performance.now();
@@ -1763,51 +1850,41 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         };
 
         for (let i = 0; i < totalChunks; i++) {
-          // 检查是否需要停止播放
           try {
             assertNotStopped();
           } catch (error) {
-            logger.debug(`ICOM WLAN stop signal received, aborting playback (sent ${i}/${totalChunks} chunks)`);
+            logger.debug(`${radioAudioOutput.label} stop signal received, aborting playback (sent ${i}/${totalChunks} chunks)`);
             throw error;
           }
 
           const start = i * chunkSize;
           const end = Math.min(start + chunkSize, audioData.length);
           const sourceChunk = audioData.subarray(start, end);
-
-          // 应用当前音量增益（每个chunk读取最新值，支持实时调整）
           const chunk = new Float32Array(sourceChunk.length);
           const gain = this.volumeGain;
           for (let j = 0; j < sourceChunk.length; j++) {
-            const s = sourceChunk[j] * gain;
-            // 限幅保护，防止异常爆音
-            chunk[j] = s > 1 ? 1 : (s < -1 ? -1 : s);
+            const sample = sourceChunk[j] * gain;
+            chunk[j] = sample > 1 ? 1 : (sample < -1 ? -1 : sample);
           }
 
-          // 节奏控制：保持约 150ms 的 ICOM 侧预缓冲，既不让缓冲见底，也避免数倍速灌入后过早结束 PTT。
           const leadMs = getBufferedLeadMs();
           if (leadMs > ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS) {
             await waitRespectingStop(leadMs - ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS);
           }
 
-          // 发送音频数据
-          await icomWlanAudioAdapter.sendAudio(chunk);
+          await radioAudioAdapter.sendAudio(chunk);
           if (options.injectIntoMonitor) {
             this.emit('txMonitorAudioData', { samples: chunk, sampleRate: targetSampleRate });
           }
-
           samplesWritten += chunk.length;
         }
 
-        // 等待已注入的最后一段预缓冲自然播放完，避免上层 PTT 轮询把“发送完成”误判为“音频结束”。
         const remainingBufferedMs = getBufferedLeadMs();
         if (remainingBufferedMs > 0) {
           await waitRespectingStop(remainingBufferedMs);
         }
 
-        const chunkEndTime = Date.now();
-        const chunkDuration = chunkEndTime - chunkStartTime;
-        logger.info(`ICOM WLAN audio send complete, duration: ${chunkDuration}ms`);
+        logger.info(`${radioAudioOutput.label} audio send complete, duration: ${Date.now() - chunkStartTime}ms`);
       })();
 
       this.currentPlaybackPromise = playbackPromise;
@@ -1817,11 +1894,10 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       } catch (error) {
         const isInterrupted = error instanceof Error && error.message === 'playback interrupted';
         if (!isInterrupted) {
-          logger.error('ICOM WLAN audio send failed', error);
+          logger.error(`${radioAudioOutput.label} audio send failed`, error);
         }
         throw error;
       } finally {
-        // 清理播放状态
         if (this.currentPlaybackPromise === playbackPromise) {
           this.playing = false;
           this.currentPlaybackPromise = null;
@@ -2256,6 +2332,16 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       };
     }
 
+    if (this.usingTciOutput && this.tciAudioAdapter) {
+      const outputSampleRate = this.tciAudioAdapter.getSampleRate();
+      return {
+        available: this.isOutputting,
+        kind: 'tci' as VoiceTxOutputSinkState['kind'],
+        outputSampleRate,
+        outputBufferSize: Math.max(80, Math.round(outputSampleRate * 0.01)),
+      };
+    }
+
     if (this.usingAndroidOutput && this.androidAudioOutput) {
       return {
         available: this.isOutputting,
@@ -2274,15 +2360,16 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
   }
 
   private async writeVoiceTxOutputChunk(samples: Float32Array, sink: VoiceTxOutputSinkState): Promise<boolean> {
-    if (sink.kind === 'icom-wlan') {
-      if (!this.icomWlanAudioAdapter) {
+    if (sink.kind === 'icom-wlan' || sink.kind === 'tci') {
+      const adapter = sink.kind === 'tci' ? this.tciAudioAdapter : this.icomWlanAudioAdapter;
+      if (!adapter) {
         return false;
       }
       try {
-        await this.icomWlanAudioAdapter.sendAudio(samples);
+        await adapter.sendAudio(samples);
         return true;
       } catch (error) {
-        logger.error('Voice audio ICOM WLAN send failed', error);
+        logger.error(`Voice audio ${sink.kind.toUpperCase()} send failed`, error);
         return false;
       }
     }

--- a/packages/server/src/audio/AudioStreamManager.ts
+++ b/packages/server/src/audio/AudioStreamManager.ts
@@ -865,6 +865,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
           logger.warn('TCI audio adapter not set, falling back to default audio device');
           outputDeviceId = undefined;
         } else {
+          await this.tciAudioAdapter.startOutput();
           this.usingTciOutput = true;
           this.outputDeviceId = 'tci-output';
           this.activeOutputDeviceName = TCI_AUDIO_DEVICE_NAME;
@@ -1081,6 +1082,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       }
 
       if (this.usingTciOutput) {
+        await this.tciAudioAdapter?.stopOutput().catch((error) => logger.debug('Failed to stop TCI audio output', error));
         this.usingTciOutput = false;
         logger.info('TCI audio output stopped');
       }
@@ -1803,6 +1805,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
 
     if (radioAudioOutput) {
       const radioAudioAdapter = radioAudioOutput.adapter;
+      const tciRadioAudioAdapter = radioAudioOutput.kind === 'tci' ? radioAudioOutput.adapter : null;
       logger.info(`playing audio via ${radioAudioOutput.label} output (zero-resample)`, {
         playbackId,
         ...diagnosticContext,
@@ -1825,6 +1828,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         const chunkStartTime = Date.now();
         const hrStart = performance.now();
         let samplesWritten = 0;
+        let tciTransmissionStarted = false;
 
         const assertNotStopped = () => {
           if (this.shouldStopPlayback) {
@@ -1849,39 +1853,53 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
           return producedMs - elapsedMs;
         };
 
-        for (let i = 0; i < totalChunks; i++) {
-          try {
-            assertNotStopped();
-          } catch (error) {
-            logger.debug(`${radioAudioOutput.label} stop signal received, aborting playback (sent ${i}/${totalChunks} chunks)`);
-            throw error;
+        try {
+          if (tciRadioAudioAdapter) {
+            await tciRadioAudioAdapter.beginTransmission();
+            tciTransmissionStarted = true;
           }
 
-          const start = i * chunkSize;
-          const end = Math.min(start + chunkSize, audioData.length);
-          const sourceChunk = audioData.subarray(start, end);
-          const chunk = new Float32Array(sourceChunk.length);
-          const gain = this.volumeGain;
-          for (let j = 0; j < sourceChunk.length; j++) {
-            const sample = sourceChunk[j] * gain;
-            chunk[j] = sample > 1 ? 1 : (sample < -1 ? -1 : sample);
+          for (let i = 0; i < totalChunks; i++) {
+            try {
+              assertNotStopped();
+            } catch (error) {
+              logger.debug(`${radioAudioOutput.label} stop signal received, aborting playback (sent ${i}/${totalChunks} chunks)`);
+              throw error;
+            }
+
+            const start = i * chunkSize;
+            const end = Math.min(start + chunkSize, audioData.length);
+            const sourceChunk = audioData.subarray(start, end);
+            const chunk = new Float32Array(sourceChunk.length);
+            const gain = this.volumeGain;
+            for (let j = 0; j < sourceChunk.length; j++) {
+              const sample = sourceChunk[j] * gain;
+              chunk[j] = sample > 1 ? 1 : (sample < -1 ? -1 : sample);
+            }
+
+            const leadMs = getBufferedLeadMs();
+            if (leadMs > ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS) {
+              await waitRespectingStop(leadMs - ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS);
+            }
+
+            await radioAudioAdapter.sendAudio(chunk);
+            if (options.injectIntoMonitor) {
+              this.emit('txMonitorAudioData', { samples: chunk, sampleRate: targetSampleRate });
+            }
+            samplesWritten += chunk.length;
           }
 
-          const leadMs = getBufferedLeadMs();
-          if (leadMs > ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS) {
-            await waitRespectingStop(leadMs - ICOM_WLAN_TX_TARGET_BUFFER_LEAD_MS);
+          const remainingBufferedMs = getBufferedLeadMs();
+          if (tciRadioAudioAdapter) {
+            const drainTimeoutMs = Math.max(1000, Math.ceil(audioData.length / targetSampleRate * 1000) + 1000);
+            await tciRadioAudioAdapter.drainTransmission(drainTimeoutMs);
+          } else if (remainingBufferedMs > 0) {
+            await waitRespectingStop(remainingBufferedMs);
           }
-
-          await radioAudioAdapter.sendAudio(chunk);
-          if (options.injectIntoMonitor) {
-            this.emit('txMonitorAudioData', { samples: chunk, sampleRate: targetSampleRate });
+        } finally {
+          if (tciTransmissionStarted) {
+            await tciRadioAudioAdapter?.endTransmission().catch((error) => logger.debug('Failed to end TCI transmission', error));
           }
-          samplesWritten += chunk.length;
-        }
-
-        const remainingBufferedMs = getBufferedLeadMs();
-        if (remainingBufferedMs > 0) {
-          await waitRespectingStop(remainingBufferedMs);
         }
 
         logger.info(`${radioAudioOutput.label} audio send complete, duration: ${Date.now() - chunkStartTime}ms`);

--- a/packages/server/src/audio/TciAudioAdapter.ts
+++ b/packages/server/src/audio/TciAudioAdapter.ts
@@ -1,0 +1,91 @@
+import { EventEmitter } from 'eventemitter3';
+import { TciConnection } from '../radio/connections/TciConnection.js';
+import type { AudioFrameMeta } from '../radio/connections/IRadioConnection.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('TciAudioAdapter');
+
+export interface TciAudioAdapterEvents {
+  audioData: (samples: Float32Array, meta?: AudioFrameMeta) => void;
+  error: (error: Error) => void;
+}
+
+/**
+ * TCI audio adapter for SunSDR/ExpertSDR.
+ * It keeps the app-facing path identical to the ICOM WLAN adapter: RX PCM16
+ * frames become Float32 samples, and TX Float32 chunks are sent as TCI audio.
+ */
+export class TciAudioAdapter extends EventEmitter<TciAudioAdapterEvents> {
+  private readonly handleAudioFrameBound = (pcm16: Buffer, meta?: AudioFrameMeta) => this.handleAudioFrame(pcm16, meta);
+  private readonly handleErrorBound = (error: Error) => this.emit('error', error);
+  private isReceiving = false;
+
+  constructor(private readonly tciConnection: TciConnection) {
+    super();
+    logger.info(`Initialized with TCI audio sample rate ${this.getSampleRate()}Hz`);
+  }
+
+  startReceiving(): void {
+    if (this.isReceiving) {
+      logger.warn('Already receiving TCI audio');
+      return;
+    }
+
+    this.tciConnection.on('audioFrame', this.handleAudioFrameBound);
+    this.tciConnection.on('error', this.handleErrorBound);
+    void this.tciConnection.startAudioStream().catch((error) => {
+      logger.error('Failed to start TCI audio stream', error);
+      this.emit('error', error instanceof Error ? error : new Error(String(error)));
+    });
+    this.isReceiving = true;
+    logger.info('TCI audio reception started');
+  }
+
+  stopReceiving(): void {
+    if (!this.isReceiving) {
+      return;
+    }
+
+    this.tciConnection.off('audioFrame', this.handleAudioFrameBound);
+    this.tciConnection.off('error', this.handleErrorBound);
+    void this.tciConnection.stopAudioStream().catch((error) => {
+      logger.debug('Failed to stop TCI audio stream', error);
+    });
+    this.isReceiving = false;
+    logger.info('TCI audio reception stopped');
+  }
+
+  async sendAudio(samples: Float32Array): Promise<void> {
+    try {
+      await this.tciConnection.sendAudio(samples);
+    } catch (error) {
+      logger.error('Failed to send TCI audio', error);
+      throw error;
+    }
+  }
+
+  isReceivingAudio(): boolean {
+    return this.isReceiving;
+  }
+
+  getSampleRate(): number {
+    return this.tciConnection.getAudioSampleRate();
+  }
+
+  private handleAudioFrame(pcm16: Buffer, meta?: AudioFrameMeta): void {
+    try {
+      this.emit('audioData', this.pcm16ToFloat32(pcm16), meta);
+    } catch (error) {
+      logger.error('Failed to process TCI audio frame', error);
+      this.emit('error', error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private pcm16ToFloat32(buffer: Buffer): Float32Array {
+    const samples = new Float32Array(buffer.length / 2);
+    for (let i = 0; i < samples.length; i += 1) {
+      samples[i] = buffer.readInt16LE(i * 2) / 32768;
+    }
+    return samples;
+  }
+}

--- a/packages/server/src/audio/TciAudioAdapter.ts
+++ b/packages/server/src/audio/TciAudioAdapter.ts
@@ -33,7 +33,7 @@ export class TciAudioAdapter extends EventEmitter<TciAudioAdapterEvents> {
 
     this.tciConnection.on('audioFrame', this.handleAudioFrameBound);
     this.tciConnection.on('error', this.handleErrorBound);
-    void this.tciConnection.startAudioStream().catch((error) => {
+    void this.tciConnection.startAudioStream('rx-input').catch((error) => {
       logger.error('Failed to start TCI audio stream', error);
       this.emit('error', error instanceof Error ? error : new Error(String(error)));
     });
@@ -48,11 +48,32 @@ export class TciAudioAdapter extends EventEmitter<TciAudioAdapterEvents> {
 
     this.tciConnection.off('audioFrame', this.handleAudioFrameBound);
     this.tciConnection.off('error', this.handleErrorBound);
-    void this.tciConnection.stopAudioStream().catch((error) => {
+    void this.tciConnection.stopAudioStream('rx-input').catch((error) => {
       logger.debug('Failed to stop TCI audio stream', error);
     });
     this.isReceiving = false;
     logger.info('TCI audio reception stopped');
+  }
+
+  async startOutput(): Promise<void> {
+    await this.tciConnection.startAudioStream('tx-output');
+  }
+
+  async stopOutput(): Promise<void> {
+    await this.tciConnection.stopAudioStream('tx-output');
+  }
+
+  async beginTransmission(): Promise<void> {
+    await this.startOutput();
+    this.tciConnection.beginTxAudio();
+  }
+
+  async drainTransmission(timeoutMs: number): Promise<void> {
+    await this.tciConnection.waitForTxAudioDrain(timeoutMs);
+  }
+
+  async endTransmission(): Promise<void> {
+    this.tciConnection.endTxAudio();
   }
 
   async sendAudio(samples: Float32Array): Promise<void> {

--- a/packages/server/src/audio/VoiceTxOutputTypes.ts
+++ b/packages/server/src/audio/VoiceTxOutputTypes.ts
@@ -1,6 +1,6 @@
 export interface VoiceTxOutputSinkState {
   available: boolean;
-  kind: 'rtaudio' | 'icom-wlan' | 'android';
+  kind: 'rtaudio' | 'icom-wlan' | 'tci' | 'android';
   outputSampleRate: number;
   outputBufferSize: number;
 }

--- a/packages/server/src/audio/__tests__/AudioHotplugRecovery.test.ts
+++ b/packages/server/src/audio/__tests__/AudioHotplugRecovery.test.ts
@@ -508,6 +508,27 @@ describe('audio hotplug recovery', () => {
     expect(resolution.output.effectiveDevice?.id).toBe('icom-wlan-output');
   });
 
+  it('treats TCI Audio as a virtual selected device for TCI profiles', async () => {
+    mockState.devices = [];
+    mockConfigManager.getRadioConfig.mockReturnValue({
+      type: 'tci',
+      tci: { host: '127.0.0.1', port: 40001, audioEnabled: true, audioSampleRate: 12000 },
+    } as never);
+    const manager = AudioDeviceManager.getInstance();
+
+    const resolution = await manager.resolveAudioSettings({
+      inputDeviceName: 'TCI Audio',
+      outputDeviceName: 'TCI Audio',
+      sampleRate: 48000,
+      bufferSize: 1024,
+    }, 'tci');
+
+    expect(resolution.input.status).toBe('virtual-selected');
+    expect(resolution.input.effectiveDevice).toMatchObject({ id: 'tci-input', sampleRate: 12000 });
+    expect(resolution.output.status).toBe('virtual-selected');
+    expect(resolution.output.effectiveDevice).toMatchObject({ id: 'tci-output', sampleRate: 12000 });
+  });
+
   it('resolves existing OpenWebRX virtual input devices and marks removed stations missing', async () => {
     mockState.devices = [
       { id: 1, name: 'Built-in Mic', inputChannels: 1, outputChannels: 0, preferredSampleRate: 48000, isDefaultInput: true },

--- a/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
+++ b/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
@@ -52,6 +52,8 @@ type MockIcomAdapter = {
   removeAllListeners?: EventEmitter['removeAllListeners'];
 };
 
+type MockTciAdapter = MockIcomAdapter;
+
 type MockOpenWebRXAdapter = EventEmitter & {
   getSampleRate: ReturnType<typeof vi.fn>;
   startReceiving: ReturnType<typeof vi.fn>;
@@ -63,6 +65,14 @@ function createIcomManager(adapter: MockIcomAdapter): AudioStreamManager {
   manager.setIcomWlanAudioAdapter(adapter as never);
   (manager as unknown as { usingIcomWlanOutput: boolean; isOutputting: boolean }).usingIcomWlanOutput = true;
   (manager as unknown as { usingIcomWlanOutput: boolean; isOutputting: boolean }).isOutputting = true;
+  return manager;
+}
+
+function createTciManager(adapter: MockTciAdapter): AudioStreamManager {
+  const manager = new AudioStreamManager();
+  manager.setTciAudioAdapter(adapter as never);
+  (manager as unknown as { usingTciOutput: boolean; isOutputting: boolean }).usingTciOutput = true;
+  (manager as unknown as { usingTciOutput: boolean; isOutputting: boolean }).isOutputting = true;
   return manager;
 }
 
@@ -127,6 +137,26 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     expect(playbackError.message).toBe('playback interrupted');
   });
 
+  it('paces TCI chunks through the same radio-audio output path', async () => {
+    const adapter: MockTciAdapter = {
+      sendAudio: vi.fn().mockResolvedValue(undefined),
+      getSampleRate: vi.fn().mockReturnValue(12000),
+    };
+    const manager = createTciManager(adapter);
+    const audio = new Float32Array(12000);
+
+    const playback = manager.playAudio(audio, 12000);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(manager.isPlaying()).toBe(true);
+    expect(adapter.sendAudio).toHaveBeenCalled();
+    expect(adapter.sendAudio.mock.calls.length).toBeLessThan(10);
+
+    await expect(playback).resolves.toBeUndefined();
+    expect(manager.isPlaying()).toBe(false);
+    expect(adapter.sendAudio).toHaveBeenCalledTimes(10);
+  });
+
   it('emits native 12k ICOM input frames while still writing the digital ring buffer', async () => {
     const adapter = Object.assign(new EventEmitter(), {
       sendAudio: vi.fn().mockResolvedValue(undefined),
@@ -152,6 +182,41 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     expect(manager.getAudioProvider().getAvailableMs()).toBeGreaterThan(0);
 
     await manager.stopStream();
+  });
+
+  it('emits native TCI input frames while still writing the digital ring buffer', async () => {
+    mockConfigManager.getAudioConfig.mockReturnValue({
+      inputDeviceName: 'TCI Audio',
+      outputDeviceName: 'TCI Audio',
+      sampleRate: 48000,
+      bufferSize: 1024,
+    });
+    mockConfigManager.getRadioConfig.mockReturnValue({ type: 'tci', tci: { audioEnabled: true, audioSampleRate: 12000 } } as never);
+    const adapter = Object.assign(new EventEmitter(), {
+      sendAudio: vi.fn().mockResolvedValue(undefined),
+      getSampleRate: vi.fn().mockReturnValue(12000),
+      startReceiving: vi.fn(),
+      stopReceiving: vi.fn(),
+    });
+    const manager = new AudioStreamManager();
+    manager.setTciAudioAdapter(adapter as never);
+    const nativeFrames: Array<{ samples: Float32Array; sampleRate: number; sourceKind: string; sequence: number }> = [];
+    manager.on('nativeAudioInputData', frame => nativeFrames.push(frame));
+
+    await manager.startStream();
+    adapter.emit('audioData', new Float32Array([0.1, 0.2, 0.3, 0.4]));
+
+    expect(adapter.startReceiving).toHaveBeenCalledOnce();
+    expect(nativeFrames).toHaveLength(1);
+    expect(nativeFrames[0]?.sampleRate).toBe(12000);
+    expect(nativeFrames[0]?.sourceKind).toBe('tci');
+    expect(nativeFrames[0]?.sequence).toBe(0);
+    expect(nativeFrames[0]?.samples[0]).toBeCloseTo(0.1);
+    expect(nativeFrames[0]?.samples[3]).toBeCloseTo(0.4);
+    expect(manager.getAudioProvider().getAvailableMs()).toBeGreaterThan(0);
+
+    await manager.stopStream();
+    expect(adapter.stopReceiving).toHaveBeenCalledOnce();
   });
 
   it('threads ICOM wire-level seq into the ring buffer for packet-loss detection', async () => {

--- a/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
+++ b/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
@@ -52,7 +52,13 @@ type MockIcomAdapter = {
   removeAllListeners?: EventEmitter['removeAllListeners'];
 };
 
-type MockTciAdapter = MockIcomAdapter;
+type MockTciAdapter = MockIcomAdapter & {
+  startOutput?: ReturnType<typeof vi.fn>;
+  stopOutput?: ReturnType<typeof vi.fn>;
+  beginTransmission?: ReturnType<typeof vi.fn>;
+  drainTransmission?: ReturnType<typeof vi.fn>;
+  endTransmission?: ReturnType<typeof vi.fn>;
+};
 
 type MockOpenWebRXAdapter = EventEmitter & {
   getSampleRate: ReturnType<typeof vi.fn>;
@@ -141,6 +147,9 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     const adapter: MockTciAdapter = {
       sendAudio: vi.fn().mockResolvedValue(undefined),
       getSampleRate: vi.fn().mockReturnValue(12000),
+      beginTransmission: vi.fn().mockResolvedValue(undefined),
+      drainTransmission: vi.fn().mockResolvedValue(undefined),
+      endTransmission: vi.fn().mockResolvedValue(undefined),
     };
     const manager = createTciManager(adapter);
     const audio = new Float32Array(12000);
@@ -155,6 +164,34 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     await expect(playback).resolves.toBeUndefined();
     expect(manager.isPlaying()).toBe(false);
     expect(adapter.sendAudio).toHaveBeenCalledTimes(10);
+    expect(adapter.beginTransmission).toHaveBeenCalledOnce();
+    expect(adapter.drainTransmission).toHaveBeenCalledOnce();
+    expect(adapter.endTransmission).toHaveBeenCalledOnce();
+  });
+
+  it('starts and stops the TCI audio stream for output-only profiles', async () => {
+    mockConfigManager.getAudioConfig.mockReturnValue({
+      inputDeviceName: 'Built-in Mic',
+      outputDeviceName: 'TCI Audio',
+      sampleRate: 48000,
+      bufferSize: 1024,
+    });
+    mockConfigManager.getRadioConfig.mockReturnValue({ type: 'tci', tci: { audioEnabled: true, audioSampleRate: 12000 } } as never);
+    const adapter: MockTciAdapter = {
+      sendAudio: vi.fn().mockResolvedValue(undefined),
+      getSampleRate: vi.fn().mockReturnValue(12000),
+      startOutput: vi.fn().mockResolvedValue(undefined),
+      stopOutput: vi.fn().mockResolvedValue(undefined),
+    };
+    const manager = new AudioStreamManager();
+    manager.setTciAudioAdapter(adapter as never);
+
+    await manager.startOutput();
+    expect(adapter.startOutput).toHaveBeenCalledOnce();
+    expect(manager.getStatus().outputDeviceId).toBe('tci-output');
+
+    await manager.stopOutput();
+    expect(adapter.stopOutput).toHaveBeenCalledOnce();
   });
 
   it('emits native 12k ICOM input frames while still writing the digital ring buffer', async () => {

--- a/packages/server/src/audio/__tests__/TciAudioAdapter.test.ts
+++ b/packages/server/src/audio/__tests__/TciAudioAdapter.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'eventemitter3';
+import { TciAudioAdapter } from '../TciAudioAdapter.js';
+
+class MockTciConnection extends EventEmitter {
+  startAudioStream = vi.fn().mockResolvedValue(undefined);
+  stopAudioStream = vi.fn().mockResolvedValue(undefined);
+  sendAudio = vi.fn().mockResolvedValue(undefined);
+  getAudioSampleRate = vi.fn(() => 12000);
+}
+
+describe('TciAudioAdapter', () => {
+  it('converts RX PCM16 frames to Float32 samples and controls stream lifecycle', async () => {
+    const connection = new MockTciConnection();
+    const adapter = new TciAudioAdapter(connection as never);
+    const frames: Float32Array[] = [];
+    adapter.on('audioData', (samples) => frames.push(samples));
+
+    adapter.startReceiving();
+    await Promise.resolve();
+    const pcm16 = Buffer.alloc(4);
+    pcm16.writeInt16LE(0, 0);
+    pcm16.writeInt16LE(16384, 2);
+    connection.emit('audioFrame', pcm16);
+
+    expect(connection.startAudioStream).toHaveBeenCalledOnce();
+    expect(frames).toHaveLength(1);
+    expect(Array.from(frames[0]!)).toEqual([0, 0.5]);
+    expect(adapter.isReceivingAudio()).toBe(true);
+
+    adapter.stopReceiving();
+    await Promise.resolve();
+    expect(connection.stopAudioStream).toHaveBeenCalledOnce();
+    expect(adapter.isReceivingAudio()).toBe(false);
+  });
+
+  it('sends TX Float32 samples through the TCI connection', async () => {
+    const connection = new MockTciConnection();
+    const adapter = new TciAudioAdapter(connection as never);
+    const samples = new Float32Array([0.25, -0.25]);
+
+    await adapter.sendAudio(samples);
+
+    expect(connection.sendAudio).toHaveBeenCalledWith(samples);
+    expect(adapter.getSampleRate()).toBe(12000);
+  });
+});

--- a/packages/server/src/audio/__tests__/TciAudioAdapter.test.ts
+++ b/packages/server/src/audio/__tests__/TciAudioAdapter.test.ts
@@ -5,6 +5,9 @@ import { TciAudioAdapter } from '../TciAudioAdapter.js';
 class MockTciConnection extends EventEmitter {
   startAudioStream = vi.fn().mockResolvedValue(undefined);
   stopAudioStream = vi.fn().mockResolvedValue(undefined);
+  beginTxAudio = vi.fn();
+  waitForTxAudioDrain = vi.fn().mockResolvedValue(undefined);
+  endTxAudio = vi.fn();
   sendAudio = vi.fn().mockResolvedValue(undefined);
   getAudioSampleRate = vi.fn(() => 12000);
 }
@@ -23,15 +26,32 @@ describe('TciAudioAdapter', () => {
     pcm16.writeInt16LE(16384, 2);
     connection.emit('audioFrame', pcm16);
 
-    expect(connection.startAudioStream).toHaveBeenCalledOnce();
+    expect(connection.startAudioStream).toHaveBeenCalledWith('rx-input');
     expect(frames).toHaveLength(1);
     expect(Array.from(frames[0]!)).toEqual([0, 0.5]);
     expect(adapter.isReceivingAudio()).toBe(true);
 
     adapter.stopReceiving();
     await Promise.resolve();
-    expect(connection.stopAudioStream).toHaveBeenCalledOnce();
+    expect(connection.stopAudioStream).toHaveBeenCalledWith('rx-input');
     expect(adapter.isReceivingAudio()).toBe(false);
+  });
+
+  it('controls TCI TX audio lifecycle separately from RX receiving', async () => {
+    const connection = new MockTciConnection();
+    const adapter = new TciAudioAdapter(connection as never);
+
+    await adapter.startOutput();
+    await adapter.beginTransmission();
+    await adapter.drainTransmission(250);
+    await adapter.endTransmission();
+    await adapter.stopOutput();
+
+    expect(connection.startAudioStream).toHaveBeenCalledWith('tx-output');
+    expect(connection.beginTxAudio).toHaveBeenCalledOnce();
+    expect(connection.waitForTxAudioDrain).toHaveBeenCalledWith(250);
+    expect(connection.endTxAudio).toHaveBeenCalledOnce();
+    expect(connection.stopAudioStream).toHaveBeenCalledWith('tx-output');
   });
 
   it('sends TX Float32 samples through the TCI connection', async () => {

--- a/packages/server/src/audio/audio-device-manager.ts
+++ b/packages/server/src/audio/audio-device-manager.ts
@@ -18,7 +18,7 @@ import {
 } from './android-audio-devices.js';
 
 const logger = createLogger('AudioDeviceManager');
-type RadioType = 'none' | 'network' | 'serial' | 'icom-wlan';
+type RadioType = 'none' | 'network' | 'serial' | 'icom-wlan' | 'tci';
 type AudioDirection = 'input' | 'output';
 type AudioDeviceAvailability = 'available' | 'cached' | 'active';
 
@@ -42,6 +42,7 @@ const FALLBACK_SAMPLE_RATES = [8000, 12000, 16000, 22050, 24000, 44100, 48000, 9
 export class AudioDeviceManager {
   private static instance: AudioDeviceManager;
   private icomWlanConnectedCallback: (() => boolean) | null = null;
+  private tciConnectedCallback: (() => boolean) | null = null;
   private readonly deviceRegistry: Record<AudioDirection, Map<string, RegisteredAudioDevice>> = {
     input: new Map(),
     output: new Map(),
@@ -67,6 +68,13 @@ export class AudioDeviceManager {
    */
   setIcomWlanConnectedCallback(callback: () => boolean): void {
     this.icomWlanConnectedCallback = callback;
+  }
+
+  /**
+   * 设置 TCI 连接状态检查回调
+   */
+  setTciConnectedCallback(callback: () => boolean): void {
+    this.tciConnectedCallback = callback;
   }
 
   async initializeDeviceRegistry(): Promise<void> {
@@ -141,13 +149,21 @@ export class AudioDeviceManager {
       if (this.shouldShowIcomWlanDevice()) {
         devices.unshift(this.createIcomWlanDevice('input'));
       }
+      if (this.shouldShowTciDevice()) {
+        devices.unshift(this.createTciDevice('input'));
+      }
 
       const openwebrxDevices = this.getOpenWebRXVirtualDevices();
       if (openwebrxDevices.length > 0) {
         devices.push(...openwebrxDevices);
       }
-    } else if (this.shouldShowIcomWlanDevice()) {
-      devices.unshift(this.createIcomWlanDevice('output'));
+    } else {
+      if (this.shouldShowIcomWlanDevice()) {
+        devices.unshift(this.createIcomWlanDevice('output'));
+      }
+      if (this.shouldShowTciDevice()) {
+        devices.unshift(this.createTciDevice('output'));
+      }
     }
 
     return devices;
@@ -455,6 +471,36 @@ export class AudioDeviceManager {
     };
   }
 
+  private shouldShowTciDevice(): boolean {
+    const configManager = ConfigManager.getInstance();
+    const radioConfig = configManager.getRadioConfig();
+
+    if (radioConfig.type !== 'tci' || radioConfig.tci?.audioEnabled === false) {
+      return false;
+    }
+
+    if (this.tciConnectedCallback) {
+      return this.tciConnectedCallback();
+    }
+
+    return true;
+  }
+
+  private createTciDevice(type: 'input' | 'output'): AudioDevice {
+    const sampleRate = ConfigManager.getInstance().getRadioConfig().tci?.audioSampleRate ?? 12000;
+    return {
+      id: `tci-${type}`,
+      name: 'TCI Audio',
+      isDefault: false,
+      channels: 1,
+      sampleRate,
+      sampleRates: [sampleRate],
+      type,
+      availability: 'available',
+      isActiveByTx5dr: false,
+    };
+  }
+
   private normalizeSampleRates(sampleRates: unknown): number[] {
     if (!Array.isArray(sampleRates)) {
       return [];
@@ -603,7 +649,7 @@ export class AudioDeviceManager {
         configuredDeviceName,
         configuredDevice,
         effectiveDevice: configuredDevice,
-        status: configuredDevice.id.startsWith('openwebrx-') || configuredDevice.id.startsWith('icom-wlan-')
+        status: configuredDevice.id.startsWith('openwebrx-') || configuredDevice.id.startsWith('icom-wlan-') || configuredDevice.id.startsWith('tci-')
           ? 'virtual-selected'
           : 'selected',
         reason: null,
@@ -618,6 +664,17 @@ export class AudioDeviceManager {
         effectiveDevice: virtualDevice,
         status: 'virtual-selected',
         reason: 'icom-wlan-radio-audio',
+      };
+    }
+
+    if (configuredDeviceName === 'TCI Audio' && radioType === 'tci') {
+      const virtualDevice = this.createTciDevice(direction);
+      return {
+        configuredDeviceName,
+        configuredDevice: virtualDevice,
+        effectiveDevice: virtualDevice,
+        status: 'virtual-selected',
+        reason: 'tci-radio-audio',
       };
     }
 
@@ -730,6 +787,10 @@ export class AudioDeviceManager {
       return 'icom-wlan-input';
     }
 
+    if (deviceName === 'TCI Audio') {
+      return 'tci-input';
+    }
+
     const device = await this.getInputDeviceByName(deviceName);
     if (device) {
       if (device.availability === 'cached' && !device.isActiveByTx5dr) {
@@ -761,6 +822,10 @@ export class AudioDeviceManager {
 
     if (deviceName === 'ICOM WLAN') {
       return 'icom-wlan-output';
+    }
+
+    if (deviceName === 'TCI Audio') {
+      return 'tci-output';
     }
 
     const device = await this.getOutputDeviceByName(deviceName);

--- a/packages/server/src/config/ProfileManager.ts
+++ b/packages/server/src/config/ProfileManager.ts
@@ -31,15 +31,16 @@ export class ProfileManager {
     const configManager = ConfigManager.getInstance();
     const now = Date.now();
 
-    // ICOM WLAN 模式下，仅在用户未指定音频设备时默认使用 ICOM WLAN 虚拟设备
-    const audioLockedToRadio = data.radio.type === 'icom-wlan';
+    // Radio-audio modes default to their virtual audio device when the user has not specified one.
+    const audioLockedToRadio = data.radio.type === 'icom-wlan' || data.radio.type === 'tci';
+    const radioAudioDeviceName = data.radio.type === 'tci' ? 'TCI Audio' : 'ICOM WLAN';
     let audio: AudioDeviceSettings = normalizeAudioDeviceSettings(data.audio || { inputSampleRate: 48000, outputSampleRate: 48000, inputBufferSize: 1024, outputBufferSize: 1024 });
 
     if (audioLockedToRadio && !audio.inputDeviceName && !audio.outputDeviceName) {
       audio = {
         ...audio,
-        inputDeviceName: 'ICOM WLAN',
-        outputDeviceName: 'ICOM WLAN',
+        inputDeviceName: radioAudioDeviceName,
+        outputDeviceName: radioAudioDeviceName,
       };
     }
 
@@ -70,16 +71,17 @@ export class ProfileManager {
     const configManager = ConfigManager.getInstance();
     const existingProfile = configManager.getProfile(id);
 
-    // 如果更新了电台类型为 icom-wlan，标记锁定但不强制覆盖用户的音频设备选择
-    if (updates.radio?.type === 'icom-wlan') {
+    // 如果更新了电台类型为 radio-audio 模式，标记锁定但不强制覆盖用户的音频设备选择
+    if (updates.radio?.type === 'icom-wlan' || updates.radio?.type === 'tci') {
       updates.audioLockedToRadio = true;
-      // 仅在未提供音频配置时默认设置 ICOM WLAN 虚拟设备
+      const radioAudioDeviceName = updates.radio.type === 'tci' ? 'TCI Audio' : 'ICOM WLAN';
+      // 仅在未提供音频配置时默认设置对应虚拟设备
       if (!updates.audio) {
         if (!existingProfile?.audio?.inputDeviceName && !existingProfile?.audio?.outputDeviceName) {
           updates.audio = {
             ...normalizeAudioDeviceSettings(existingProfile?.audio),
-            inputDeviceName: 'ICOM WLAN',
-            outputDeviceName: 'ICOM WLAN',
+            inputDeviceName: radioAudioDeviceName,
+            outputDeviceName: radioAudioDeviceName,
           };
         }
       }

--- a/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
+++ b/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
@@ -227,6 +227,59 @@ describe('ProfileManager audio runtime config application', () => {
     expect(mockReloadAudioConfig).not.toHaveBeenCalled();
   });
 
+  it('defaults TCI Profiles to the TCI virtual audio device', async () => {
+    const manager = ProfileManager.getInstance();
+
+    const profile = await manager.createProfile({
+      name: 'SunSDR',
+      radio: {
+        type: 'tci',
+        tci: { host: '127.0.0.1', port: 40001, receiver: 0, trx: 0, vfo: 0, audioEnabled: true, audioSampleRate: 12000 },
+      } as RadioProfile['radio'],
+    });
+
+    expect(profile.audioLockedToRadio).toBe(true);
+    expect(profile.audio).toMatchObject({
+      inputDeviceName: 'TCI Audio',
+      outputDeviceName: 'TCI Audio',
+    });
+    expect(mockConfigManager.addProfile).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'SunSDR',
+      audioLockedToRadio: true,
+    }));
+  });
+
+  it('marks TCI Profile radio updates as locked to radio audio', async () => {
+    state.profiles = [makeProfile({
+      audio: {
+        inputDeviceName: undefined,
+        outputDeviceName: undefined,
+        inputSampleRate: 48000,
+        outputSampleRate: 48000,
+        inputBufferSize: 1024,
+        outputBufferSize: 1024,
+        outputSampleFormat: 'float32',
+        outputChannelMode: 'mono',
+      },
+    })];
+    const manager = ProfileManager.getInstance();
+
+    await manager.updateProfile('profile-1', {
+      radio: {
+        type: 'tci',
+        tci: { host: '127.0.0.1', port: 40001, receiver: 0, trx: 0, vfo: 0, audioEnabled: true, audioSampleRate: 12000 },
+      } as RadioProfile['radio'],
+    });
+
+    expect(mockConfigManager.updateProfile).toHaveBeenCalledWith('profile-1', expect.objectContaining({
+      audioLockedToRadio: true,
+      audio: expect.objectContaining({
+        inputDeviceName: 'TCI Audio',
+        outputDeviceName: 'TCI Audio',
+      }),
+    }));
+  });
+
   it('reloads audio config after activating a Profile before starting the engine', async () => {
     const manager = ProfileManager.getInstance();
 

--- a/packages/server/src/config/config-manager.ts
+++ b/packages/server/src/config/config-manager.ts
@@ -712,6 +712,7 @@ export class ConfigManager {
     const hasNewNestedFields =
       radioConfig.network !== undefined ||
       radioConfig.icomWlan !== undefined ||
+      radioConfig.tci !== undefined ||
       radioConfig.serial !== undefined;
 
     return hasOldFlatFields && !hasNewNestedFields;

--- a/packages/server/src/radio/PhysicalRadioManager.ts
+++ b/packages/server/src/radio/PhysicalRadioManager.ts
@@ -500,6 +500,12 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       if (oldIp !== newIp) {
         logger.info(`ICOM WLAN IP changed: ${oldIp} -> ${newIp}`);
       }
+    } else if (config.type === 'tci') {
+      const oldEndpoint = `${oldConfig.tci?.host ?? ''}:${oldConfig.tci?.port ?? ''}`;
+      const newEndpoint = `${config.tci?.host ?? ''}:${config.tci?.port ?? ''}`;
+      if (oldEndpoint !== newEndpoint) {
+        logger.info(`TCI endpoint changed: ${oldEndpoint} -> ${newEndpoint}`);
+      }
     }
 
     // 如果已有连接，先内部断开（不触发事件，避免时序混乱）
@@ -949,6 +955,13 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
           connectionType: 'network',
         };
       }
+
+      case 'tci':
+        return {
+          manufacturer: 'Expert Electronics',
+          model: 'TCI / SunSDR',
+          connectionType: 'tci',
+        };
 
       case 'icom-wlan': {
         const detectedInfo = typeof (this.connection as any).getDetectedRadioInfo === 'function'
@@ -1874,6 +1887,20 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
   }
 
   /**
+   * 获取 TCI 连接（用于音频适配器）
+   */
+  getTciConnection(): any | null {
+    if (
+      !this.connection ||
+      this.connection.getType() !== RadioConnectionType.TCI
+    ) {
+      return null;
+    }
+
+    return this.connection;
+  }
+
+  /**
    * 获取当前活动连接
    */
   getActiveConnection(): IRadioConnection | null {
@@ -2038,7 +2065,11 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
           cfg = this.configManager.getRadioConfig();
         }
         logger.debug(`Using config type: ${cfg.type}`,
-                    cfg.type === 'icom-wlan' ? { ip: cfg.icomWlan?.ip, port: cfg.icomWlan?.port } : {});
+                    cfg.type === 'icom-wlan'
+                      ? { ip: cfg.icomWlan?.ip, port: cfg.icomWlan?.port }
+                      : cfg.type === 'tci'
+                        ? { host: cfg.tci?.host, port: cfg.tci?.port }
+                        : {});
         await this.doConnect(cfg);
       },
 
@@ -2987,6 +3018,19 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       return (
         a.icomWlan?.ip === b.icomWlan?.ip &&
         a.icomWlan?.port === b.icomWlan?.port
+      );
+    }
+
+    // 比较 TCI 配置
+    if (a.type === 'tci' && b.type === 'tci') {
+      return (
+        a.tci?.host === b.tci?.host &&
+        a.tci?.port === b.tci?.port &&
+        a.tci?.receiver === b.tci?.receiver &&
+        a.tci?.trx === b.tci?.trx &&
+        a.tci?.vfo === b.tci?.vfo &&
+        a.tci?.audioEnabled === b.tci?.audioEnabled &&
+        a.tci?.audioSampleRate === b.tci?.audioSampleRate
       );
     }
 

--- a/packages/server/src/radio/PhysicalRadioManager.ts
+++ b/packages/server/src/radio/PhysicalRadioManager.ts
@@ -67,6 +67,18 @@ const HAMLIB_RIG_SCHEMA_TIMEOUT_MS = 3000;
 /** Hamlib valid frequency range: 1 kHz to 10 GHz */
 const HAMLIB_MIN_FREQUENCY_HZ = 1000;
 const HAMLIB_MAX_FREQUENCY_HZ = 10_000_000_000;
+const RECOVERABLE_TCI_WRITE_TIMEOUT_PATTERNS = [
+  'timed out waiting for tci state',
+  'timed out waiting for tci reply',
+];
+const TCI_WRITE_TIMEOUT_OPERATIONS = new Set([
+  'setFrequency',
+  'setPTT',
+  'setMode',
+  'applyOperatingState',
+  'applyOperatingState.setFrequency',
+  'applyOperatingState.setMode',
+]);
 
 function isFrequencyInHamlibRange(freq: unknown): freq is number {
   return typeof freq === 'number'
@@ -90,6 +102,52 @@ function withHamlibSchemaTimeout<T>(
       clearTimeout(timeout);
     }
   });
+}
+
+function collectErrorMessages(error: unknown, messages: string[] = []): string[] {
+  if (error instanceof RadioError) {
+    messages.push(error.message, error.userMessage);
+    if (error.cause && error.cause !== error) {
+      collectErrorMessages(error.cause, messages);
+    }
+    return messages;
+  }
+
+  if (error instanceof Error) {
+    messages.push(error.message);
+    const cause = (error as Error & { cause?: unknown }).cause;
+    if (cause && cause !== error) {
+      collectErrorMessages(cause, messages);
+    }
+    return messages;
+  }
+
+  messages.push(String(error));
+  return messages;
+}
+
+function isRecoverableTciWriteTimeout(error: unknown): boolean {
+  if (!(error instanceof RadioError)) {
+    return false;
+  }
+  if (error.code !== RadioErrorCode.OPERATION_TIMEOUT || error.context?.protocol !== 'tci') {
+    return false;
+  }
+  const operation = String(error.context?.operation ?? '');
+  if (!TCI_WRITE_TIMEOUT_OPERATIONS.has(operation)) {
+    return false;
+  }
+  if (error.context?.writeTimeout === true || error.context?.recoverable === true) {
+    return true;
+  }
+  return collectErrorMessages(error).some((message) => {
+    const lowerMessage = message.toLowerCase();
+    return RECOVERABLE_TCI_WRITE_TIMEOUT_PATTERNS.some((pattern) => lowerMessage.includes(pattern));
+  });
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 /**
@@ -1013,6 +1071,14 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
         logger.warn(`Frequency write is unavailable for this radio: ${(error as Error).message}`);
         return false;
       }
+      if (isRecoverableTciWriteTimeout(error)) {
+        logger.warn('TCI write timeout tolerated', {
+          operation: 'setFrequency',
+          frequencyHz: freq,
+          error: (error as Error).message,
+        });
+        return false;
+      }
       logger.error(`Failed to set frequency: ${(error as Error).message}`);
       this.handleConnectionError(error as Error);
       return false;
@@ -1166,6 +1232,11 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       if (result.modeError) {
         if (isRecoverableOptionalRadioError(result.modeError)) {
           this.markCoreCapabilityUnsupported('writeRadioMode', result.modeError);
+        } else if (isRecoverableTciWriteTimeout(result.modeError)) {
+          logger.warn('TCI write timeout tolerated', {
+            operation: 'applyOperatingState.mode',
+            error: result.modeError.message,
+          });
         } else if (!request.tolerateModeFailure) {
           this.handleConnectionError(result.modeError);
         } else {
@@ -1183,6 +1254,20 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       if (request.frequency !== undefined && isRecoverableOptionalRadioError(error)) {
         this.markCoreCapabilityUnsupported('writeFrequency', error);
         return { frequencyApplied: false, modeApplied: false };
+      }
+
+      if (isRecoverableTciWriteTimeout(error)) {
+        logger.warn('TCI write timeout tolerated', {
+          operation: 'applyOperatingState',
+          frequencyHz: request.frequency,
+          mode: request.mode,
+          error: (error as Error).message,
+        });
+        return {
+          frequencyApplied: false,
+          modeApplied: false,
+          modeError: request.mode ? asError(error) : undefined,
+        };
       }
 
       this.handleConnectionError(error as Error);
@@ -1248,6 +1333,14 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
 
       logger.debug(`PTT set: ${state ? 'TX' : 'RX'}`);
     } catch (error) {
+      if (isRecoverableTciWriteTimeout(error)) {
+        logger.warn('TCI write timeout tolerated', {
+          operation: 'setPTT',
+          ptt: state,
+          error: (error as Error).message,
+        });
+        return;
+      }
       logger.error(
         `PTT ${state ? 'TX' : 'RX'} failed: ${(error as Error).message}`
       );
@@ -1316,6 +1409,14 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
     } catch (error) {
       if (isRecoverableOptionalRadioError(error)) {
         this.markCoreCapabilityUnsupported('writeRadioMode', error);
+        throw new Error(`set mode failed: ${(error as Error).message}`);
+      }
+      if (isRecoverableTciWriteTimeout(error)) {
+        logger.warn('TCI write timeout tolerated', {
+          operation: 'setMode',
+          mode,
+          error: (error as Error).message,
+        });
         throw new Error(`set mode failed: ${(error as Error).message}`);
       }
       this.handleConnectionError(error as Error);
@@ -2366,6 +2467,13 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
         logger.info('Power operation active; suppressing HEALTH_CHECK_FAILED');
         return;
       }
+      if (isRecoverableTciWriteTimeout(error)) {
+        logger.warn('TCI write timeout tolerated', {
+          operation: error instanceof RadioError ? error.context?.operation : undefined,
+          error: error.message,
+        });
+        return;
+      }
       // 同时通知状态机触发重连逻辑
       if (this.radioActor && !this.isDisconnecting) {
         this.radioActor.send({ type: 'HEALTH_CHECK_FAILED', error });
@@ -2722,6 +2830,13 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
   private handleConnectionError(error: Error): void {
     if (this.shouldSuppressSessionCancellationError(error)) {
       logger.debug(`Suppressing stale session health error: ${error.message}`);
+      return;
+    }
+    if (isRecoverableTciWriteTimeout(error)) {
+      logger.warn('TCI write timeout tolerated', {
+        operation: error instanceof RadioError ? error.context?.operation : undefined,
+        error: error.message,
+      });
       return;
     }
     logger.error(`Connection error: ${error.message}`);

--- a/packages/server/src/radio/__tests__/PhysicalRadioManager.test.ts
+++ b/packages/server/src/radio/__tests__/PhysicalRadioManager.test.ts
@@ -159,6 +159,23 @@ describe('PhysicalRadioManager', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('does not report TCI write-confirm frequency timeouts as connection health failures', async () => {
+    const error = new RadioError({
+      code: RadioErrorCode.OPERATION_TIMEOUT,
+      message: 'TCI setFrequency failed: Timed out waiting for TCI state VFO:0,0,7074000',
+      userMessage: 'TCI radio operation failed',
+      severity: RadioErrorSeverity.WARNING,
+      context: { operation: 'setFrequency', protocol: 'tci', writeTimeout: true, recoverable: true },
+    });
+    const setFrequency = vi.fn().mockRejectedValue(error);
+    asTestManager(manager).connection = { setFrequency };
+
+    await expect(manager.setFrequency(7074000)).resolves.toBe(false);
+
+    expect(setFrequency).toHaveBeenCalledWith(7074000);
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('does not report ICOM WLAN transient frequency fallback as a connection health failure', async () => {
     const getFrequency = vi.fn().mockResolvedValue(0);
     asTestManager(manager).connection = {
@@ -761,6 +778,27 @@ describe('PhysicalRadioManager', () => {
     expect(result.frequencyApplied).toBe(true);
     expect(result.modeApplied).toBe(false);
     expect(result.modeError?.message).toBe('protocol error');
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('downgrades TCI operating-state write timeouts instead of reconnecting', async () => {
+    const error = new RadioError({
+      code: RadioErrorCode.OPERATION_TIMEOUT,
+      message: 'TCI applyOperatingState failed: Timed out waiting for TCI reply to VFO:0,0,7074000;',
+      userMessage: 'TCI radio operation failed',
+      severity: RadioErrorSeverity.WARNING,
+      context: { operation: 'applyOperatingState', protocol: 'tci', writeTimeout: true, recoverable: true },
+    });
+    const applyOperatingState = vi.fn().mockRejectedValue(error);
+    asTestManager(manager).connection = {
+      applyOperatingState,
+      setKnownFrequency: vi.fn(),
+    };
+
+    const result = await manager.applyOperatingState({ frequency: 7074000, mode: 'DIGU' });
+
+    expect(result).toMatchObject({ frequencyApplied: false, modeApplied: false });
+    expect(result.modeError).toBe(error);
     expect(send).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/radio/__tests__/TciConnection.test.ts
+++ b/packages/server/src/radio/__tests__/TciConnection.test.ts
@@ -35,19 +35,19 @@ describe('TciConnection', () => {
     expect(connection.getState()).toBe(RadioConnectionState.CONNECTED);
 
     await connection.setFrequency(21_074_000);
-    await connection.setMode('USB', 'nochange', { intent: 'digital' });
+    await connection.setMode('LSB', 'nochange', { intent: 'digital' });
     await connection.setPTT(true);
     await connection.setSplitEnabled(true);
     await connection.setRFPower(0.42);
 
     expect(await connection.getFrequency()).toBe(21_074_000);
     expect(await connection.getPTT()).toBe(true);
-    expect(await connection.getMode()).toMatchObject({ mode: 'DIGU' });
+    expect(await connection.getMode()).toMatchObject({ mode: 'DIGL' });
     expect(await connection.getSplitEnabled()).toBe(true);
     expect(await connection.getRFPower()).toBeCloseTo(0.42, 2);
     expect(server.receivedCommands.map((command) => command.raw)).toEqual(expect.arrayContaining([
       'VFO:0,0,21074000',
-      'MODULATION:0,DIGU',
+      'MODULATION:0,DIGL',
       'TRX:1,true,tci',
       'SPLIT_ENABLE:1,true',
       'DRIVE:1,42',
@@ -95,6 +95,73 @@ describe('TciConnection', () => {
     expect(meterData.swr?.swr).toBe(1.4);
 
     await connection.stopAudioStream();
+    await connection.disconnect('test complete');
+  });
+
+  it('skips idempotent frequency and PTT writes when startup state already matches', async () => {
+    server = new MockTciServer({
+      startupCommands: [
+        'PROTOCOL:2.0;',
+        'DEVICE:Mock ExpertSDR3;',
+        'VFO:0,0,7074000;',
+        'TRX:0,false;',
+        'READY:true;',
+      ],
+    });
+    server.onCommand(({ command }) => command.name === 'vfo' || command.name === 'trx');
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection();
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 0,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+    const commandCountBefore = server.receivedCommands.length;
+
+    await connection.setPTT(false);
+    await connection.setFrequency(7_074_000);
+
+    expect(server.receivedCommands).toHaveLength(commandCountBefore);
+    expect(connection.getState()).toBe(RadioConnectionState.CONNECTED);
+
+    await connection.disconnect('test complete');
+  });
+
+  it('downgrades operating-state TCI frequency confirmation timeouts without disconnecting', async () => {
+    server = new MockTciServer();
+    server.onCommand(({ command }) => command.name === 'vfo');
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection();
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 0,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+
+    const result = await connection.applyOperatingState({ frequency: 7_074_000 });
+
+    expect(result).toMatchObject({ frequencyApplied: false, modeApplied: false });
+    expect(connection.getState()).toBe(RadioConnectionState.CONNECTED);
+    expect(connection.isHealthy()).toBe(true);
+
     await connection.disconnect('test complete');
   });
 });

--- a/packages/server/src/radio/__tests__/TciConnection.test.ts
+++ b/packages/server/src/radio/__tests__/TciConnection.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { MockTciServer } from 'tci-client-node/testing';
+import { TciSampleType, payloadToFloat32 } from 'tci-client-node';
+import { TciConnection } from '../connections/TciConnection.js';
+import { RadioConnectionState, RadioConnectionType, type MeterData } from '../connections/IRadioConnection.js';
+
+let server: MockTciServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+describe('TciConnection', () => {
+  it('maps IRadioConnection calls to TCI CAT commands and state', async () => {
+    server = new MockTciServer();
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection();
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 1,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+
+    expect(connection.getType()).toBe(RadioConnectionType.TCI);
+    expect(connection.getState()).toBe(RadioConnectionState.CONNECTED);
+
+    await connection.setFrequency(21_074_000);
+    await connection.setMode('USB', 'nochange', { intent: 'digital' });
+    await connection.setPTT(true);
+    await connection.setSplitEnabled(true);
+    await connection.setRFPower(0.42);
+
+    expect(await connection.getFrequency()).toBe(21_074_000);
+    expect(await connection.getPTT()).toBe(true);
+    expect(await connection.getMode()).toMatchObject({ mode: 'DIGU' });
+    expect(await connection.getSplitEnabled()).toBe(true);
+    expect(await connection.getRFPower()).toBeCloseTo(0.42, 2);
+    expect(server.receivedCommands.map((command) => command.raw)).toEqual(expect.arrayContaining([
+      'VFO:0,0,21074000',
+      'MODULATION:0,DIGU',
+      'TRX:1,true,tci',
+      'SPLIT_ENABLE:1,true',
+      'DRIVE:1,42',
+    ]));
+
+    await connection.disconnect('test complete');
+  });
+
+  it('forwards RX/TX audio and meter events through the radio connection abstraction', async () => {
+    server = new MockTciServer();
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection();
+    const audioFrame = onceEvent<Buffer>(connection, 'audioFrame');
+    const meterFrames: MeterData[] = [];
+    connection.on('meterData', (data) => meterFrames.push(data));
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 0,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+
+    await connection.startAudioStream();
+    server.sendRxAudioFrame({ sampleType: TciSampleType.FLOAT32, samples: new Float32Array([0, 0.5, -0.5]) });
+    const [pcm16] = await audioFrame;
+    expect(Array.from(payloadToFloat32(pcm16, TciSampleType.INT16))).toEqual([0, expect.closeTo(0.5, 4), expect.closeTo(-0.5, 4)]);
+
+    await connection.sendAudio(new Float32Array([0.25, -0.25]));
+    await waitFor(() => server!.receivedTxAudioFrames.length === 1);
+    expect(Array.from(payloadToFloat32(server.receivedTxAudioFrames[0]!))).toEqual([expect.closeTo(0.25, 4), expect.closeTo(-0.25, 4)]);
+
+    server.broadcast('RX_CHANNEL_SENSORS:0,0,-71.5;TX_SENSORS:0,-20,12.5,18.25,1.4;');
+    await waitFor(() => meterFrames.some((data) => data.power?.watts === 12.5 && data.swr?.swr === 1.4));
+    const meterData = meterFrames.at(-1)!;
+    expect(meterData.level?.raw).toBe(-71.5);
+    expect(meterData.power?.watts).toBe(12.5);
+    expect(meterData.swr?.swr).toBe(1.4);
+
+    await connection.stopAudioStream();
+    await connection.disconnect('test complete');
+  });
+});
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error('Timed out waiting for predicate');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function onceEvent<T>(connection: TciConnection, event: string): Promise<[T]> {
+  return new Promise((resolve) => connection.once(event as never, (value: T) => resolve([value])));
+}

--- a/packages/server/src/radio/__tests__/TciConnection.test.ts
+++ b/packages/server/src/radio/__tests__/TciConnection.test.ts
@@ -83,9 +83,14 @@ describe('TciConnection', () => {
     const [pcm16] = await audioFrame;
     expect(Array.from(payloadToFloat32(pcm16, TciSampleType.INT16))).toEqual([0, expect.closeTo(0.5, 4), expect.closeTo(-0.5, 4)]);
 
+    await connection.beginTxAudio();
     await connection.sendAudio(new Float32Array([0.25, -0.25]));
+    expect(server.receivedTxAudioFrames).toHaveLength(0);
+    server.sendTxChrono({ sampleCount: 2 });
     await waitFor(() => server!.receivedTxAudioFrames.length === 1);
     expect(Array.from(payloadToFloat32(server.receivedTxAudioFrames[0]!))).toEqual([expect.closeTo(0.25, 4), expect.closeTo(-0.25, 4)]);
+    await connection.waitForTxAudioDrain(100);
+    connection.endTxAudio();
 
     server.broadcast('RX_CHANNEL_SENSORS:0,0,-71.5;TX_SENSORS:0,-20,12.5,18.25,1.4;');
     await waitFor(() => meterFrames.some((data) => data.power?.watts === 12.5 && data.swr?.swr === 1.4));
@@ -95,6 +100,66 @@ describe('TciConnection', () => {
     expect(meterData.swr?.swr).toBe(1.4);
 
     await connection.stopAudioStream();
+    await connection.disconnect('test complete');
+  });
+
+  it('responds to TX_CHRONO with padded silence when queued TX audio underflows', async () => {
+    server = new MockTciServer();
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection();
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 0,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+
+    connection.beginTxAudio();
+    await connection.sendAudio(new Float32Array([0.5]));
+    server.sendTxChrono({ sampleCount: 4 });
+
+    await waitFor(() => server!.receivedTxAudioFrames.length === 1);
+    expect(Array.from(payloadToFloat32(server.receivedTxAudioFrames[0]!))).toEqual([expect.closeTo(0.5, 4), 0, 0, 0]);
+
+    connection.endTxAudio();
+    await connection.disconnect('test complete');
+  });
+
+  it('keeps TCI audio stream open until both RX and TX output owners stop', async () => {
+    server = new MockTciServer();
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection();
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 0,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+
+    await connection.startAudioStream('rx-input');
+    await connection.startAudioStream('tx-output');
+    await connection.stopAudioStream('rx-input');
+    expect(server.receivedCommands.filter((command) => command.name === 'audio_stop')).toHaveLength(0);
+
+    await connection.stopAudioStream('tx-output');
+    await waitFor(() => server!.receivedCommands.some((command) => command.raw === 'AUDIO_STOP:0'));
+
     await connection.disconnect('test complete');
   });
 

--- a/packages/server/src/radio/connections/IRadioConnection.ts
+++ b/packages/server/src/radio/connections/IRadioConnection.ts
@@ -34,6 +34,11 @@ export enum RadioConnectionType {
   ICOM_WLAN = 'icom-wlan',
 
   /**
+   * TCI / SunSDR WebSocket 连接
+   */
+  TCI = 'tci',
+
+  /**
    * Hamlib 连接（支持多种型号）
    */
   HAMLIB = 'hamlib',
@@ -165,7 +170,7 @@ export interface IRadioConnectionEvents {
   frequencyChanged: (frequency: number) => void;
 
   /**
-   * 音频帧（仅 ICOM WLAN）
+   * 音频帧（ICOM WLAN / TCI）
    * @param meta 可选的线级元数据：seq（线级序列号，用于丢包检测）、timestampMs（RX 到达时间，诊断用）
    */
   audioFrame: (pcm16: Buffer, meta?: AudioFrameMeta) => void;

--- a/packages/server/src/radio/connections/RadioConnectionFactory.ts
+++ b/packages/server/src/radio/connections/RadioConnectionFactory.ts
@@ -11,6 +11,7 @@
 import { RadioError, RadioErrorCode } from '../../utils/errors/RadioError.js';
 import type { IRadioConnection, RadioConnectionConfig } from './IRadioConnection.js';
 import { IcomWlanConnection } from './IcomWlanConnection.js';
+import { TciConnection } from './TciConnection.js';
 import { HamlibConnection } from './HamlibConnection.js';
 import { NullConnection } from './NullConnection.js';
 import { createLogger } from '../../utils/logger.js';
@@ -45,6 +46,10 @@ export class RadioConnectionFactory {
         logger.debug('Creating ICOM WLAN connection instance');
         return new IcomWlanConnection();
 
+      case 'tci':
+        logger.debug('Creating TCI connection instance');
+        return new TciConnection();
+
       case 'network':
       case 'serial':
         logger.debug(`Creating Hamlib connection instance (${config.type})`);
@@ -60,7 +65,7 @@ export class RadioConnectionFactory {
           message: `Unsupported connection type: ${(config as any).type}`,
           userMessage: 'Unsupported radio connection type',
           suggestions: [
-            'Supported types: icom-wlan, network, serial',
+            'Supported types: icom-wlan, tci, network, serial',
             'Check the connection type in the configuration file',
           ],
         });
@@ -85,6 +90,26 @@ export class RadioConnectionFactory {
 
     logger.debug('Creating ICOM WLAN connection instance');
     return new IcomWlanConnection();
+  }
+
+  /**
+   * 创建 TCI 连接实例
+   *
+   * @param config - TCI 配置
+   * @returns TCI 连接实例
+   */
+  static createTci(config: RadioConnectionConfig): IRadioConnection {
+    if (config.type !== 'tci') {
+      throw new RadioError({
+        code: RadioErrorCode.INVALID_CONFIG,
+        message: `Configuration type error: expected 'tci', got '${config.type}'`,
+        userMessage: 'Configuration type mismatch',
+        suggestions: ['Please use a TCI type configuration'],
+      });
+    }
+
+    logger.debug('Creating TCI connection instance');
+    return new TciConnection();
   }
 
   /**
@@ -132,6 +157,14 @@ export class RadioConnectionFactory {
         else {
           if (!config.icomWlan.ip) errors.push('ICOM WLAN configuration missing required field: icomWlan.ip');
           if (!config.icomWlan.port) errors.push('ICOM WLAN configuration missing required field: icomWlan.port');
+        }
+        break;
+
+      case 'tci':
+        if (!config.tci) errors.push('TCI configuration missing tci object');
+        else {
+          if (!config.tci.host) errors.push('TCI configuration missing required field: tci.host');
+          if (!config.tci.port) errors.push('TCI configuration missing required field: tci.port');
         }
         break;
 

--- a/packages/server/src/radio/connections/TciConnection.ts
+++ b/packages/server/src/radio/connections/TciConnection.ts
@@ -5,6 +5,7 @@ import {
   TciSampleType,
   payloadToFloat32,
   float32ToPcm16,
+  type TciTxChronoRequest,
   type TciStreamFrame,
 } from 'tci-client-node';
 import type { MeterCapabilities, TunerCapabilities, TunerStatus } from '@tx5dr/contracts';
@@ -33,6 +34,13 @@ const TCI_COMMAND_TIMEOUT_MS = 1_500;
 const TCI_CONNECT_TIMEOUT_MS = 6_000;
 const TCI_WRITE_TIMEOUT_MS = 3_000;
 const TCI_FREQUENCY_WRITE_SETTLE_MS = 250;
+const TCI_TX_STREAM_BUFFERING_MS = 150;
+
+interface TxDrainWaiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
 
 export class TciConnection extends EventEmitter<IRadioConnectionEvents> implements IRadioConnection {
   private readonly ioQueue = new RadioIoQueue({ label: 'TCI WebSocket' });
@@ -48,6 +56,12 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   private lastTxPeakPowerW: number | null = null;
   private lastSWR: number | null = null;
   private audioRunning = false;
+  private readonly audioStreamOwners = new Set<string>();
+  private txTransmissionActive = false;
+  private txAudioChunks: Float32Array[] = [];
+  private txAudioChunkOffset = 0;
+  private txAudioQueuedSamples = 0;
+  private txDrainWaiters: TxDrainWaiter[] = [];
 
   getType(): RadioConnectionType {
     return RadioConnectionType.TCI;
@@ -103,6 +117,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     this.lastKnownMode = null;
     this.lastKnownPtt = null;
     this.audioRunning = false;
+    this.audioStreamOwners.clear();
+    this.txTransmissionActive = false;
+    this.clearTxAudioQueue('connect-reset');
     this.setState(RadioConnectionState.CONNECTING);
 
     const url = `ws://${tci.host}:${tci.port || DEFAULT_TCI_PORT}`;
@@ -131,6 +148,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
         sampleType: TciSampleType.FLOAT32,
         channels: 1,
         samplesPerFrame: 512,
+        txBufferingMs: TCI_TX_STREAM_BUFFERING_MS,
       });
       await client.setRxSensorsEnabled(true, 300).catch((error) => logger.debug('Failed to enable TCI RX sensors', error));
       await client.setTxSensorsEnabled(true, 300).catch((error) => logger.debug('Failed to enable TCI TX sensors', error));
@@ -193,6 +211,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   async setPTT(enabled: boolean): Promise<void> {
     await this.runTask('setPTT', async () => {
       this.checkConnected();
+      if (!enabled) {
+        this.clearTxAudioQueue('ptt-off');
+      }
       if (this.isPttAlreadyApplied(enabled)) {
         logger.debug('TCI state matched before write', { operation: 'setPTT', ptt: enabled });
         this.lastKnownPtt = enabled;
@@ -200,6 +221,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
       }
       await this.client!.setPtt(enabled, { source: enabled ? 'tci' : undefined });
       this.lastKnownPtt = enabled;
+      if (!enabled) {
+        this.clearTxAudioQueue('ptt-off-applied');
+      }
     }, { critical: true });
   }
 
@@ -389,16 +413,26 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     return this.currentConfig?.tci?.audioSampleRate ?? DEFAULT_TCI_AUDIO_RATE;
   }
 
-  async startAudioStream(): Promise<void> {
+  async startAudioStream(owner = 'rx'): Promise<void> {
     this.checkConnected();
+    this.audioStreamOwners.add(owner);
     if (this.audioRunning) {
       return;
     }
-    await this.client!.startAudio(this.currentConfig?.tci?.receiver ?? 0);
-    this.audioRunning = true;
+    try {
+      await this.client!.startAudio(this.currentConfig?.tci?.receiver ?? 0);
+      this.audioRunning = true;
+    } catch (error) {
+      this.audioStreamOwners.delete(owner);
+      throw error;
+    }
   }
 
-  async stopAudioStream(): Promise<void> {
+  async stopAudioStream(owner = 'rx'): Promise<void> {
+    this.audioStreamOwners.delete(owner);
+    if (this.audioStreamOwners.size > 0) {
+      return;
+    }
     if (!this.client?.isConnected() || !this.audioRunning) {
       this.audioRunning = false;
       return;
@@ -409,13 +443,34 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
 
   async sendAudio(samples: Float32Array): Promise<void> {
     this.checkConnected();
-    this.client!.sendTxAudio({
-      receiver: this.currentConfig?.tci?.receiver ?? 0,
-      sampleRate: this.getAudioSampleRate(),
-      sampleType: TciSampleType.FLOAT32,
-      channels: 1,
-      samples,
+    this.enqueueTxAudio(samples);
+  }
+
+  beginTxAudio(): void {
+    this.txTransmissionActive = true;
+    this.clearTxAudioQueue('tx-begin');
+  }
+
+  async waitForTxAudioDrain(timeoutMs: number): Promise<void> {
+    if (this.txAudioQueuedSamples <= 0) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const waiter: TxDrainWaiter = {
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.txDrainWaiters = this.txDrainWaiters.filter((candidate) => candidate !== waiter);
+          reject(new Error(`Timed out waiting for TCI TX audio drain (${this.txAudioQueuedSamples} samples queued)`));
+        }, timeoutMs),
+      };
+      this.txDrainWaiters.push(waiter);
     });
+  }
+
+  endTxAudio(): void {
+    this.txTransmissionActive = false;
+    this.clearTxAudioQueue('tx-end');
   }
 
   private setupClientListeners(client: TciClient): void {
@@ -427,6 +482,10 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     client.on('error', (error) => this.emit('error', this.convertError(error, 'event')));
     client.on('state', () => this.syncStateFromClient());
     client.on('rxAudioFrame', (frame) => this.handleRxAudioFrame(frame));
+    client.on('txChrono', (request) => {
+      if (this.client !== client) return;
+      this.handleTxChrono(request);
+    });
   }
 
   private syncStateFromClient(): void {
@@ -515,10 +574,93 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     }
   }
 
+  private handleTxChrono(request: TciTxChronoRequest): void {
+    try {
+      const channels = Math.max(1, Math.floor(request.channels || 1));
+      const requestedSamples = Math.max(0, Math.floor(request.sampleCount) * channels);
+      const { samples, copied } = this.dequeueTxAudio(requestedSamples);
+      if (copied < requestedSamples) {
+        logger.debug('TCI TX chrono underflow; sending silence for missing samples', {
+          requestedSamples,
+          copied,
+          queuedSamples: this.txAudioQueuedSamples,
+          active: this.txTransmissionActive,
+        });
+      }
+      this.client?.sendTxAudioForChrono(request, samples);
+    } catch (error) {
+      this.emit('error', this.convertError(error, 'txChrono'));
+    }
+  }
+
+  private enqueueTxAudio(samples: Float32Array): void {
+    if (samples.length <= 0) {
+      return;
+    }
+    const copy = new Float32Array(samples);
+    this.txAudioChunks.push(copy);
+    this.txAudioQueuedSamples += copy.length;
+  }
+
+  private dequeueTxAudio(sampleCount: number): { samples: Float32Array; copied: number } {
+    const output = new Float32Array(Math.max(0, sampleCount));
+    let copied = 0;
+    while (copied < output.length && this.txAudioChunks.length > 0) {
+      const chunk = this.txAudioChunks[0]!;
+      const available = chunk.length - this.txAudioChunkOffset;
+      const take = Math.min(output.length - copied, available);
+      output.set(chunk.subarray(this.txAudioChunkOffset, this.txAudioChunkOffset + take), copied);
+      copied += take;
+      this.txAudioChunkOffset += take;
+      this.txAudioQueuedSamples = Math.max(0, this.txAudioQueuedSamples - take);
+      if (this.txAudioChunkOffset >= chunk.length) {
+        this.txAudioChunks.shift();
+        this.txAudioChunkOffset = 0;
+      }
+    }
+    this.resolveTxDrainWaitersIfDrained();
+    return { samples: output, copied };
+  }
+
+  private clearTxAudioQueue(reason: string): void {
+    if (this.txAudioQueuedSamples > 0 || this.txAudioChunks.length > 0) {
+      logger.debug('Clearing TCI TX audio queue', { reason, queuedSamples: this.txAudioQueuedSamples });
+    }
+    this.txAudioChunks = [];
+    this.txAudioChunkOffset = 0;
+    this.txAudioQueuedSamples = 0;
+    this.resolveTxDrainWaitersIfDrained();
+  }
+
+  private resolveTxDrainWaitersIfDrained(): void {
+    if (this.txAudioQueuedSamples > 0 || this.txDrainWaiters.length === 0) {
+      return;
+    }
+    const waiters = this.txDrainWaiters;
+    this.txDrainWaiters = [];
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve();
+    }
+  }
+
+  private rejectTxDrainWaiters(error: Error): void {
+    const waiters = this.txDrainWaiters;
+    this.txDrainWaiters = [];
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  }
+
   private async cleanup(): Promise<void> {
     const client = this.client;
     this.client = null;
     this.audioRunning = false;
+    this.audioStreamOwners.clear();
+    this.txTransmissionActive = false;
+    this.rejectTxDrainWaiters(new Error('TCI connection closed before TX audio drained'));
+    this.clearTxAudioQueue('cleanup');
     if (client) {
       client.removeAllListeners();
       await client.disconnect().catch((error) => logger.debug('TCI disconnect cleanup failed', error));

--- a/packages/server/src/radio/connections/TciConnection.ts
+++ b/packages/server/src/radio/connections/TciConnection.ts
@@ -1,0 +1,569 @@
+import { EventEmitter } from 'eventemitter3';
+import {
+  TciClient,
+  TciError,
+  TciSampleType,
+  payloadToFloat32,
+  float32ToPcm16,
+  type TciStreamFrame,
+} from 'tci-client-node';
+import type { MeterCapabilities, TunerCapabilities, TunerStatus } from '@tx5dr/contracts';
+import { RadioError, RadioErrorCode, RadioErrorSeverity } from '../../utils/errors/RadioError.js';
+import { createLogger } from '../../utils/logger.js';
+import { buildLevelMeterReading, formatSValue } from './meterUtils.js';
+import { RadioIoQueue } from './RadioIoQueue.js';
+import {
+  type ApplyOperatingStateRequest,
+  type ApplyOperatingStateResult,
+  type IRadioConnection,
+  type IRadioConnectionEvents,
+  type MeterData,
+  type RadioConnectionConfig,
+  RadioConnectionState,
+  RadioConnectionType,
+  type RadioModeBandwidth,
+  type RadioModeInfo,
+  type SetRadioModeOptions,
+} from './IRadioConnection.js';
+
+const logger = createLogger('TciConnection');
+const DEFAULT_TCI_PORT = 40001;
+const DEFAULT_TCI_AUDIO_RATE = 12_000;
+const TCI_COMMAND_TIMEOUT_MS = 1_500;
+const TCI_CONNECT_TIMEOUT_MS = 6_000;
+
+export class TciConnection extends EventEmitter<IRadioConnectionEvents> implements IRadioConnection {
+  private readonly ioQueue = new RadioIoQueue({ label: 'TCI WebSocket' });
+  private ioSessionId = 0;
+  private client: TciClient | null = null;
+  private currentConfig: RadioConnectionConfig | null = null;
+  private state = RadioConnectionState.DISCONNECTED;
+  private lastKnownFrequency: number | null = null;
+  private lastKnownMode: string | null = null;
+  private lastKnownPtt = false;
+  private lastRxLevelDbm: number | null = null;
+  private lastTxPowerW: number | null = null;
+  private lastTxPeakPowerW: number | null = null;
+  private lastSWR: number | null = null;
+  private audioRunning = false;
+
+  getType(): RadioConnectionType {
+    return RadioConnectionType.TCI;
+  }
+
+  getState(): RadioConnectionState {
+    return this.state;
+  }
+
+  isHealthy(): boolean {
+    return this.state === RadioConnectionState.CONNECTED && Boolean(this.client?.isConnected());
+  }
+
+  isConnected(): boolean {
+    return this.isHealthy();
+  }
+
+  isCriticalOperationActive(): boolean {
+    return this.ioQueue.isCriticalActive();
+  }
+
+  getRadioIoQueueSnapshot() {
+    return this.ioQueue.getSnapshot();
+  }
+
+  async connect(config: RadioConnectionConfig): Promise<void> {
+    if (this.client) {
+      await this.disconnect('reconnect');
+    }
+
+    if (config.type !== 'tci') {
+      throw new RadioError({
+        code: RadioErrorCode.INVALID_CONFIG,
+        message: `Configuration type error: expected 'tci', got '${config.type}'`,
+        userMessage: 'Radio configuration type is incorrect',
+        suggestions: ['Select TCI / SunSDR as the radio connection type'],
+      });
+    }
+
+    const tci = config.tci;
+    if (!tci?.host || !tci.port) {
+      throw new RadioError({
+        code: RadioErrorCode.INVALID_CONFIG,
+        message: 'TCI configuration missing required fields: tci.host, tci.port',
+        userMessage: 'TCI configuration is incomplete',
+        suggestions: ['Enter the ExpertSDR TCI host', 'Enter the TCI WebSocket port (default 40001)'],
+      });
+    }
+
+    this.currentConfig = config;
+    this.ioSessionId += 1;
+    this.lastKnownFrequency = null;
+    this.lastKnownMode = null;
+    this.audioRunning = false;
+    this.setState(RadioConnectionState.CONNECTING);
+
+    const url = `ws://${tci.host}:${tci.port || DEFAULT_TCI_PORT}`;
+    const client = new TciClient({
+      url,
+      receiver: tci.receiver ?? 0,
+      trx: tci.trx ?? 0,
+      vfo: tci.vfo ?? 0,
+      connectTimeoutMs: TCI_CONNECT_TIMEOUT_MS,
+      commandTimeoutMs: TCI_COMMAND_TIMEOUT_MS,
+    });
+    this.client = client;
+    this.setupClientListeners(client);
+
+    try {
+      logger.info('Connecting to TCI radio', { url, receiver: tci.receiver ?? 0, trx: tci.trx ?? 0, vfo: tci.vfo ?? 0 });
+      await client.connect();
+      await this.waitForReady(client, 2_000).catch((error) => {
+        logger.warn('TCI READY was not received before timeout; continuing with open WebSocket', error);
+      });
+      await client.configureAudio({
+        sampleRate: tci.audioSampleRate ?? DEFAULT_TCI_AUDIO_RATE,
+        sampleType: TciSampleType.FLOAT32,
+        channels: 1,
+        samplesPerFrame: 512,
+      });
+      await client.setRxSensorsEnabled(true, 300).catch((error) => logger.debug('Failed to enable TCI RX sensors', error));
+      await client.setTxSensorsEnabled(true, 300).catch((error) => logger.debug('Failed to enable TCI TX sensors', error));
+
+      const state = client.getState();
+      this.lastKnownFrequency = state.frequencies[`${tci.receiver ?? 0}:${tci.vfo ?? 0}`] ?? null;
+      this.lastKnownMode = state.modes[`${tci.receiver ?? 0}:${tci.vfo ?? 0}`] ?? null;
+      this.lastKnownPtt = state.ptt[String(tci.trx ?? 0)] ?? false;
+
+      this.setState(RadioConnectionState.CONNECTED);
+      this.emit('connected');
+      logger.info('TCI radio connected successfully', { device: state.device, protocol: state.protocol });
+    } catch (error) {
+      await this.cleanup();
+      this.setState(RadioConnectionState.ERROR);
+      throw this.convertError(error, 'connect');
+    }
+  }
+
+  async disconnect(reason?: string): Promise<void> {
+    logger.info(`Disconnecting TCI radio: ${reason || 'no reason'}`);
+    this.ioSessionId += 1;
+    await this.cleanup();
+    this.setState(RadioConnectionState.DISCONNECTED);
+    this.emit('disconnected', reason);
+  }
+
+  async setFrequency(frequency: number): Promise<void> {
+    await this.runTask('setFrequency', async () => {
+      this.checkConnected();
+      await this.client!.setFrequency(frequency);
+      this.lastKnownFrequency = frequency;
+      this.emit('frequencyChanged', frequency);
+    }, { critical: true });
+  }
+
+  async getFrequency(): Promise<number> {
+    return this.runTask('getFrequency', async () => {
+      this.checkConnected();
+      const frequency = await this.client!.getFrequency();
+      if (typeof frequency === 'number' && Number.isFinite(frequency) && frequency > 0) {
+        this.lastKnownFrequency = frequency;
+        return frequency;
+      }
+      if (this.lastKnownFrequency !== null) {
+        return this.lastKnownFrequency;
+      }
+      throw new Error('TCI frequency read returned no value');
+    }, { id: 'getFrequency' });
+  }
+
+  async setPTT(enabled: boolean): Promise<void> {
+    await this.runTask('setPTT', async () => {
+      this.checkConnected();
+      await this.client!.setPtt(enabled, { source: enabled ? 'tci' : undefined });
+      this.lastKnownPtt = enabled;
+    }, { critical: true });
+  }
+
+  async getPTT(): Promise<boolean> {
+    return this.runTask('getPTT', async () => {
+      this.checkConnected();
+      const ptt = await this.client!.getPtt();
+      if (typeof ptt === 'boolean') {
+        this.lastKnownPtt = ptt;
+      }
+      return this.lastKnownPtt;
+    }, { id: 'getPTT' });
+  }
+
+  async setMode(mode: string, _bandwidth?: RadioModeBandwidth, options?: SetRadioModeOptions): Promise<void> {
+    await this.runTask('setMode', async () => {
+      this.checkConnected();
+      const tciMode = this.normalizeMode(mode, options);
+      await this.client!.setMode(tciMode);
+      this.lastKnownMode = tciMode.toLowerCase();
+    }, { critical: true });
+  }
+
+  async applyOperatingState(request: ApplyOperatingStateRequest): Promise<ApplyOperatingStateResult> {
+    return this.runTask('applyOperatingState', async () => {
+      this.checkConnected();
+      let frequencyApplied = false;
+      let modeApplied = false;
+      let modeError: Error | undefined;
+
+      if (request.frequency !== undefined) {
+        await this.client!.setFrequency(request.frequency);
+        this.lastKnownFrequency = request.frequency;
+        this.emit('frequencyChanged', request.frequency);
+        frequencyApplied = true;
+      }
+
+      if (request.mode) {
+        try {
+          const tciMode = this.normalizeMode(request.mode, request.options);
+          await this.client!.setMode(tciMode);
+          this.lastKnownMode = tciMode.toLowerCase();
+          modeApplied = true;
+        } catch (error) {
+          if (!request.tolerateModeFailure) {
+            throw error;
+          }
+          modeError = error instanceof Error ? error : new Error(String(error));
+        }
+      }
+
+      return { frequencyApplied, modeApplied, modeError };
+    }, { critical: true });
+  }
+
+  async getMode(): Promise<RadioModeInfo> {
+    return this.runTask('getMode', async () => {
+      this.checkConnected();
+      const mode = await this.client!.getMode();
+      if (mode) {
+        this.lastKnownMode = mode;
+      }
+      return { mode: (mode ?? this.lastKnownMode ?? 'UNKNOWN').toUpperCase(), bandwidth: 'Normal' };
+    }, { id: 'getMode' });
+  }
+
+  async getSupportedModes(): Promise<string[]> {
+    const modes = this.client?.getState().modulations ?? [];
+    return modes.length > 0 ? modes.map((mode) => mode.toUpperCase()) : ['LSB', 'USB', 'CW', 'AM', 'NFM', 'DIGU', 'DIGL'];
+  }
+
+  supportsCWMessageKeyer(): boolean {
+    return true;
+  }
+
+  async sendCWMessage(message: string, _wpm: number): Promise<void> {
+    await this.runTask('sendCWMessage', async () => {
+      this.checkConnected();
+      await this.client!.sendCwMessage(message);
+    }, { critical: true });
+  }
+
+  async stopCWMessage(): Promise<void> {
+    await this.runTask('stopCWMessage', async () => {
+      if (!this.client?.isConnected()) {
+        return;
+      }
+      await this.client.stopCw();
+    }, { critical: true });
+  }
+
+  getMeterCapabilities(): MeterCapabilities {
+    return { strength: true, swr: true, alc: false, power: true, powerWatts: true };
+  }
+
+  async getTunerCapabilities(): Promise<TunerCapabilities> {
+    return { supported: false, hasSwitch: false, hasManualTune: false };
+  }
+
+  async getTunerStatus(): Promise<TunerStatus> {
+    return { enabled: false, active: false, status: 'idle' };
+  }
+
+  async setSplitEnabled(enabled: boolean): Promise<void> {
+    await this.runTask('setSplitEnabled', async () => {
+      this.checkConnected();
+      await this.client!.setSplit(enabled);
+    }, { critical: true });
+  }
+
+  async getSplitEnabled(): Promise<boolean> {
+    const trx = this.currentConfig?.tci?.trx ?? 0;
+    return this.client?.getState().split[String(trx)] ?? false;
+  }
+
+  async setRFPower(value: number): Promise<void> {
+    await this.runTask('setRFPower', async () => {
+      this.checkConnected();
+      await this.client!.setDrive(Math.round(Math.max(0, Math.min(1, value)) * 100));
+    }, { critical: true });
+  }
+
+  async getRFPower(): Promise<number> {
+    const trx = this.currentConfig?.tci?.trx ?? 0;
+    const drive = this.client?.getState().drive[String(trx)];
+    if (typeof drive === 'number') {
+      return Math.max(0, Math.min(1, drive / 100));
+    }
+    throw new Error('TCI drive level is not available yet');
+  }
+
+  setKnownFrequency(frequencyHz: number): void {
+    if (Number.isFinite(frequencyHz) && frequencyHz > 0) {
+      this.lastKnownFrequency = frequencyHz;
+    }
+  }
+
+  getConnectionInfo() {
+    return {
+      type: this.getType(),
+      state: this.getState(),
+      config: {
+        type: this.currentConfig?.type,
+        tci: this.currentConfig?.tci,
+      },
+    };
+  }
+
+  getAudioSampleRate(): number {
+    return this.currentConfig?.tci?.audioSampleRate ?? DEFAULT_TCI_AUDIO_RATE;
+  }
+
+  async startAudioStream(): Promise<void> {
+    this.checkConnected();
+    if (this.audioRunning) {
+      return;
+    }
+    await this.client!.startAudio(this.currentConfig?.tci?.receiver ?? 0);
+    this.audioRunning = true;
+  }
+
+  async stopAudioStream(): Promise<void> {
+    if (!this.client?.isConnected() || !this.audioRunning) {
+      this.audioRunning = false;
+      return;
+    }
+    await this.client.stopAudio(this.currentConfig?.tci?.receiver ?? 0);
+    this.audioRunning = false;
+  }
+
+  async sendAudio(samples: Float32Array): Promise<void> {
+    this.checkConnected();
+    this.client!.sendTxAudio({
+      receiver: this.currentConfig?.tci?.receiver ?? 0,
+      sampleRate: this.getAudioSampleRate(),
+      sampleType: TciSampleType.FLOAT32,
+      channels: 1,
+      samples,
+    });
+  }
+
+  private setupClientListeners(client: TciClient): void {
+    client.on('disconnected', (reason) => {
+      if (this.client !== client) return;
+      this.setState(RadioConnectionState.DISCONNECTED);
+      this.emit('disconnected', reason instanceof Error ? reason.message : String(reason ?? 'TCI disconnected'));
+    });
+    client.on('error', (error) => this.emit('error', this.convertError(error, 'event')));
+    client.on('state', () => this.syncStateFromClient());
+    client.on('rxAudioFrame', (frame) => this.handleRxAudioFrame(frame));
+  }
+
+  private syncStateFromClient(): void {
+    if (!this.client) return;
+    const tci = this.currentConfig?.tci;
+    const state = this.client.getState();
+    const rxKey = `${tci?.receiver ?? 0}:${tci?.vfo ?? 0}`;
+    const trxKey = String(tci?.trx ?? 0);
+    const frequency = state.frequencies[rxKey];
+    if (typeof frequency === 'number' && frequency > 0 && frequency !== this.lastKnownFrequency) {
+      this.lastKnownFrequency = frequency;
+      this.emit('frequencyChanged', frequency);
+    }
+    const mode = state.modes[rxKey];
+    if (mode) {
+      this.lastKnownMode = mode;
+    }
+    if (typeof state.ptt[trxKey] === 'boolean') {
+      this.lastKnownPtt = state.ptt[trxKey];
+    }
+
+    this.updateMetersFromState(state.rxSensors, state.txSensors);
+  }
+
+  private updateMetersFromState(
+    rxSensors: Record<string, Record<string, number | string | boolean>>,
+    txSensors: Record<string, Record<string, number | string | boolean>>,
+  ): void {
+    const tci = this.currentConfig?.tci;
+    const rxKey = `${tci?.receiver ?? 0}:${tci?.vfo ?? 0}`;
+    const rx = rxSensors[rxKey] ?? rxSensors[String(tci?.receiver ?? 0)];
+    const tx = txSensors[String(tci?.trx ?? 0)];
+    const levelDbm = toNumber(rx?.levelDbm);
+    const rmsPower = toNumber(tx?.rmsPowerW);
+    const peakPower = toNumber(tx?.peakPowerW);
+    const swr = toNumber(tx?.swr);
+    let changed = false;
+
+    if (levelDbm !== undefined) {
+      this.lastRxLevelDbm = levelDbm;
+      changed = true;
+    }
+    if (rmsPower !== undefined) {
+      this.lastTxPowerW = rmsPower;
+      changed = true;
+    }
+    if (peakPower !== undefined) {
+      this.lastTxPeakPowerW = peakPower;
+      changed = true;
+    }
+    if (swr !== undefined) {
+      this.lastSWR = swr;
+      changed = true;
+    }
+
+    if (changed) {
+      this.emit('meterData', this.buildMeterData());
+    }
+  }
+
+  private buildMeterData(): MeterData {
+    const frequency = this.lastKnownFrequency ?? 14_000_000;
+    const s9Dbm = frequency < 30_000_000 ? -73 : -93;
+    const dbOffset = (this.lastRxLevelDbm ?? s9Dbm) - s9Dbm;
+    const level = this.lastRxLevelDbm === null
+      ? null
+      : buildLevelMeterReading(this.lastRxLevelDbm, dbOffset, frequency, 's-meter-dbm', formatSValue(dbOffset));
+    const powerWatts = this.lastTxPowerW ?? this.lastTxPeakPowerW;
+    const powerPercent = powerWatts === null || powerWatts === undefined ? 0 : Math.max(0, Math.min(100, powerWatts));
+    return {
+      swr: this.lastSWR === null ? null : { raw: this.lastSWR, swr: this.lastSWR, alert: this.lastSWR >= 2.5 },
+      alc: null,
+      level,
+      power: powerWatts === null || powerWatts === undefined
+        ? null
+        : { raw: powerWatts, percent: powerPercent, watts: powerWatts, maxWatts: null },
+    };
+  }
+
+  private handleRxAudioFrame(frame: TciStreamFrame): void {
+    try {
+      const samples = payloadToFloat32(frame);
+      this.emit('audioFrame', float32ToPcm16(samples), { timestampMs: Date.now() });
+    } catch (error) {
+      this.emit('error', this.convertError(error, 'rxAudioFrame'));
+    }
+  }
+
+  private async cleanup(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    this.audioRunning = false;
+    if (client) {
+      client.removeAllListeners();
+      await client.disconnect().catch((error) => logger.debug('TCI disconnect cleanup failed', error));
+    }
+  }
+
+  private checkConnected(): void {
+    if (!this.client?.isConnected() || this.state !== RadioConnectionState.CONNECTED) {
+      throw new RadioError({
+        code: RadioErrorCode.INVALID_STATE,
+        message: `TCI connection is not connected (state=${this.state})`,
+        userMessage: 'TCI radio is not connected',
+        severity: RadioErrorSeverity.WARNING,
+      });
+    }
+  }
+
+  private async runTask<T>(
+    name: string,
+    task: () => Promise<T>,
+    options: { id?: string; critical?: boolean } = {},
+  ): Promise<T> {
+    return this.ioQueue.run({ sessionId: this.ioSessionId, name, id: options.id, critical: options.critical }, async () => {
+      try {
+        return await task();
+      } catch (error) {
+        throw this.convertError(error, name);
+      }
+    });
+  }
+
+  private setState(state: RadioConnectionState): void {
+    if (this.state === state) {
+      return;
+    }
+    this.state = state;
+    this.emit('stateChanged', state);
+  }
+
+  private waitForReady(client: TciClient, timeoutMs: number): Promise<void> {
+    if (client.getState().ready) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error('TCI READY timeout'));
+      }, timeoutMs);
+      const onReady = () => {
+        cleanup();
+        resolve();
+      };
+      const cleanup = () => {
+        clearTimeout(timer);
+        client.off('ready', onReady);
+      };
+      client.once('ready', onReady);
+    });
+  }
+
+  private normalizeMode(mode: string, options?: SetRadioModeOptions): string {
+    const upper = mode.trim().toUpperCase();
+    if (upper === 'FT8' || upper === 'FT4') return 'DIGU';
+    if (['USB-D', 'USB-DATA', 'PKTUSB', 'DATA-U', 'DIGU'].includes(upper)) return 'DIGU';
+    if (['LSB-D', 'LSB-DATA', 'PKTLSB', 'DATA-L', 'DIGL'].includes(upper)) return 'DIGL';
+    if (options?.intent === 'digital' && upper === 'USB') return 'DIGU';
+    if (options?.intent === 'digital' && upper === 'LSB') return 'DIGL';
+    return upper;
+  }
+
+  private convertError(error: unknown, operation: string): RadioError {
+    if (error instanceof RadioError) {
+      return error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    const code = error instanceof TciError && error.code === 'connect-timeout'
+      ? RadioErrorCode.CONNECTION_TIMEOUT
+      : error instanceof TciError && error.code === 'not-connected'
+        ? RadioErrorCode.CONNECTION_LOST
+        : message.toLowerCase().includes('timeout')
+          ? RadioErrorCode.OPERATION_TIMEOUT
+          : RadioErrorCode.WEBSOCKET_ERROR;
+    return new RadioError({
+      code,
+      message: `TCI ${operation} failed: ${message}`,
+      userMessage: 'TCI radio operation failed',
+      suggestions: [
+        'Check that ExpertSDR/SunSDR TCI server is enabled',
+        'Confirm the TCI host and port are reachable',
+        'Avoid connecting multiple TCI clients if the radio rejects them',
+      ],
+      cause: error,
+      context: { operation, protocol: 'tci' },
+    });
+  }
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}

--- a/packages/server/src/radio/connections/TciConnection.ts
+++ b/packages/server/src/radio/connections/TciConnection.ts
@@ -31,6 +31,8 @@ const DEFAULT_TCI_PORT = 40001;
 const DEFAULT_TCI_AUDIO_RATE = 12_000;
 const TCI_COMMAND_TIMEOUT_MS = 1_500;
 const TCI_CONNECT_TIMEOUT_MS = 6_000;
+const TCI_WRITE_TIMEOUT_MS = 3_000;
+const TCI_FREQUENCY_WRITE_SETTLE_MS = 250;
 
 export class TciConnection extends EventEmitter<IRadioConnectionEvents> implements IRadioConnection {
   private readonly ioQueue = new RadioIoQueue({ label: 'TCI WebSocket' });
@@ -40,7 +42,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   private state = RadioConnectionState.DISCONNECTED;
   private lastKnownFrequency: number | null = null;
   private lastKnownMode: string | null = null;
-  private lastKnownPtt = false;
+  private lastKnownPtt: boolean | null = null;
   private lastRxLevelDbm: number | null = null;
   private lastTxPowerW: number | null = null;
   private lastTxPeakPowerW: number | null = null;
@@ -99,6 +101,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     this.ioSessionId += 1;
     this.lastKnownFrequency = null;
     this.lastKnownMode = null;
+    this.lastKnownPtt = null;
     this.audioRunning = false;
     this.setState(RadioConnectionState.CONNECTING);
 
@@ -110,6 +113,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
       vfo: tci.vfo ?? 0,
       connectTimeoutMs: TCI_CONNECT_TIMEOUT_MS,
       commandTimeoutMs: TCI_COMMAND_TIMEOUT_MS,
+      writeAckMode: 'state',
+      writeTimeoutMs: TCI_WRITE_TIMEOUT_MS,
+      frequencyWriteSettleMs: TCI_FREQUENCY_WRITE_SETTLE_MS,
     });
     this.client = client;
     this.setupClientListeners(client);
@@ -132,7 +138,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
       const state = client.getState();
       this.lastKnownFrequency = state.frequencies[`${tci.receiver ?? 0}:${tci.vfo ?? 0}`] ?? null;
       this.lastKnownMode = state.modes[`${tci.receiver ?? 0}:${tci.vfo ?? 0}`] ?? null;
-      this.lastKnownPtt = state.ptt[String(tci.trx ?? 0)] ?? false;
+      this.lastKnownPtt = typeof state.ptt[String(tci.trx ?? 0)] === 'boolean'
+        ? state.ptt[String(tci.trx ?? 0)]
+        : null;
 
       this.setState(RadioConnectionState.CONNECTED);
       this.emit('connected');
@@ -155,9 +163,15 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   async setFrequency(frequency: number): Promise<void> {
     await this.runTask('setFrequency', async () => {
       this.checkConnected();
-      await this.client!.setFrequency(frequency);
-      this.lastKnownFrequency = frequency;
-      this.emit('frequencyChanged', frequency);
+      const targetFrequency = Math.round(frequency);
+      if (this.isFrequencyAlreadyApplied(targetFrequency)) {
+        logger.debug('TCI state matched before write', { operation: 'setFrequency', frequency: targetFrequency });
+        this.lastKnownFrequency = targetFrequency;
+        return;
+      }
+      await this.client!.setFrequency(targetFrequency);
+      this.lastKnownFrequency = targetFrequency;
+      this.emit('frequencyChanged', targetFrequency);
     }, { critical: true });
   }
 
@@ -179,6 +193,11 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   async setPTT(enabled: boolean): Promise<void> {
     await this.runTask('setPTT', async () => {
       this.checkConnected();
+      if (this.isPttAlreadyApplied(enabled)) {
+        logger.debug('TCI state matched before write', { operation: 'setPTT', ptt: enabled });
+        this.lastKnownPtt = enabled;
+        return;
+      }
       await this.client!.setPtt(enabled, { source: enabled ? 'tci' : undefined });
       this.lastKnownPtt = enabled;
     }, { critical: true });
@@ -191,7 +210,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
       if (typeof ptt === 'boolean') {
         this.lastKnownPtt = ptt;
       }
-      return this.lastKnownPtt;
+      return this.lastKnownPtt ?? false;
     }, { id: 'getPTT' });
   }
 
@@ -199,6 +218,11 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     await this.runTask('setMode', async () => {
       this.checkConnected();
       const tciMode = this.normalizeMode(mode, options);
+      if (this.isModeAlreadyApplied(tciMode)) {
+        logger.debug('TCI state matched before write', { operation: 'setMode', mode: tciMode });
+        this.lastKnownMode = tciMode.toLowerCase();
+        return;
+      }
       await this.client!.setMode(tciMode);
       this.lastKnownMode = tciMode.toLowerCase();
     }, { critical: true });
@@ -212,23 +236,55 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
       let modeError: Error | undefined;
 
       if (request.frequency !== undefined) {
-        await this.client!.setFrequency(request.frequency);
-        this.lastKnownFrequency = request.frequency;
-        this.emit('frequencyChanged', request.frequency);
-        frequencyApplied = true;
+        const targetFrequency = Math.round(request.frequency);
+        if (this.isFrequencyAlreadyApplied(targetFrequency)) {
+          logger.debug('TCI state matched before write', { operation: 'applyOperatingState.setFrequency', frequency: targetFrequency });
+          this.lastKnownFrequency = targetFrequency;
+          frequencyApplied = true;
+        } else {
+          try {
+            await this.client!.setFrequency(targetFrequency);
+            this.lastKnownFrequency = targetFrequency;
+            this.emit('frequencyChanged', targetFrequency);
+            frequencyApplied = true;
+          } catch (error) {
+            if (!isTciCommandTimeout(error)) {
+              throw error;
+            }
+            logger.warn('TCI write timeout tolerated', {
+              operation: 'applyOperatingState.setFrequency',
+              frequency: targetFrequency,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
       }
 
       if (request.mode) {
         try {
           const tciMode = this.normalizeMode(request.mode, request.options);
-          await this.client!.setMode(tciMode);
-          this.lastKnownMode = tciMode.toLowerCase();
-          modeApplied = true;
-        } catch (error) {
-          if (!request.tolerateModeFailure) {
-            throw error;
+          if (this.isModeAlreadyApplied(tciMode)) {
+            logger.debug('TCI state matched before write', { operation: 'applyOperatingState.setMode', mode: tciMode });
+            this.lastKnownMode = tciMode.toLowerCase();
+            modeApplied = true;
+          } else {
+            await this.client!.setMode(tciMode);
+            this.lastKnownMode = tciMode.toLowerCase();
+            modeApplied = true;
           }
-          modeError = error instanceof Error ? error : new Error(String(error));
+        } catch (error) {
+          if (isTciCommandTimeout(error)) {
+            logger.warn('TCI write timeout tolerated', {
+              operation: 'applyOperatingState.setMode',
+              mode: request.mode,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            modeError = this.convertError(error, 'applyOperatingState.setMode');
+          } else if (!request.tolerateModeFailure) {
+            throw error;
+          } else {
+            modeError = error instanceof Error ? error : new Error(String(error));
+          }
         }
       }
 
@@ -533,31 +589,82 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     return upper;
   }
 
+  private isFrequencyAlreadyApplied(frequency: number): boolean {
+    if (this.isSameFrequency(this.lastKnownFrequency, frequency)) {
+      return true;
+    }
+    const tci = this.currentConfig?.tci;
+    const stateFrequency = this.client?.getState().frequencies[`${tci?.receiver ?? 0}:${tci?.vfo ?? 0}`];
+    return this.isSameFrequency(stateFrequency, frequency);
+  }
+
+  private isModeAlreadyApplied(mode: string): boolean {
+    const normalized = mode.toLowerCase();
+    if (this.lastKnownMode?.toLowerCase() === normalized) {
+      return true;
+    }
+    const tci = this.currentConfig?.tci;
+    return this.client?.getState().modes[`${tci?.receiver ?? 0}:${tci?.vfo ?? 0}`]?.toLowerCase() === normalized;
+  }
+
+  private isPttAlreadyApplied(enabled: boolean): boolean {
+    if (this.lastKnownPtt === enabled) {
+      return true;
+    }
+    const trx = this.currentConfig?.tci?.trx ?? 0;
+    return this.client?.getState().ptt[String(trx)] === enabled;
+  }
+
+  private isSameFrequency(left: number | null | undefined, right: number | null | undefined): boolean {
+    return typeof left === 'number'
+      && typeof right === 'number'
+      && Number.isFinite(left)
+      && Number.isFinite(right)
+      && Math.round(left) === Math.round(right);
+  }
+
   private convertError(error: unknown, operation: string): RadioError {
     if (error instanceof RadioError) {
       return error;
     }
     const message = error instanceof Error ? error.message : String(error);
-    const code = error instanceof TciError && error.code === 'connect-timeout'
+    const isTciError = error instanceof TciError;
+    const isWriteTimeout = isTciCommandTimeout(error) && isTciWriteOperation(operation);
+    const code = isTciError && error.code === 'connect-timeout'
       ? RadioErrorCode.CONNECTION_TIMEOUT
-      : error instanceof TciError && error.code === 'not-connected'
+      : isTciError && (error.code === 'not-connected' || error.code === 'disconnected')
         ? RadioErrorCode.CONNECTION_LOST
-        : message.toLowerCase().includes('timeout')
+        : isTciError && error.code === 'command-timeout'
           ? RadioErrorCode.OPERATION_TIMEOUT
-          : RadioErrorCode.WEBSOCKET_ERROR;
+          : message.toLowerCase().includes('timeout')
+            ? RadioErrorCode.OPERATION_TIMEOUT
+            : RadioErrorCode.WEBSOCKET_ERROR;
     return new RadioError({
       code,
       message: `TCI ${operation} failed: ${message}`,
       userMessage: 'TCI radio operation failed',
+      severity: isWriteTimeout ? RadioErrorSeverity.WARNING : RadioErrorSeverity.ERROR,
       suggestions: [
         'Check that ExpertSDR/SunSDR TCI server is enabled',
         'Confirm the TCI host and port are reachable',
         'Avoid connecting multiple TCI clients if the radio rejects them',
       ],
       cause: error,
-      context: { operation, protocol: 'tci' },
+      context: { operation, protocol: 'tci', writeTimeout: isWriteTimeout, recoverable: isWriteTimeout },
     });
   }
+}
+
+function isTciCommandTimeout(error: unknown): boolean {
+  return error instanceof TciError && error.code === 'command-timeout';
+}
+
+function isTciWriteOperation(operation: string): boolean {
+  return operation === 'setFrequency'
+    || operation === 'setPTT'
+    || operation === 'setMode'
+    || operation === 'applyOperatingState'
+    || operation.startsWith('applyOperatingState.');
 }
 
 function toNumber(value: unknown): number | undefined {

--- a/packages/server/src/routes/radio.ts
+++ b/packages/server/src/routes/radio.ts
@@ -250,11 +250,12 @@ function isHardwareSameTarget(a: HamlibConfig, b: HamlibConfig): boolean {
     case 'serial': return a.serial?.path === b.serial?.path;
     case 'network': return a.network?.host === b.network?.host && a.network?.port === b.network?.port;
     case 'icom-wlan': return a.icomWlan?.ip === b.icomWlan?.ip && a.icomWlan?.port === b.icomWlan?.port;
+    case 'tci': return a.tci?.host === b.tci?.host && a.tci?.port === b.tci?.port;
     default: return true;
   }
 }
 
-/** 判断测试配置是否与已有连接存在硬件冲突（串口独占 / ICOM WLAN 单客户端） */
+/** 判断测试配置是否与已有连接存在硬件冲突（串口独占 / ICOM WLAN/TCI 单客户端） */
 function isHardwareConflict(active: HamlibConfig, test: HamlibConfig): boolean {
   // 串口：同一 path 就冲突（OS 独占）
   if (test.type === 'serial' && active.type === 'serial'
@@ -262,6 +263,9 @@ function isHardwareConflict(active: HamlibConfig, test: HamlibConfig): boolean {
   // ICOM WLAN：同一 IP 就冲突（单客户端限制）
   if (test.type === 'icom-wlan' && active.type === 'icom-wlan'
       && active.icomWlan?.ip === test.icomWlan?.ip) return true;
+  // TCI：同一 ExpertSDR WebSocket endpoint 视为冲突
+  if (test.type === 'tci' && active.type === 'tci'
+      && active.tci?.host === test.tci?.host && active.tci?.port === test.tci?.port) return true;
   return false;
 }
 
@@ -271,6 +275,7 @@ function describeHardware(config: HamlibConfig): string {
     case 'serial': return `Serial ${config.serial?.path || ''}`;
     case 'network': return `Network ${config.network?.host || ''}:${config.network?.port || ''}`;
     case 'icom-wlan': return `ICOM WLAN ${config.icomWlan?.ip || ''}`;
+    case 'tci': return `TCI ${config.tci?.host || ''}:${config.tci?.port || ''}`;
     default: return 'Unknown';
   }
 }
@@ -478,14 +483,15 @@ export async function radioRoutes(fastify: FastifyInstance) {
     // 标记是否刚刚触发了引擎重启（用于避免重复调用 applyConfig）
     let engineRestarted = false;
 
-    // 如果切换到 ICOM WLAN 模式，自动设置音频设备为 ICOM WLAN
-    if (config.type === 'icom-wlan') {
-      logger.debug('ICOM WLAN mode detected, auto-setting audio devices');
+    // 如果切换到 radio-audio 模式，自动设置对应虚拟音频设备
+    if (config.type === 'icom-wlan' || (config.type === 'tci' && config.tci?.audioEnabled !== false)) {
+      const radioAudioDeviceName = config.type === 'tci' ? 'TCI Audio' : 'ICOM WLAN';
+      logger.debug(`${radioAudioDeviceName} mode detected, auto-setting audio devices`);
       const audioConfig = configManager.getAudioConfig();
       const updatedAudioConfig = {
         ...audioConfig,
-        inputDeviceName: 'ICOM WLAN',
-        outputDeviceName: 'ICOM WLAN'
+        inputDeviceName: radioAudioDeviceName,
+        outputDeviceName: radioAudioDeviceName
       };
 
       // 重启引擎以应用音频配置（参考 POST /audio/settings 的实现）
@@ -497,7 +503,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
 
       await profileManager.updateActiveProfileAudioConfig(updatedAudioConfig);
       engine.getAudioStreamManager().reloadAudioConfig();
-      logger.info('Audio devices auto-set to ICOM WLAN');
+      logger.info(`Audio devices auto-set to ${radioAudioDeviceName}`);
 
       if (wasRunning) {
         logger.debug('Restarting engine');
@@ -864,7 +870,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
         }
       }
 
-      // 硬件冲突检测：串口独占 / ICOM WLAN 单客户端
+      // 硬件冲突检测：串口独占 / ICOM WLAN/TCI 单客户端
       if (isHardwareConflict(activeConfig, config)) {
         return reply.send({
           success: false,

--- a/packages/server/src/subsystems/EngineLifecycle.ts
+++ b/packages/server/src/subsystems/EngineLifecycle.ts
@@ -10,6 +10,7 @@ import type { VoiceSessionManager } from '../voice/VoiceSessionManager.js';
 import { ConfigManager } from '../config/config-manager.js';
 import { ResourceManager, type SimplifiedResourceConfig } from '../utils/ResourceManager.js';
 import { IcomWlanAudioAdapter } from '../audio/IcomWlanAudioAdapter.js';
+import { TciAudioAdapter } from '../audio/TciAudioAdapter.js';
 import { OpenWebRXAudioAdapter } from '../openwebrx/OpenWebRXAudioAdapter.js';
 import { AudioDeviceManager } from '../audio/audio-device-manager.js';
 import type { AudioSidecarController } from './AudioSidecarController.js';
@@ -78,6 +79,9 @@ export class EngineLifecycle {
 
   // ICOM WLAN 音频适配器
   private icomWlanAudioAdapter: IcomWlanAudioAdapter | null = null;
+
+  // TCI / SunSDR 音频适配器
+  private tciAudioAdapter: TciAudioAdapter | null = null;
 
   // OpenWebRX 音频适配器
   private openwebrxAudioAdapter: OpenWebRXAudioAdapter | null = null;
@@ -181,6 +185,12 @@ export class EngineLifecycle {
               throw new Error('ICOM WLAN IP or port missing');
             }
             logger.debug(`ICOM WLAN config validated: IP=${radioConfig.icomWlan.ip}, Port=${radioConfig.icomWlan.port}`);
+          } else if (radioConfig.type === 'tci') {
+            if (!radioConfig.tci?.host || !radioConfig.tci?.port) {
+              logger.error('TCI config incomplete:', radioConfig.tci);
+              throw new Error('TCI host or port missing');
+            }
+            logger.debug(`TCI config validated: ${radioConfig.tci.host}:${radioConfig.tci.port}`);
           }
           logger.debug('Applying radio config:', radioConfig);
           await radioManager.applyConfig(radioConfig);
@@ -220,6 +230,38 @@ export class EngineLifecycle {
             audioStreamManager.setIcomWlanAudioAdapter(null);
             this.icomWlanAudioAdapter = null;
             logger.debug('ICOM WLAN audio adapter cleaned up');
+          }
+        },
+        priority: 2,
+        dependencies: [],
+        optional: true,
+      },
+      {
+        name: 'tciAudioAdapter',
+        start: async () => {
+          const radioConfig = configManager.getRadioConfig();
+          if (radioConfig.type !== 'tci' || radioConfig.tci?.audioEnabled === false) {
+            logger.debug('Not TCI audio mode, skipping adapter init');
+            return;
+          }
+          logger.debug('Initializing TCI audio adapter');
+          const tciConnection = radioManager.getTciConnection();
+          if (!tciConnection || !tciConnection.isConnected()) {
+            logger.warn('TCI radio not connected, falling back to normal audio input');
+            return;
+          }
+          this.tciAudioAdapter = new TciAudioAdapter(tciConnection);
+          audioStreamManager.setTciAudioAdapter(this.tciAudioAdapter);
+          const audioDeviceManager = AudioDeviceManager.getInstance();
+          audioDeviceManager.setTciConnectedCallback(() => tciConnection.isConnected());
+          logger.debug('TCI audio adapter initialized');
+        },
+        stop: async () => {
+          if (this.tciAudioAdapter) {
+            this.tciAudioAdapter.stopReceiving();
+            audioStreamManager.setTciAudioAdapter(null);
+            this.tciAudioAdapter = null;
+            logger.debug('TCI audio adapter cleaned up');
           }
         },
         priority: 2,

--- a/packages/server/src/subsystems/TransmissionPipeline.ts
+++ b/packages/server/src/subsystems/TransmissionPipeline.ts
@@ -373,7 +373,7 @@ export class TransmissionPipeline {
   }
 
   private shouldReleasePTTImmediatelyAfterAudio(): boolean {
-    return this.deps.radioManager.getConfig().type === 'icom-wlan';
+    return this.deps.radioManager.getConfig().type === 'icom-wlan' || this.deps.radioManager.getConfig().type === 'tci';
   }
 
   private async handleEncodeComplete(result: {
@@ -567,7 +567,7 @@ export class TransmissionPipeline {
       });
 
       if (this.shouldReleasePTTImmediatelyAfterAudio()) {
-        logger.debug('ICOM WLAN audio complete, stopping PTT without post-audio hold');
+        logger.debug('Radio audio output complete, stopping PTT without post-audio hold');
         this.stopPTTPoll();
         await this.stopPTT();
       }

--- a/packages/server/src/subsystems/__tests__/EngineLifecycle.test.ts
+++ b/packages/server/src/subsystems/__tests__/EngineLifecycle.test.ts
@@ -89,6 +89,7 @@ describe('EngineLifecycle', () => {
     expect(resourceManager.register.mock.calls.map(([config]) => config.name)).toEqual([
       'radio',
       'icomWlanAudioAdapter',
+      'tciAudioAdapter',
       'openwebrxAudioAdapter',
       'decodeWorkerPool',
       'clock',
@@ -107,7 +108,7 @@ describe('EngineLifecycle', () => {
 
     expect(resourceManager.stopAll).toHaveBeenCalledTimes(2);
     expect(resourceManager.clear).toHaveBeenCalledTimes(2);
-    const firstPlanCount = 8; // radio + icom + openwebrx + decodeWorkerPool + clock + slotScheduler + spectrumScheduler + operatorManager
+    const firstPlanCount = 9; // radio + icom + tci + openwebrx + decodeWorkerPool + clock + slotScheduler + spectrumScheduler + operatorManager
     const secondPlanNames = resourceManager.register.mock.calls
       .slice(firstPlanCount)
       .map(([config]) => config.name);
@@ -115,6 +116,7 @@ describe('EngineLifecycle', () => {
     expect(secondPlanNames).toEqual([
       'radio',
       'icomWlanAudioAdapter',
+      'tciAudioAdapter',
       'openwebrxAudioAdapter',
       'spectrumScheduler',
       'voiceSessionManager',
@@ -157,6 +159,7 @@ describe('EngineLifecycle', () => {
     expect(names).toEqual([
       'radio',
       'icomWlanAudioAdapter',
+      'tciAudioAdapter',
       'openwebrxAudioAdapter',
       'spectrumScheduler',
       'voiceSessionManager',
@@ -172,6 +175,7 @@ describe('EngineLifecycle', () => {
     expect(names).toEqual([
       'radio',
       'icomWlanAudioAdapter',
+      'tciAudioAdapter',
       'openwebrxAudioAdapter',
       'spectrumScheduler',
     ]);

--- a/packages/web/src/components/cw/CWKeyerPanel.tsx
+++ b/packages/web/src/components/cw/CWKeyerPanel.tsx
@@ -196,7 +196,8 @@ export function CWKeyerPanel({ embedded = false }: CWKeyerPanelProps = {}) {
   const radioConfigType = radioState.state.radioConfig?.type;
   const isRadioKeyerCapableConfig = radioConfigType === 'serial'
     || radioConfigType === 'network'
-    || radioConfigType === 'icom-wlan';
+    || radioConfigType === 'icom-wlan'
+    || radioConfigType === 'tci';
   const catBackendError = cwKeyerStatus?.backend === 'cat' && cwKeyerStatus.backendAvailable === false
     ? cwKeyerStatus.backendError
     : null;
@@ -206,7 +207,7 @@ export function CWKeyerPanel({ embedded = false }: CWKeyerPanelProps = {}) {
   const catUnavailableReason = !radioConnected
     ? t('radio:cw.catUnavailableDisconnected', 'Connect a radio before using CAT CW.')
     : !isRadioKeyerCapableConfig
-      ? t('radio:cw.catUnavailableHamlibOnly', 'CAT CW currently supports Hamlib serial/network or ICOM WLAN radio connections only.')
+      ? t('radio:cw.catUnavailableHamlibOnly', 'CAT CW currently supports Hamlib serial/network, ICOM WLAN, or TCI radio connections only.')
       : catUnsupportedSendMorse
         ? t('radio:cw.catUnsupportedSendMorse', 'The radio does not report CAT/radio CW text sending support. Use Key jack instead, or verify Hamlib SEND_MORSE / ICOM CI-V CW support.')
         : catBackendError;

--- a/packages/web/src/components/radio/control/RadioControl.tsx
+++ b/packages/web/src/components/radio/control/RadioControl.tsx
@@ -462,6 +462,7 @@ const RadioStatus: React.FC<{ connection: ConnectionState; radioConnection: Radi
     }
     if (config.type === 'network') return 'Network RigCtrl';
     if (config.type === 'icom-wlan') return 'ICOM WLAN';
+    if (config.type === 'tci') return 'TCI / SunSDR';
     return t('status.radio');
   };
 

--- a/packages/web/src/components/radio/profile/ProfileModal.tsx
+++ b/packages/web/src/components/radio/profile/ProfileModal.tsx
@@ -47,6 +47,8 @@ function isRedactedProfile(profile: RadioProfile): boolean {
       return !profile.radio.serial;
     case 'icom-wlan':
       return !profile.radio.icomWlan;
+    case 'tci':
+      return !profile.radio.tci;
     default:
       return false;
   }
@@ -87,6 +89,18 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
   const handleAudioConfigChange = useCallback((config: AudioDeviceSettingsType) => {
     setEditAudioConfig(config);
     userManuallyChangedAudioRef.current = true;
+  }, []);
+
+  const handleRadioConfigChange = useCallback((config: HamlibConfig) => {
+    setEditRadioConfig((prev) => {
+      if (prev.type !== config.type && !userManuallyChangedAudioRef.current) {
+        if (config.type === 'icom-wlan' || config.type === 'tci') {
+          const deviceName = config.type === 'tci' ? 'TCI Audio' : 'ICOM WLAN';
+          setEditAudioConfig({ ...NEW_PROFILE_AUDIO_DEFAULTS, inputDeviceName: deviceName, outputDeviceName: deviceName });
+        }
+      }
+      return config;
+    });
   }, []);
 
   // 同步 profiles 到本地状态
@@ -214,6 +228,9 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
       case 'icom-wlan': return config.icomWlan?.ip
         ? `ICOM WLAN | ${config.icomWlan.ip}`
         : 'ICOM WLAN';
+      case 'tci': return config.tci?.host && config.tci?.port
+        ? `TCI / SunSDR | ${config.tci.host}:${config.tci.port}`
+        : 'TCI / SunSDR';
       default: return t('profileModal.unknownType');
     }
   };
@@ -359,8 +376,9 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
     }
   };
 
-  // ICOM WLAN 检测：音频锁定提示
-  const isIcomWlan = editRadioConfig.type === 'icom-wlan';
+  // Radio-audio 模式检测：音频锁定提示
+  const radioAudioDeviceName = editRadioConfig.type === 'tci' ? 'TCI Audio' : 'ICOM WLAN';
+  const isRadioAudioMode = editRadioConfig.type === 'icom-wlan' || editRadioConfig.type === 'tci';
 
   // Reset manual-change flag when radio connection type changes
   const prevRadioTypeRef = useRef(editRadioConfig.type);
@@ -535,19 +553,19 @@ export function ProfileModal({ isOpen, onClose }: ProfileModalProps) {
           <RadioDeviceSettings
             ref={radioSettingsRef}
             initialConfig={editRadioConfig}
-            onChange={setEditRadioConfig}
+            onChange={handleRadioConfigChange}
           />
 
           <Divider />
 
           {/* 音频设置 */}
           <div>
-            {isIcomWlan && (
+            {isRadioAudioMode && (
               <Card shadow="none" radius="lg" classNames={{ base: 'border border-divider bg-content1 mb-3' }}>
                 <CardBody className="p-3">
                   <div className="flex items-center gap-2 text-primary">
                     <Chip size="sm" color="primary" variant="flat">{t('profileModal.icomDefault')}</Chip>
-                    <span className="text-sm">{t('profileModal.icomDefaultDesc')}</span>
+                    <span className="text-sm">{t(editRadioConfig.type === 'tci' ? 'profileModal.tciDefaultDesc' : 'profileModal.icomDefaultDesc', { device: radioAudioDeviceName })}</span>
                   </div>
                 </CardBody>
               </Card>

--- a/packages/web/src/components/radio/profile/ProfileSetupOverlay.tsx
+++ b/packages/web/src/components/radio/profile/ProfileSetupOverlay.tsx
@@ -13,7 +13,7 @@ import {
   Progress
 } from '@heroui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowRight, faArrowLeft, faCheck, faWifi, faPlug, faBan, faSatelliteDish } from '@fortawesome/free-solid-svg-icons';
+import { faArrowRight, faArrowLeft, faCheck, faWifi, faPlug, faBan, faSatelliteDish, faTowerBroadcast } from '@fortawesome/free-solid-svg-icons';
 import { addToast } from '@heroui/toast';
 import { api } from '@tx5dr/core';
 import type { HamlibConfig, AudioDeviceSettings as AudioDeviceSettingsType, SupportedRig } from '@tx5dr/contracts';
@@ -29,7 +29,7 @@ interface ProfileSetupOverlayProps {
   isOpen: boolean;
 }
 
-type RadioType = 'none' | 'network' | 'serial' | 'icom-wlan';
+type RadioType = 'none' | 'network' | 'serial' | 'icom-wlan' | 'tci';
 
 export function ProfileSetupOverlay({ isOpen }: ProfileSetupOverlayProps) {
   const { t } = useTranslation();
@@ -38,6 +38,7 @@ export function ProfileSetupOverlay({ isOpen }: ProfileSetupOverlayProps) {
     { type: 'serial' as RadioType, icon: faPlug, title: t('settings:radioType.serial'), description: t('settings:radioType.serialDesc') },
     { type: 'network' as RadioType, icon: faSatelliteDish, title: t('settings:radioType.network'), description: t('settings:radioType.networkDesc') },
     { type: 'icom-wlan' as RadioType, icon: faWifi, title: t('settings:radioType.icomWlan'), description: t('settings:radioType.icomWlanDesc') },
+    { type: 'tci' as RadioType, icon: faTowerBroadcast, title: t('settings:radioType.tci'), description: t('settings:radioType.tciDesc') },
   ], [t]);
   const [step, setStep] = useState(0); // 0=选类型, 1=填配置, 2=选音频, 3=命名
   const [selectedType, setSelectedType] = useState<RadioType | null>(null);
@@ -98,12 +99,16 @@ export function ProfileSetupOverlay({ isOpen }: ProfileSetupOverlayProps) {
   // 步骤1：选择类型后
   const handleSelectType = (type: RadioType) => {
     setSelectedType(type);
-    setRadioConfig({ type } as HamlibConfig);
+    setRadioConfig(type === 'tci' ? {
+      type,
+      tci: { host: '127.0.0.1', port: 40001, receiver: 0, trx: 0, vfo: 0, audioEnabled: true, audioSampleRate: 12000 },
+    } as HamlibConfig : { type } as HamlibConfig);
     autoAudioAppliedRef.current = null;
     userManuallyChangedAudioRef.current = false;
-    // ICOM WLAN 默认使用电台音频设备
-    if (type === 'icom-wlan') {
-      setAudioConfig({ ...NEW_PROFILE_AUDIO_DEFAULTS, inputDeviceName: 'ICOM WLAN', outputDeviceName: 'ICOM WLAN' });
+    // Radio-audio modes default to their virtual radio audio device
+    if (type === 'icom-wlan' || type === 'tci') {
+      const deviceName = type === 'tci' ? 'TCI Audio' : 'ICOM WLAN';
+      setAudioConfig({ ...NEW_PROFILE_AUDIO_DEFAULTS, inputDeviceName: deviceName, outputDeviceName: deviceName });
     } else {
       setAudioConfig(NEW_PROFILE_AUDIO_DEFAULTS);
     }
@@ -178,6 +183,7 @@ export function ProfileSetupOverlay({ isOpen }: ProfileSetupOverlayProps) {
   const getDefaultName = () => {
     switch (selectedType) {
       case 'icom-wlan': return 'ICOM WLAN';
+      case 'tci': return 'TCI / SunSDR';
       case 'network': return t('settings:radioType.network');
       case 'serial': return t('settings:radioType.serial');
       case 'none': return t('settings:radioType.none');

--- a/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
+++ b/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
@@ -875,6 +875,25 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
       );
     };
 
+    const selectRadioType = (type: HamlibConfig['type']) => {
+      if (type === 'tci') {
+        updateConfig({
+          type,
+          tci: config.tci ?? {
+            host: '127.0.0.1',
+            port: 40001,
+            receiver: 0,
+            trx: 0,
+            vfo: 0,
+            audioEnabled: true,
+            audioSampleRate: 12000,
+          },
+        });
+        return;
+      }
+      updateConfig({ type });
+    };
+
     // 渲染配置内容
     const renderConfigContent = () => {
       switch (config.type) {
@@ -1500,6 +1519,115 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
               </CardBody>
             </Card>
           );
+        case 'tci':
+          return (
+            <Card shadow="none" radius="lg" classNames={{ base: "border border-divider bg-content1" }}>
+              <CardBody className="space-y-4 p-4">
+                <h4 className="font-semibold text-default-900">{t('radio.tciTitle')}</h4>
+                <p className="text-sm text-default-600">{t('radio.tciDesc')}</p>
+                <Divider />
+                <div className="space-y-4">
+                  <Input
+                    label={t('radio.host')}
+                    placeholder="127.0.0.1"
+                    value={config.tci?.host || ''}
+                    onChange={e => updateConfig({ tci: { host: e.target.value, port: config.tci?.port ?? 40001, receiver: config.tci?.receiver ?? 0, trx: config.tci?.trx ?? 0, vfo: config.tci?.vfo ?? 0, audioEnabled: config.tci?.audioEnabled ?? true, audioSampleRate: config.tci?.audioSampleRate ?? 12000 } })}
+                  />
+                  <Input
+                    label={t('radio.port')}
+                    placeholder="40001"
+                    type="number"
+                    value={String(config.tci?.port ?? '')}
+                    onChange={e => updateConfig({ tci: { host: config.tci?.host ?? '127.0.0.1', port: Number(e.target.value), receiver: config.tci?.receiver ?? 0, trx: config.tci?.trx ?? 0, vfo: config.tci?.vfo ?? 0, audioEnabled: config.tci?.audioEnabled ?? true, audioSampleRate: config.tci?.audioSampleRate ?? 12000 } })}
+                  />
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <Input
+                      label={t('radio.tciReceiver')}
+                      type="number"
+                      min="0"
+                      value={String(config.tci?.receiver ?? 0)}
+                      onChange={e => updateConfig({ tci: { host: config.tci?.host ?? '127.0.0.1', port: config.tci?.port ?? 40001, receiver: Number(e.target.value), trx: config.tci?.trx ?? 0, vfo: config.tci?.vfo ?? 0, audioEnabled: config.tci?.audioEnabled ?? true, audioSampleRate: config.tci?.audioSampleRate ?? 12000 } })}
+                    />
+                    <Input
+                      label={t('radio.tciTrx')}
+                      type="number"
+                      min="0"
+                      value={String(config.tci?.trx ?? 0)}
+                      onChange={e => updateConfig({ tci: { host: config.tci?.host ?? '127.0.0.1', port: config.tci?.port ?? 40001, receiver: config.tci?.receiver ?? 0, trx: Number(e.target.value), vfo: config.tci?.vfo ?? 0, audioEnabled: config.tci?.audioEnabled ?? true, audioSampleRate: config.tci?.audioSampleRate ?? 12000 } })}
+                    />
+                    <Input
+                      label={t('radio.tciVfo')}
+                      type="number"
+                      min="0"
+                      value={String(config.tci?.vfo ?? 0)}
+                      onChange={e => updateConfig({ tci: { host: config.tci?.host ?? '127.0.0.1', port: config.tci?.port ?? 40001, receiver: config.tci?.receiver ?? 0, trx: config.tci?.trx ?? 0, vfo: Number(e.target.value), audioEnabled: config.tci?.audioEnabled ?? true, audioSampleRate: config.tci?.audioSampleRate ?? 12000 } })}
+                    />
+                  </div>
+                  <div className="flex items-start justify-between gap-4 rounded-lg bg-default-50 p-3">
+                    <div>
+                      <p className="text-sm font-medium text-default-700">{t('radio.tciAudioEnabled')}</p>
+                      <p className="text-xs text-default-500">{t('radio.tciAudioEnabledDesc')}</p>
+                    </div>
+                    <Switch
+                      size="sm"
+                      isSelected={config.tci?.audioEnabled ?? true}
+                      onValueChange={audioEnabled => updateConfig({ tci: { host: config.tci?.host ?? '127.0.0.1', port: config.tci?.port ?? 40001, receiver: config.tci?.receiver ?? 0, trx: config.tci?.trx ?? 0, vfo: config.tci?.vfo ?? 0, audioEnabled, audioSampleRate: config.tci?.audioSampleRate ?? 12000 } })}
+                    />
+                  </div>
+                  <Select
+                    label={t('radio.tciAudioSampleRate')}
+                    selectedKeys={[String(config.tci?.audioSampleRate ?? 12000)]}
+                    onSelectionChange={keys => {
+                      const value = Number(Array.from(keys)[0] ?? 12000);
+                      updateConfig({ tci: { host: config.tci?.host ?? '127.0.0.1', port: config.tci?.port ?? 40001, receiver: config.tci?.receiver ?? 0, trx: config.tci?.trx ?? 0, vfo: config.tci?.vfo ?? 0, audioEnabled: config.tci?.audioEnabled ?? true, audioSampleRate: value } });
+                    }}
+                    variant="flat"
+                  >
+                    {[8000, 12000, 24000, 48000].map(rate => (
+                      <SelectItem key={String(rate)} textValue={`${rate} Hz`}>{rate.toLocaleString()} Hz</SelectItem>
+                    ))}
+                  </Select>
+                  <Divider />
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="flat"
+                      color="primary"
+                      onPress={handleTestConnection}
+                      isLoading={isTestingConnection}
+                      isDisabled={!config.tci?.host || !config.tci?.port || isTestingPTT}
+                    >
+                      {isTestingConnection ? t('radio.testingConnection') : t('radio.testConnection')}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="flat"
+                      color="secondary"
+                      onPress={handleTestPTT}
+                      isLoading={isTestingPTT}
+                      isDisabled={!config.tci?.host || !config.tci?.port || isTestingConnection}
+                    >
+                      {isTestingPTT ? t('radio.testingPTT') : t('radio.testPTT')}
+                    </Button>
+                  </div>
+                  {testResult && (
+                    <Chip
+                      color={testResult.type === 'success' ? 'success' : 'danger'}
+                      variant="flat"
+                      className="w-full"
+                    >
+                      {testResult.message}
+                    </Chip>
+                  )}
+                  <div className="text-xs text-default-400 space-y-1 bg-default-50 p-3 rounded-lg">
+                    <p className="font-medium">💡 {t('radio.usageTips')}</p>
+                    <p>• {t('radio.tipTci')}</p>
+                    <p>• {t('radio.tipTciAudio')}</p>
+                  </div>
+                </div>
+              </CardBody>
+            </Card>
+          );
         case 'icom-wlan':
           return (
             <Card shadow="none" radius="lg" classNames={{ base: "border border-divider bg-content1" }}>
@@ -1716,7 +1844,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
         <div className="inline-block max-w-full overflow-x-auto align-top sm:max-w-none sm:overflow-visible">
           <Tabs
             selectedKey={config.type}
-            onSelectionChange={(key) => updateConfig({ type: key as HamlibConfig['type'] })}
+            onSelectionChange={(key) => selectRadioType(key as HamlibConfig['type'])}
             size="lg"
             classNames={{
               tabList: 'w-auto flex-nowrap',
@@ -1727,6 +1855,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
             <Tab key="serial" title={`🔌 ${t('radio.modeSerial')}`} />
             <Tab key="network" title={`🌐 ${t('radio.modeNetwork')}`} />
             <Tab key="icom-wlan" title={`📡 ${t('radio.modeIcomWlan')}`} />
+            <Tab key="tci" title={`🛰️ ${t('radio.modeTci')}`} />
           </Tabs>
         </div>
 

--- a/packages/web/src/data/dependencies.json
+++ b/packages/web/src/data/dependencies.json
@@ -119,6 +119,13 @@
     "category": "backend"
   },
   {
+    "name": "tci-client-node",
+    "version": "0.1.0",
+    "license": "MIT",
+    "url": "https://github.com/boybook/tci-client-node",
+    "category": "backend"
+  },
+  {
     "name": "fast-jwt",
     "version": "4.x",
     "license": "MIT",

--- a/packages/web/src/i18n/locales/en/radio.json
+++ b/packages/web/src/i18n/locales/en/radio.json
@@ -487,7 +487,8 @@
     "unknownType": "Unknown type",
     "reorderFailed": "Failed to save order",
     "retry": "Please try again",
-    "updateFailed": "Update failed"
+    "updateFailed": "Update failed",
+    "tciDefaultDesc": "TCI mode uses {{device}} by default; change it only if you have a special audio route."
   },
   "errorHistory": {
     "title": "Radio Error History",
@@ -920,7 +921,7 @@
     "catUnavailableTitle": "CAT CW is not available",
     "catUnavailableBody": "Connect a radio that supports CAT/radio CW text sending before using this backend.",
     "catUnavailableDisconnected": "Connect a radio before using CAT CW.",
-    "catUnavailableHamlibOnly": "CAT CW currently supports Hamlib serial/network or ICOM WLAN radio connections only.",
+    "catUnavailableHamlibOnly": "CAT CW currently supports Hamlib serial/network, ICOM WLAN, or TCI radio connections only.",
     "catUnsupportedSendMorse": "The radio does not report CAT/radio CW text sending support. Use Key jack instead, or verify Hamlib SEND_MORSE / ICOM CI-V CW support.",
     "qsoTab": "QSOs",
     "qso": {

--- a/packages/web/src/i18n/locales/en/settings.json
+++ b/packages/web/src/i18n/locales/en/settings.json
@@ -301,7 +301,19 @@
     "cwKeyDeviceBusy": "CW key port {{port}} is already in use. Stop the current CW keyer or close other programs using this serial port.",
     "cwKeyDeviceBusyDifferentSettings": "CW key port {{port}} is already open by the current CW keyer with {{currentMethod}} / active {{currentActiveLevel}}. To test {{requestedMethod}} / active {{requestedActiveLevel}}, stop the current CW keyer, or save the settings and restart it before trying again.",
     "cwKeyerCurrentlyActive": "The CW keyer is currently sending or manually keying. Stop the current CW transmission before running the hardware test.",
-    "cwKeyReleaseFailed": "The CW release command did not reach {{port}}. The USB serial adapter may have dropped during transmit; confirm the radio has stopped transmitting, then reconnect the device and check antenna/feed-line separation from the USB cable."
+    "cwKeyReleaseFailed": "The CW release command did not reach {{port}}. The USB serial adapter may have dropped during transmit; confirm the radio has stopped transmitting, then reconnect the device and check antenna/feed-line separation from the USB cable.",
+    "tciTitle": "TCI / SunSDR Radio",
+    "tciDesc": "Connect to SunSDR / ExpertSDR through the TCI WebSocket server, including CAT and radio audio.",
+    "modeTci": "TCI / SunSDR",
+    "tciReceiver": "Receiver",
+    "tciTrx": "TRX",
+    "tciVfo": "VFO",
+    "tciAudioEnabled": "Enable TCI audio",
+    "tciAudioEnabledDesc": "Use TCI RX/TX audio as a virtual audio device.",
+    "tciAudioSampleRate": "TCI audio sample rate",
+    "tipTci": "Enable the TCI server in ExpertSDR/SunSDR and keep the default port 40001 unless changed.",
+    "tipTciAudio": "Select TCI Audio for input/output when you want TX-5DR to use the radio audio stream.",
+    "tipTciCompensation": "TCI mode: usually needs low network compensation on localhost"
   },
   "audio": {
     "loading": "Loading audio devices...",
@@ -374,7 +386,9 @@
     "serial": "Hamlib Direct Radio",
     "serialDesc": "Connect directly to a supported radio through Hamlib. Depending on the model, this may use a serial port, server address, or device path.",
     "icomWlan": "ICOM WLAN",
-    "icomWlanDesc": "Connect ICOM radio via Wi-Fi"
+    "icomWlanDesc": "Connect ICOM radio via Wi-Fi",
+    "tci": "TCI / SunSDR",
+    "tciDesc": "ExpertSDR / SunSDR TCI WebSocket"
   },
   "common": {
     "error": "Error",

--- a/packages/web/src/i18n/locales/ja/radio.json
+++ b/packages/web/src/i18n/locales/ja/radio.json
@@ -465,7 +465,8 @@
     "unknownType": "不明なタイプ",
     "reorderFailed": "並べ替え保存に失敗しました",
     "retry": "もう一度試してください",
-    "updateFailed": "アップデートに失敗しました"
+    "updateFailed": "アップデートに失敗しました",
+    "tciDefaultDesc": "TCI モードでは既定で {{device}} を使用します。特別な音声経路がある場合だけ変更してください。"
   },
   "errorHistory": {
     "title": "無線エラー履歴",
@@ -815,7 +816,7 @@
     "catUnavailableTitle": "CAT CW は現在利用できません",
     "catUnavailableBody": "このバックエンドを使用する前に、CAT/無線機 CW テキスト送信をサポートする無線機に接続してください。",
     "catUnavailableDisconnected": "CAT CWを使用する前に無線機に接続してください。",
-    "catUnavailableHamlibOnly": "CAT CW は現在、Hamlib シリアル/ネットワークまたは ICOM WLAN 無線機接続をサポートしています。",
+    "catUnavailableHamlibOnly": "CAT CW は現在、Hamlib シリアル/ネットワーク、ICOM WLAN、または TCI 無線機接続に対応しています。",
     "catUnsupportedSendMorse": "現在の無線機は CAT/無線機 CW テキスト送信のサポートを報告していません。キーインターフェイスを選択するか、Hamlib SEND_MORSE / ICOM CI-V CW サポートを確認してください。",
     "qsoTab": "交信ログ",
     "qso": {

--- a/packages/web/src/i18n/locales/ja/settings.json
+++ b/packages/web/src/i18n/locales/ja/settings.json
@@ -299,7 +299,19 @@
     "cwKeyDeviceBusy": "CW キーイング ポート {{port}} は使用中です。現在の CW キーヤーを停止するか、このシリアルポートを使用している他のプログラムを終了してください。",
     "cwKeyDeviceBusyDifferentSettings": "CW キーイング ポート {{port}} は現在の CW キーヤーにより {{currentMethod}} / active {{currentActiveLevel}} で開かれています。{{requestedMethod}} / active {{requestedActiveLevel}} をテストするには、現在の CW キーヤーを停止するか、設定を保存して再起動してから再試行してください。",
     "cwKeyerCurrentlyActive": "CW キーヤーは送信中または手動キーイング中です。ハードウェア テストを実行する前に、現在の CW 送信を停止してください。",
-    "cwKeyReleaseFailed": "CW 解除コマンドが {{port}} に届きませんでした。送信中に USB シリアルが切断された可能性があります。無線機が送信を停止していることを確認してから、デバイスを再接続し、アンテナ/給電線と USB ケーブルの距離を確認してください。"
+    "cwKeyReleaseFailed": "CW 解除コマンドが {{port}} に届きませんでした。送信中に USB シリアルが切断された可能性があります。無線機が送信を停止していることを確認してから、デバイスを再接続し、アンテナ/給電線と USB ケーブルの距離を確認してください。",
+    "tciTitle": "TCI / SunSDR 無線機",
+    "tciDesc": "TCI WebSocket で SunSDR / ExpertSDR に接続し、CAT 制御と無線機音声を利用します。",
+    "modeTci": "TCI / SunSDR",
+    "tciReceiver": "レシーバー",
+    "tciTrx": "TRX",
+    "tciVfo": "VFO",
+    "tciAudioEnabled": "TCI 音声を有効化",
+    "tciAudioEnabledDesc": "TCI RX/TX 音声を仮想オーディオデバイスとして使用します。",
+    "tciAudioSampleRate": "TCI 音声サンプルレート",
+    "tipTci": "ExpertSDR/SunSDR 側で TCI サーバーを有効にし、変更していなければポート 40001 を使います。",
+    "tipTciAudio": "無線機の音声ストリームを使う場合は、入力/出力に TCI Audio を選択します。",
+    "tipTciCompensation": "TCI モード: ローカル接続では通常、低めの補正で十分です"
   },
   "audio": {
     "loading": "オーディオデバイスをロード中...",
@@ -372,7 +384,9 @@
     "serial": "ハムリブダイレクト無線機",
     "serialDesc": "Hamlib 経由でサポートされている無線に直接接続します。特定のモデルではシリアル ポート、サーバー アドレス、またはデバイス パスを使用する場合があります。",
     "icomWlan": "ICOM WLAN",
-    "icomWlanDesc": "Wi-Fi経由でICOM無線に接続する"
+    "icomWlanDesc": "Wi-Fi経由でICOM無線に接続する",
+    "tci": "TCI / SunSDR",
+    "tciDesc": "ExpertSDR / SunSDR TCI WebSocket"
   },
   "common": {
     "error": "エラー",

--- a/packages/web/src/i18n/locales/zh/radio.json
+++ b/packages/web/src/i18n/locales/zh/radio.json
@@ -487,7 +487,8 @@
     "unknownType": "未知类型",
     "reorderFailed": "排序保存失败",
     "retry": "请重试",
-    "updateFailed": "更新失败"
+    "updateFailed": "更新失败",
+    "tciDefaultDesc": "TCI 模式默认使用 {{device}}；仅在有特殊音频路由时修改。"
   },
   "errorHistory": {
     "title": "电台错误历史",
@@ -920,7 +921,7 @@
     "catUnavailableTitle": "CAT CW 当前不可用",
     "catUnavailableBody": "请连接支持 CAT/电台 CW 文本发报的电台后再使用该后端。",
     "catUnavailableDisconnected": "使用 CAT CW 前请先连接电台。",
-    "catUnavailableHamlibOnly": "CAT CW 当前支持 Hamlib 串口/网络或 ICOM WLAN 电台连接。",
+    "catUnavailableHamlibOnly": "CAT CW 当前支持 Hamlib 串口/网络、ICOM WLAN 或 TCI 电台连接。",
     "catUnsupportedSendMorse": "当前电台未报告支持 CAT/电台 CW 文本发报。请选择电键接口，或检查 Hamlib SEND_MORSE / ICOM CI-V CW 支持。",
     "qsoTab": "通联日志",
     "qso": {

--- a/packages/web/src/i18n/locales/zh/settings.json
+++ b/packages/web/src/i18n/locales/zh/settings.json
@@ -301,7 +301,19 @@
     "cwKeyDeviceBusy": "CW 键控端口 {{port}} 正被占用。请先停止当前 CW 键控器或关闭其他占用该串口的程序。",
     "cwKeyDeviceBusyDifferentSettings": "CW 键控端口 {{port}} 已由当前 CW 键控器以 {{currentMethod}} / {{currentActiveLevel}} 有效电平打开。若要测试 {{requestedMethod}} / {{requestedActiveLevel}} 有效电平，请先停止当前 CW 键控器，或保存设置并重启后再试。",
     "cwKeyerCurrentlyActive": "CW 键控器正在发报或手键中。请先停止当前 CW 发射，再运行硬件测试。",
-    "cwKeyReleaseFailed": "CW 释放命令未能送达 {{port}}。USB 串口可能在发射时掉线，请先确认电台已经停止发射，再重新连接设备并检查天线/馈线与 USB 线的距离。"
+    "cwKeyReleaseFailed": "CW 释放命令未能送达 {{port}}。USB 串口可能在发射时掉线，请先确认电台已经停止发射，再重新连接设备并检查天线/馈线与 USB 线的距离。",
+    "tciTitle": "TCI / SunSDR 电台",
+    "tciDesc": "通过 TCI WebSocket 连接 SunSDR / ExpertSDR，支持 CAT 控制和电台音频。",
+    "modeTci": "TCI / SunSDR",
+    "tciReceiver": "接收机",
+    "tciTrx": "发射机",
+    "tciVfo": "VFO",
+    "tciAudioEnabled": "启用 TCI 音频",
+    "tciAudioEnabledDesc": "将 TCI RX/TX 音频作为虚拟音频设备使用。",
+    "tciAudioSampleRate": "TCI 音频采样率",
+    "tipTci": "请在 ExpertSDR/SunSDR 中启用 TCI 服务；未修改时端口通常为 40001。",
+    "tipTciAudio": "需要 TX-5DR 使用电台音频流时，输入/输出设备请选择 TCI Audio。",
+    "tipTciCompensation": "TCI 模式：本机连接通常只需要较低网络补偿"
   },
   "audio": {
     "loading": "正在加载音频设备...",
@@ -374,7 +386,9 @@
     "serial": "Hamlib 直连电台",
     "serialDesc": "通过 Hamlib 直接连接受支持的电台，具体型号可能使用串口、服务器地址或设备路径。",
     "icomWlan": "ICOM WLAN",
-    "icomWlanDesc": "通过 Wi-Fi 连接 ICOM 电台"
+    "icomWlanDesc": "通过 Wi-Fi 连接 ICOM 电台",
+    "tci": "TCI / SunSDR",
+    "tciDesc": "ExpertSDR / SunSDR TCI WebSocket"
   },
   "common": {
     "error": "错误",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,7 +6583,7 @@ __metadata:
     onnxruntime-node: "npm:^1.26.0"
     rubato-fft-node: "npm:^0.1.0"
     serialport: "npm:^13.0.0"
-    tci-client-node: "npm:^0.1.1"
+    tci-client-node: "npm:^0.1.2"
     tsx: "npm:^4.0.0"
     typescript: "npm:^5.0.0"
     vitest: "npm:^1.0.0"
@@ -18494,13 +18494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tci-client-node@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "tci-client-node@npm:0.1.1"
+"tci-client-node@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "tci-client-node@npm:0.1.2"
   dependencies:
     eventemitter3: "npm:^5.0.1"
     ws: "npm:^8.18.3"
-  checksum: 10c0/ba6bb42b77d5fe38eda63221207ec8c8f36d6de2ef9620245dd2f06b70193749da2548bc40ed8e074432e8abeda51ab721c846393e5676ff1e32ea7bfbcadb51
+  checksum: 10c0/0941a3b6554994a11fcaa1e96bfb7e4794820070ed8d4dfda50ac38c6c585d323fece5820c76982792e39ff34969128e2b48a81775e840a6cefa649f42893d93
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,7 +6583,7 @@ __metadata:
     onnxruntime-node: "npm:^1.26.0"
     rubato-fft-node: "npm:^0.1.0"
     serialport: "npm:^13.0.0"
-    tci-client-node: "npm:^0.1.0"
+    tci-client-node: "npm:^0.1.1"
     tsx: "npm:^4.0.0"
     typescript: "npm:^5.0.0"
     vitest: "npm:^1.0.0"
@@ -18494,13 +18494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tci-client-node@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "tci-client-node@npm:0.1.0"
+"tci-client-node@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "tci-client-node@npm:0.1.1"
   dependencies:
     eventemitter3: "npm:^5.0.1"
     ws: "npm:^8.18.3"
-  checksum: 10c0/3d23ee37ccf38fae1eb302066f16b5b97735ea332130ba945c2bacea60cf12d378990021d2838e9a9bdffb1b374b6861b0379f154e5d4a1362ae4a60a4457bf5
+  checksum: 10c0/ba6bb42b77d5fe38eda63221207ec8c8f36d6de2ef9620245dd2f06b70193749da2548bc40ed8e074432e8abeda51ab721c846393e5676ff1e32ea7bfbcadb51
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,6 +6583,7 @@ __metadata:
     onnxruntime-node: "npm:^1.26.0"
     rubato-fft-node: "npm:^0.1.0"
     serialport: "npm:^13.0.0"
+    tci-client-node: "portal:../../../tci-client-node"
     tsx: "npm:^4.0.0"
     typescript: "npm:^5.0.0"
     vitest: "npm:^1.0.0"
@@ -18493,6 +18494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tci-client-node@portal:../../../tci-client-node::locator=%40tx5dr%2Fserver%40workspace%3Apackages%2Fserver":
+  version: 0.0.0-use.local
+  resolution: "tci-client-node@portal:../../../tci-client-node::locator=%40tx5dr%2Fserver%40workspace%3Apackages%2Fserver"
+  dependencies:
+    eventemitter3: "npm:^5.0.1"
+    ws: "npm:^8.18.3"
+  languageName: node
+  linkType: soft
+
 "temp-file@npm:^3.4.0":
   version: 3.4.0
   resolution: "temp-file@npm:3.4.0"
@@ -20013,6 +20023,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/4b50f67931b8c6943c893f59c524f0e4905bbd183016cfb0f2b8653aa7f28dad4e456b9d99d285bbb67cca4fedd9ce90dfdfaa82b898a11414ebd66ee99141e4
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.18.3":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,7 +6583,7 @@ __metadata:
     onnxruntime-node: "npm:^1.26.0"
     rubato-fft-node: "npm:^0.1.0"
     serialport: "npm:^13.0.0"
-    tci-client-node: "portal:../../../tci-client-node"
+    tci-client-node: "npm:^0.1.0"
     tsx: "npm:^4.0.0"
     typescript: "npm:^5.0.0"
     vitest: "npm:^1.0.0"
@@ -18494,14 +18494,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tci-client-node@portal:../../../tci-client-node::locator=%40tx5dr%2Fserver%40workspace%3Apackages%2Fserver":
-  version: 0.0.0-use.local
-  resolution: "tci-client-node@portal:../../../tci-client-node::locator=%40tx5dr%2Fserver%40workspace%3Apackages%2Fserver"
+"tci-client-node@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "tci-client-node@npm:0.1.0"
   dependencies:
     eventemitter3: "npm:^5.0.1"
     ws: "npm:^8.18.3"
+  checksum: 10c0/3d23ee37ccf38fae1eb302066f16b5b97735ea332130ba945c2bacea60cf12d378990021d2838e9a9bdffb1b374b6861b0379f154e5d4a1362ae4a60a4457bf5
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "temp-file@npm:^3.4.0":
   version: 3.4.0


### PR DESCRIPTION
## Summary

- Adds a TCI / SunSDR (ExpertSDR) radio connection path backed by the published `tci-client-node` package.
- Adds contracts schema defaults for TCI host, port, receiver, TRX, VFO, and audio options.
- Adds server-side `TciConnection` and `TciAudioAdapter` support for CAT control, meters, RX/TX audio, and transmission pipeline integration.
- Adds web settings/profile UI and i18n strings for selecting TCI / SunSDR and TCI Audio virtual devices.

## Package Dependency

`packages/server/package.json` now uses the npm package:

```json
"tci-client-node": "^0.1.0"
```

The PR is still draft while TCI/SunSDR field testing continues, but it no longer depends on a local portal package.

## Validation

- `yarn install --immutable`
- `yarn workspace @tx5dr/server test`
- `yarn workspace @tx5dr/server build`
- `yarn build`
- Previous branch validation also covered `yarn workspace @tx5dr/contracts test`, `yarn check:i18n`, and `yarn workspace @tx5dr/web build`.

The web build still reports the existing large chunk warning.