### PR TITLE
feat(plugin): add plugin event bus

### DIFF
--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -394,6 +394,12 @@ interface PluginContext {
   readonly settings: HostSettingsControl;
 
   /**
+   * 插件间通信 Event Bus（权限门控）
+   * 仅声明 permissions: ['plugin:event-bus'] 后可用，否则为 undefined
+   */
+  readonly eventBus?: PluginEventBus;
+
+  /**
    * 宿主进程持有的运行时依赖。每个依赖都需要独立权限并且可能为 undefined。
    */
   readonly hostDependencies: HostDependencies;
@@ -404,6 +410,50 @@ interface PluginContext {
    */
   readonly fetch?: (url: string, init?: RequestInit) => Promise<Response>;
 }
+```
+
+#### PluginEventBus
+
+`ctx.eventBus` 为插件提供同一宿主进程内的轻量级插件间通信能力。该能力需要 manifest 声明 `permissions: ['plugin:event-bus']`；未声明权限时 `ctx.eventBus` 为 `undefined`。
+
+v1 接口：
+
+```typescript
+interface PluginEventBus {
+  publish(topic: string, payload?: unknown): void;
+  subscribe(
+    topic: string,
+    handler: (message: PluginEventBusMessage) => void | Promise<void>,
+  ): () => void;
+}
+
+interface PluginEventBusMessage {
+  topic: string;
+  payload: unknown;
+  timestamp: number;
+  publisher: {
+    pluginName: string;
+    instanceScope: 'operator' | 'global';
+    operatorId?: string;
+  };
+}
+```
+
+行为说明：
+
+- topic 为**精确匹配**的字符串，不支持 wildcard / pattern
+- `publish()` 不等待订阅方完成
+- 订阅回调抛错不会让发布方抛错；宿主会记录运行时日志
+- 插件卸载、重载、关闭时，宿主会自动清理该实例的所有订阅
+
+建议使用带插件名前缀的 topic，例如：
+
+```typescript
+ctx.eventBus?.publish('plugin.callsign-filter.updated', { callsigns: ['JA1ABC'] });
+
+const unsubscribe = ctx.eventBus?.subscribe('plugin.callsign-filter.updated', (message) => {
+  ctx.log.info('callsign list changed', message.payload as Record<string, unknown>);
+});
 ```
 
 

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -416,11 +416,13 @@ interface PluginContext {
 
 `ctx.eventBus` 为插件提供同一宿主进程内的轻量级插件间通信能力。该能力需要 manifest 声明 `permissions: ['plugin:event-bus']`；未声明权限时 `ctx.eventBus` 为 `undefined`。
 
-v1 接口：
+接口定义：
 
 ```typescript
 interface PluginEventBus {
+  /** 向指定 topic 的所有当前订阅者发送消息（fire-and-forget） */
   publish(topic: string, payload?: unknown): void;
+  /** 订阅指定 topic，返回取消订阅函数 */
   subscribe(
     topic: string,
     handler: (message: PluginEventBusMessage) => void | Promise<void>,
@@ -428,33 +430,131 @@ interface PluginEventBus {
 }
 
 interface PluginEventBusMessage {
-  topic: string;
-  payload: unknown;
-  timestamp: number;
+  topic: string;       // 消息发布到的 topic
+  payload: unknown;    // 发布者设置的任意数据
+  timestamp: number;   // 宿主分发消息时的 epoch 毫秒时间戳
   publisher: {
-    pluginName: string;
-    instanceScope: 'operator' | 'global';
-    operatorId?: string;
+    pluginName: string;                       // 发布插件的名称
+    instanceScope: 'operator' | 'global';     // 发布者是全局实例还是操作员实例
+    operatorId?: string;                      // 操作员实例时为其 ID
   };
 }
 ```
 
-行为说明：
+##### 行为说明
 
 - topic 为**精确匹配**的字符串，不支持 wildcard / pattern
-- `publish()` 不等待订阅方完成
-- 订阅回调抛错不会让发布方抛错；宿主会记录运行时日志
+- `publish()` 不等待订阅方完成（fire-and-forget）
+- 同一 handler 函数实例不会被重复添加；不同闭包（即使逻辑相同）视为不同订阅
+- 订阅回调抛错（同步或异步）不会让发布方抛错；宿主会记录运行时日志
 - 插件卸载、重载、关闭时，宿主会自动清理该实例的所有订阅
+- 手动取消单个订阅：调用 `subscribe()` 返回的函数
 
-建议使用带插件名前缀的 topic，例如：
+##### Topic 命名约定
+
+使用**点分隔、插件名前缀**的命名方式，避免不同插件间的 topic 冲突：
+
+```
+<插件名>.<领域>.<事件>
+```
+
+示例：
+
+| Topic | 含义 |
+|-------|------|
+| `psk-reporter.spot.sent` | 一条 spot 已上传到 PSK Reporter |
+| `callsign-filter.match.found` | 呼号匹配了过滤规则 |
+| `logbook-sync.upload.complete` | 日志同步上传完成 |
+
+避免使用 `update`、`message` 等过于通用的名称。
+
+##### 基本用法
 
 ```typescript
-ctx.eventBus?.publish('plugin.callsign-filter.updated', { callsigns: ['JA1ABC'] });
+// 发布方插件
+ctx.eventBus?.publish('callsign-filter.match.found', {
+  callsign: 'JA1ABC',
+  band: '20m',
+});
 
-const unsubscribe = ctx.eventBus?.subscribe('plugin.callsign-filter.updated', (message) => {
-  ctx.log.info('callsign list changed', message.payload as Record<string, unknown>);
+// 订阅方插件
+const unsubscribe = ctx.eventBus?.subscribe('callsign-filter.match.found', (message) => {
+  const { callsign, band } = message.payload as { callsign: string; band: string };
+  ctx.log.info('received match', { callsign, band });
 });
 ```
+
+##### 跨操作员通信
+
+操作员作用域的插件可以通过 Event Bus 与同一宿主上的其他操作员通信。`publisher` 元数据让订阅者识别消息来源：
+
+```typescript
+ctx.eventBus?.subscribe('qso-monitor.qso-complete', (message) => {
+  const { callsign, band } = message.payload as { callsign: string; band: string };
+  ctx.log.info('other operator completed QSO', {
+    operator: message.publisher.operatorId,
+    callsign,
+    band,
+  });
+});
+```
+
+##### 测试
+
+使用 `@tx5dr/plugin-api/testing` 中的 `createMockEventBus()` 进行单元测试：
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { createMockEventBus } from '@tx5dr/plugin-api/testing';
+
+it('发布 spot 数据', () => {
+  // 可选：自定义发布者元数据
+  const bus = createMockEventBus({ owner: { pluginName: 'spot-monitor' } });
+  const handler = vi.fn();
+
+  bus.subscribe('spot-monitor.new-spot', handler);
+  bus.publish('spot-monitor.new-spot', { callsign: 'W1AW', frequency: 14074000 });
+
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+    topic: 'spot-monitor.new-spot',
+    payload: { callsign: 'W1AW', frequency: 14074000 },
+    publisher: expect.objectContaining({ pluginName: 'spot-monitor' }),
+  }));
+});
+
+it('跟踪已发布消息', () => {
+  const bus = createMockEventBus();
+
+  bus.publish('topic-a', { value: 1 });
+  bus.publish('topic-b', { value: 2 });
+
+  // _published 记录所有已发布消息
+  expect(bus._published).toHaveLength(2);
+  expect(bus._published[0].topic).toBe('topic-a');
+});
+
+it('取消订阅后不再接收消息', () => {
+  const bus = createMockEventBus();
+  const handler = vi.fn();
+
+  const unsub = bus.subscribe('topic', handler);
+  bus.publish('topic', 'first');
+  unsub();
+  bus.publish('topic', 'second');
+
+  expect(handler).toHaveBeenCalledTimes(1);
+});
+```
+
+Mock 对象说明：
+
+| 属性/方法 | 说明 |
+|-----------|------|
+| `_published` | 所有已发布消息的数组，用于断言 |
+| `_subscriptions` | 内部 topic → handler 映射，用于高级检查 |
+| `publish()` | 记录消息到 `_published` 并同步分发给订阅者 |
+| `subscribe()` | 返回取消订阅函数 |
 
 
 #### HostDependencies

--- a/packages/contracts/src/schema/__tests__/plugin-market.schema.test.ts
+++ b/packages/contracts/src/schema/__tests__/plugin-market.schema.test.ts
@@ -67,6 +67,7 @@ describe('plugin market schema', () => {
   });
 
   it('accepts host settings permissions', () => {
+    expect(PluginPermissionSchema.parse('plugin:event-bus')).toBe('plugin:event-bus');
     expect(PluginPermissionSchema.parse('host:hamlib')).toBe('host:hamlib');
     expect(PluginPermissionSchema.parse('operator:transmit-control')).toBe('operator:transmit-control');
     expect(PluginPermissionSchema.parse('settings:ft8')).toBe('settings:ft8');

--- a/packages/contracts/src/schema/plugin.schema.ts
+++ b/packages/contracts/src/schema/plugin.schema.ts
@@ -38,6 +38,7 @@ export type PluginInstanceScope = z.infer<typeof PluginInstanceScopeSchema>;
  */
 export const PluginPermissionSchema = z.enum([
   'network',
+  'plugin:event-bus',
   'host:hamlib',
   'operator:transmit-control',
   'radio:read',

--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -109,6 +109,47 @@ export default plugin;
 
 The whitelist intentionally excludes authentication tokens, operator CRUD, hardware radio connection settings, audio devices, rigctld, OpenWebRX, profiles, and server host/port settings. These APIs are not exposed directly to iframe pages; custom UI should call a server-side page handler with `window.tx5dr.invoke()`.
 
+## Plugin Event Bus Permission
+
+Server-side plugins can exchange in-process messages through `ctx.eventBus` when the manifest declares:
+
+```ts
+permissions: ['plugin:event-bus']
+```
+
+`ctx.eventBus` is optional and should be feature-detected:
+
+```ts
+import type { PluginDefinition } from '@tx5dr/plugin-api';
+
+const plugin: PluginDefinition = {
+  name: 'event-bus-demo',
+  version: '1.0.0',
+  type: 'utility',
+  permissions: ['plugin:event-bus'],
+  onLoad(ctx) {
+    const unsubscribe = ctx.eventBus?.subscribe('plugin.shared.topic', (message) => {
+      ctx.log.info('received bus message', {
+        topic: message.topic,
+        publisher: message.publisher.pluginName,
+      });
+    });
+
+    ctx.eventBus?.publish('plugin.shared.topic', { status: 'ready' });
+    void unsubscribe;
+  },
+};
+
+export default plugin;
+```
+
+- `publish(topic, payload)` sends a best-effort message to current subscribers of the exact same topic.
+- `subscribe(topic, handler)` returns an unsubscribe function.
+- Subscriber failures are isolated and logged by the host instead of being thrown back to the publisher.
+- The host removes subscriptions automatically when the plugin instance unloads.
+
+Use plugin-prefixed topic names such as `plugin.callsign-filter.updated` to avoid accidental collisions.
+
 ## Bridge SDK Types
 
 Plugin iframe pages communicate with the host via the Bridge SDK (`window.tx5dr`), which is automatically injected by the host. To get IDE autocomplete for the Bridge SDK, add the type reference to your project:

--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -56,7 +56,7 @@ export default {
 | Subpath | Description |
 |---------|-------------|
 | `@tx5dr/plugin-api` | Core types: `PluginDefinition`, `PluginContext`, `PluginHooks`, helper interfaces, radio/message types |
-| `@tx5dr/plugin-api/testing` | Mock factories for unit testing: `createMockContext()`, `createMockSlotInfo()`, `createMockParsedMessage()` |
+| `@tx5dr/plugin-api/testing` | Mock factories for unit testing: `createMockContext()`, `createMockSlotInfo()`, `createMockParsedMessage()`, `createMockEventBus()` |
 | `@tx5dr/plugin-api/bridge` | Ambient type declarations for the iframe Bridge SDK (`window.tx5dr`) |
 
 ## Radio Permissions
@@ -109,46 +109,168 @@ export default plugin;
 
 The whitelist intentionally excludes authentication tokens, operator CRUD, hardware radio connection settings, audio devices, rigctld, OpenWebRX, profiles, and server host/port settings. These APIs are not exposed directly to iframe pages; custom UI should call a server-side page handler with `window.tx5dr.invoke()`.
 
-## Plugin Event Bus Permission
+## Plugin Event Bus
 
-Server-side plugins can exchange in-process messages through `ctx.eventBus` when the manifest declares:
+Server-side plugins can exchange in-process messages through `ctx.eventBus`, a topic-based pub/sub bus scoped to the host process. This enables loose coupling between plugins without shared state.
+
+### Permission
+
+Declare `plugin:event-bus` in the manifest to enable the bus:
 
 ```ts
 permissions: ['plugin:event-bus']
 ```
 
-`ctx.eventBus` is optional and should be feature-detected:
+`ctx.eventBus` is optional and should be feature-detected before use.
+
+### API Summary
+
+| Method | Description |
+|--------|-------------|
+| `publish(topic, payload?)` | Fire-and-forget message to all current subscribers of the exact topic. |
+| `subscribe(topic, handler)` | Registers a handler; returns an unsubscribe function. |
+
+Every message received by a subscriber is a `PluginEventBusMessage`:
+
+```ts
+interface PluginEventBusMessage {
+  topic: string;           // The topic this message was published to
+  payload: unknown;        // Arbitrary data set by the publisher
+  timestamp: number;       // Epoch ms when the host dispatched the message
+  publisher: {
+    pluginName: string;    // Publishing plugin's name
+    instanceScope: 'operator' | 'global';
+    operatorId?: string;   // Present when the publisher is operator-scoped
+  };
+}
+```
+
+### Topic Naming Convention
+
+Use dot-separated, plugin-prefixed names to avoid collisions between plugins:
+
+```
+<plugin-name>.<domain>.<event>
+```
+
+Examples:
+- `psk-reporter.spot.sent` — a spot was uploaded to PSK Reporter
+- `callsign-filter.match.found` — a callsign matched a filter rule
+- `logbook-sync.upload.complete` — a logbook sync finished
+
+Avoid generic names like `update` or `message` — they will collide.
+
+### Basic Usage
 
 ```ts
 import type { PluginDefinition } from '@tx5dr/plugin-api';
 
-const plugin: PluginDefinition = {
-  name: 'event-bus-demo',
+// Publisher plugin
+const publisher: PluginDefinition = {
+  name: 'spot-monitor',
   version: '1.0.0',
   type: 'utility',
   permissions: ['plugin:event-bus'],
-  onLoad(ctx) {
-    const unsubscribe = ctx.eventBus?.subscribe('plugin.shared.topic', (message) => {
-      ctx.log.info('received bus message', {
-        topic: message.topic,
-        publisher: message.publisher.pluginName,
-      });
-    });
-
-    ctx.eventBus?.publish('plugin.shared.topic', { status: 'ready' });
-    void unsubscribe;
+  hooks: {
+    onDecode(messages, ctx) {
+      for (const msg of messages) {
+        ctx.eventBus?.publish('spot-monitor.new-spot', {
+          callsign: msg.callsign,
+          frequency: msg.frequencyHz,
+        });
+      }
+    },
   },
 };
 
-export default plugin;
+// Subscriber plugin
+const subscriber: PluginDefinition = {
+  name: 'spot-logger',
+  version: '1.0.0',
+  type: 'utility',
+  permissions: ['plugin:event-bus'],
+  hooks: {
+    onLoad(ctx) {
+      ctx.eventBus?.subscribe('spot-monitor.new-spot', (message) => {
+        ctx.log.info('received spot', {
+          from: message.publisher.pluginName,
+          callsign: (message.payload as any).callsign,
+        });
+      });
+    },
+  },
+};
 ```
 
-- `publish(topic, payload)` sends a best-effort message to current subscribers of the exact same topic.
-- `subscribe(topic, handler)` returns an unsubscribe function.
-- Subscriber failures are isolated and logged by the host instead of being thrown back to the publisher.
-- The host removes subscriptions automatically when the plugin instance unloads.
+### Cross-Operator Communication
 
-Use plugin-prefixed topic names such as `plugin.callsign-filter.updated` to avoid accidental collisions.
+Operator-scoped plugins can communicate across operators on the same host. The `publisher` metadata lets subscribers identify which operator sent the message:
+
+```ts
+ctx.eventBus?.subscribe('qso-monitor.qso-complete', (message) => {
+  const { callsign, band } = message.payload as any;
+  ctx.log.info('QSO completed by another operator', {
+    operator: message.publisher.operatorId,
+    callsign,
+    band,
+  });
+});
+```
+
+### Lifecycle and Error Handling
+
+- **Auto-cleanup**: the host removes all subscriptions when a plugin instance unloads. No manual cleanup required.
+- **Manual unsubscribe**: call the function returned by `subscribe()` to cancel a single subscription early.
+- **Error isolation**: subscriber exceptions (sync or async) are captured and logged by the host. They never propagate back to the publisher.
+- **Delivery order**: subscribers receive messages in registration order. Async handlers are awaited, but the publisher does not wait for completion.
+
+### Testing
+
+Use `createMockEventBus()` from `@tx5dr/plugin-api/testing` to test plugin event bus logic in isolation:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createMockEventBus } from '@tx5dr/plugin-api/testing';
+
+it('publishes spot data', () => {
+  const bus = createMockEventBus({ owner: { pluginName: 'spot-monitor' } });
+  const handler = vi.fn();
+
+  bus.subscribe('spot-monitor.new-spot', handler);
+  bus.publish('spot-monitor.new-spot', { callsign: 'W1AW', frequency: 14074000 });
+
+  expect(handler).toHaveBeenCalledTimes(1);
+  expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+    topic: 'spot-monitor.new-spot',
+    payload: { callsign: 'W1AW', frequency: 14074000 },
+    publisher: expect.objectContaining({ pluginName: 'spot-monitor' }),
+  }));
+});
+
+it('tracks published messages', () => {
+  const bus = createMockEventBus();
+
+  bus.publish('topic-a', { value: 1 });
+  bus.publish('topic-b', { value: 2 });
+
+  expect(bus._published).toHaveLength(2);
+  expect(bus._published[0].topic).toBe('topic-a');
+});
+
+it('unsubscribe prevents further delivery', () => {
+  const bus = createMockEventBus();
+  const handler = vi.fn();
+
+  const unsub = bus.subscribe('topic', handler);
+  bus.publish('topic', 'first');
+  unsub();
+  bus.publish('topic', 'second');
+
+  expect(handler).toHaveBeenCalledTimes(1);
+});
+```
+
+The mock records all published messages in `_published` and exposes the internal `_subscriptions` map for advanced inspection.
 
 ## Bridge SDK Types
 

--- a/packages/plugin-api/src/__tests__/testing-utils.test.ts
+++ b/packages/plugin-api/src/__tests__/testing-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   createMockKVStore,
   createMockLogger,
@@ -147,6 +147,35 @@ describe('plugin-api testing utilities', () => {
       eventBus.publish('plugin.topic', 'second');
       await Promise.resolve();
       expect(received).toEqual(['first']);
+    });
+
+    it('deduplicates the same handler per topic', async () => {
+      const eventBus = createMockEventBus();
+      const handler = vi.fn();
+
+      eventBus.subscribe('plugin.topic', handler);
+      eventBus.subscribe('plugin.topic', handler);
+      eventBus.publish('plugin.topic', 'value');
+      await Promise.resolve();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits operatorId for global-scope publishers', () => {
+      const eventBus = createMockEventBus({
+        owner: {
+          pluginName: 'global-plugin',
+          instanceScope: 'global',
+          operatorId: 'operator-should-be-ignored',
+        },
+      });
+
+      eventBus.publish('plugin.topic', 'value');
+
+      expect(eventBus._published[0]?.publisher).toEqual({
+        pluginName: 'global-plugin',
+        instanceScope: 'global',
+      });
     });
   });
 

--- a/packages/plugin-api/src/__tests__/testing-utils.test.ts
+++ b/packages/plugin-api/src/__tests__/testing-utils.test.ts
@@ -12,6 +12,7 @@ import {
   createMockLogbookAccess,
   createMockBandAccess,
   createMockHostSettingsControl,
+  createMockEventBus,
 } from '../testing/index.js';
 
 describe('plugin-api testing utilities', () => {
@@ -79,6 +80,7 @@ describe('plugin-api testing utilities', () => {
       expect(ctx.operator.grid).toBe('FN31');
       expect(ctx.radio.isConnected).toBe(true);
       expect(ctx.config).toEqual({});
+      expect(typeof ctx.eventBus.publish).toBe('function');
     });
 
     it('does not expose mock host dependencies without permissions', () => {
@@ -119,6 +121,32 @@ describe('plugin-api testing utilities', () => {
       await expect(ctx.settings.ft8.update({ maxSameTransmissionCount: 0 })).resolves.toMatchObject({
         maxSameTransmissionCount: 0,
       });
+    });
+
+    it('accepts an event bus override', () => {
+      const eventBus = createMockEventBus();
+      const ctx = createMockContext({ eventBus });
+      expect(ctx.eventBus).toBe(eventBus);
+    });
+  });
+
+  describe('createMockEventBus', () => {
+    it('publishes to matching subscribers and supports unsubscribe', async () => {
+      const eventBus = createMockEventBus();
+      const received: string[] = [];
+      const unsubscribe = eventBus.subscribe('plugin.topic', async (message) => {
+        received.push(String(message.payload));
+      });
+
+      eventBus.publish('plugin.topic', 'first');
+      await Promise.resolve();
+      expect(received).toEqual(['first']);
+      expect(eventBus._published).toHaveLength(1);
+
+      unsubscribe();
+      eventBus.publish('plugin.topic', 'second');
+      await Promise.resolve();
+      expect(received).toEqual(['first']);
     });
   });
 

--- a/packages/plugin-api/src/context.ts
+++ b/packages/plugin-api/src/context.ts
@@ -9,6 +9,7 @@ import type {
   UIBridge,
   PluginFileStore,
   PluginNetworkControl,
+  PluginEventBus,
 } from './helpers.js';
 import type { LogbookSyncRegistrar } from './sync.js';
 import type { HostSettingsControl } from './settings.js';
@@ -147,6 +148,14 @@ export interface PluginContext {
    * such as WSJT-X UDP belong inside plugins.
    */
   readonly network?: PluginNetworkControl;
+
+  /**
+   * Permission-gated plugin-to-plugin event bus.
+   *
+   * Topics are shared across plugin instances within the same host process.
+   * Treat this capability as optional and feature-detect before use.
+   */
+  readonly eventBus?: PluginEventBus;
 
   /**
    * Host-owned runtime dependencies exposed to plugins.

--- a/packages/plugin-api/src/helpers.ts
+++ b/packages/plugin-api/src/helpers.ts
@@ -134,19 +134,69 @@ export interface PluginNetworkControl {
   readonly udp: PluginUdpControl;
 }
 
+/**
+ * A message delivered through the plugin-to-plugin event bus.
+ *
+ * Every message carries metadata about its publisher so subscribers can
+ * apply routing or filtering logic based on the source plugin.
+ */
 export interface PluginEventBusMessage {
+  /** The topic this message was published to. */
   topic: string;
+  /** Arbitrary payload. The host does not inspect or validate this value. */
   payload: unknown;
+  /** Epoch milliseconds when the host dispatched the message. */
   timestamp: number;
+  /** Identity of the plugin instance that published this message. */
   publisher: {
+    /** Name of the publishing plugin (from its `PluginDefinition.name`). */
     pluginName: string;
+    /** Whether the publisher is a global or per-operator instance. */
     instanceScope: 'operator' | 'global';
+    /** Operator ID when the publisher is an operator-scoped instance. */
     operatorId?: string;
   };
 }
 
+/**
+ * Permission-gated pub/sub bus for in-process plugin-to-plugin communication.
+ *
+ * Topics are plain strings shared across all plugin instances within the same
+ * host process. Messages are delivered synchronously to each subscriber in
+ * subscription order; async handlers are awaited but their errors are captured
+ * and logged by the host rather than propagated to the publisher.
+ *
+ * **Lifecycle**: the host automatically removes all subscriptions owned by a
+ * plugin instance when it unloads. Individual subscriptions can be cancelled
+ * earlier by calling the function returned from {@link subscribe}.
+ *
+ * **Topic naming**: use dot-separated, plugin-prefixed names to avoid
+ * collisions — for example `my-plugin.status.changed` or
+ * `callsign-filter.match.found`.
+ */
 export interface PluginEventBus {
+  /**
+   * Publishes a message to all current subscribers of the given topic.
+   *
+   * This is a fire-and-forget operation. The host guarantees that subscriber
+   * exceptions never propagate back to the caller.
+   *
+   * @param topic - Exact topic string to publish to.
+   * @param payload - Optional arbitrary data. Keep payloads reasonably small.
+   */
   publish(topic: string, payload?: unknown): void;
+
+  /**
+   * Subscribes to messages on the given topic.
+   *
+   * The same handler function instance will only be added once per topic.
+   * Different closures with identical logic are treated as distinct subscribers.
+   *
+   * @param topic - Exact topic string to listen on.
+   * @param handler - Callback invoked for each matching message. May return a
+   *   `Promise`; the host catches rejections and logs them.
+   * @returns An unsubscribe function. Calling it more than once is a no-op.
+   */
   subscribe(
     topic: string,
     handler: (message: PluginEventBusMessage) => void | Promise<void>,

--- a/packages/plugin-api/src/helpers.ts
+++ b/packages/plugin-api/src/helpers.ts
@@ -134,6 +134,25 @@ export interface PluginNetworkControl {
   readonly udp: PluginUdpControl;
 }
 
+export interface PluginEventBusMessage {
+  topic: string;
+  payload: unknown;
+  timestamp: number;
+  publisher: {
+    pluginName: string;
+    instanceScope: 'operator' | 'global';
+    operatorId?: string;
+  };
+}
+
+export interface PluginEventBus {
+  publish(topic: string, payload?: unknown): void;
+  subscribe(
+    topic: string,
+    handler: (message: PluginEventBusMessage) => void | Promise<void>,
+  ): () => void;
+}
+
 /**
  * Control surface for the active operator instance.
  *

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -99,6 +99,8 @@ export type {
   PluginUIPageContext,
   PluginFileStore,
   PluginNetworkControl,
+  PluginEventBus,
+  PluginEventBusMessage,
   PluginUdpControl,
   PluginUdpSocket,
   PluginUdpSocketOptions,

--- a/packages/plugin-api/src/testing/index.ts
+++ b/packages/plugin-api/src/testing/index.ts
@@ -449,9 +449,42 @@ export function createMockNetworkControl(): MockNetworkControl {
 
 // ===== Factory: EventBus =====
 
-export function createMockEventBus(): MockEventBus {
+/**
+ * Options for {@link createMockEventBus}.
+ */
+export interface MockEventBusOptions {
+  /** Publisher metadata injected into every message. Defaults to `mock-plugin` / `operator-0`. */
+  owner?: {
+    pluginName?: string;
+    instanceScope?: 'operator' | 'global';
+    operatorId?: string;
+  };
+}
+
+/**
+ * Creates a mock {@link PluginEventBus} for unit testing plugin code.
+ *
+ * All published messages are recorded in `_published` for assertion.
+ * The internal `_subscriptions` map lets tests inspect active subscriptions.
+ *
+ * @param options - Optional configuration for publisher metadata.
+ * @returns A mock event bus with inspection helpers.
+ *
+ * @example
+ * ```ts
+ * const bus = createMockEventBus({ owner: { pluginName: 'my-plugin' } });
+ * bus.subscribe('topic', handler);
+ * bus.publish('topic', { value: 42 });
+ * expect(bus._published).toHaveLength(1);
+ * expect(bus._published[0].publisher.pluginName).toBe('my-plugin');
+ * ```
+ */
+export function createMockEventBus(options?: MockEventBusOptions): MockEventBus {
   const subscriptions = new Map<string, Array<(message: PluginEventBusMessage) => void | Promise<void>>>();
   const published: PluginEventBusMessage[] = [];
+  const ownerName = options?.owner?.pluginName ?? 'mock-plugin';
+  const ownerScope = options?.owner?.instanceScope ?? 'operator';
+  const ownerId = options?.owner?.operatorId ?? 'operator-0';
 
   return {
     _subscriptions: subscriptions,
@@ -462,9 +495,9 @@ export function createMockEventBus(): MockEventBus {
         payload,
         timestamp: Date.now(),
         publisher: {
-          pluginName: 'mock-plugin',
-          instanceScope: 'operator',
-          operatorId: 'operator-0',
+          pluginName: ownerName,
+          instanceScope: ownerScope,
+          operatorId: ownerId,
         },
       };
       published.push(message);

--- a/packages/plugin-api/src/testing/index.ts
+++ b/packages/plugin-api/src/testing/index.ts
@@ -484,7 +484,9 @@ export function createMockEventBus(options?: MockEventBusOptions): MockEventBus 
   const published: PluginEventBusMessage[] = [];
   const ownerName = options?.owner?.pluginName ?? 'mock-plugin';
   const ownerScope = options?.owner?.instanceScope ?? 'operator';
-  const ownerId = options?.owner?.operatorId ?? 'operator-0';
+  const ownerId = ownerScope === 'operator'
+    ? (options?.owner?.operatorId ?? 'operator-0')
+    : undefined;
 
   return {
     _subscriptions: subscriptions,
@@ -508,8 +510,10 @@ export function createMockEventBus(options?: MockEventBusOptions): MockEventBus 
     },
     subscribe(topic, handler) {
       const handlers = subscriptions.get(topic) ?? [];
-      handlers.push(handler);
-      subscriptions.set(topic, handlers);
+      if (!handlers.includes(handler)) {
+        handlers.push(handler);
+        subscriptions.set(topic, handlers);
+      }
       return () => {
         const current = subscriptions.get(topic);
         if (!current) return;

--- a/packages/plugin-api/src/testing/index.ts
+++ b/packages/plugin-api/src/testing/index.ts
@@ -20,6 +20,8 @@ import type {
   UIBridge,
   PluginFileStore,
   PluginNetworkControl,
+  PluginEventBus,
+  PluginEventBusMessage,
   PluginUdpRemoteInfo,
   PluginUdpSocket,
 } from '../helpers.js';
@@ -80,6 +82,7 @@ export interface MockPluginContext extends PluginContext {
   readonly settings: HostSettingsControl;
   readonly hostDependencies: HostDependencies;
   readonly network: PluginNetworkControl;
+  readonly eventBus: PluginEventBus;
 }
 
 export interface MockUdpSocket extends PluginUdpSocket {
@@ -92,6 +95,11 @@ export interface MockUdpSocket extends PluginUdpSocket {
 
 export interface MockNetworkControl extends PluginNetworkControl {
   readonly _sockets: MockUdpSocket[];
+}
+
+export interface MockEventBus extends PluginEventBus {
+  readonly _subscriptions: Map<string, Array<(message: PluginEventBusMessage) => void | Promise<void>>>;
+  readonly _published: PluginEventBusMessage[];
 }
 
 
@@ -439,6 +447,50 @@ export function createMockNetworkControl(): MockNetworkControl {
   };
 }
 
+// ===== Factory: EventBus =====
+
+export function createMockEventBus(): MockEventBus {
+  const subscriptions = new Map<string, Array<(message: PluginEventBusMessage) => void | Promise<void>>>();
+  const published: PluginEventBusMessage[] = [];
+
+  return {
+    _subscriptions: subscriptions,
+    _published: published,
+    publish(topic: string, payload?: unknown) {
+      const message: PluginEventBusMessage = {
+        topic,
+        payload,
+        timestamp: Date.now(),
+        publisher: {
+          pluginName: 'mock-plugin',
+          instanceScope: 'operator',
+          operatorId: 'operator-0',
+        },
+      };
+      published.push(message);
+      const handlers = [...(subscriptions.get(topic) ?? [])];
+      for (const handler of handlers) {
+        void Promise.resolve(handler(message));
+      }
+    },
+    subscribe(topic, handler) {
+      const handlers = subscriptions.get(topic) ?? [];
+      handlers.push(handler);
+      subscriptions.set(topic, handlers);
+      return () => {
+        const current = subscriptions.get(topic);
+        if (!current) return;
+        const next = current.filter((candidate) => candidate !== handler);
+        if (next.length === 0) {
+          subscriptions.delete(topic);
+          return;
+        }
+        subscriptions.set(topic, next);
+      };
+    },
+  };
+}
+
 // ===== Factory: HostSettingsControl =====
 
 export function createMockHostSettingsControl(overrides?: Partial<HostSettingsControl>): HostSettingsControl {
@@ -533,6 +585,8 @@ export interface MockPluginContextOptions {
   band?: Partial<BandAccess>;
   /** Host settings control overrides. */
   settings?: Partial<HostSettingsControl>;
+  /** Event bus override. */
+  eventBus?: PluginEventBus;
   /** Host dependency overrides. */
   hostDependencies?: HostDependencies;
   /** Manifest permissions to model permission-gated optional host dependencies. */
@@ -569,6 +623,7 @@ export function createMockContext(options?: MockPluginContextOptions): MockPlugi
   const settings = createMockHostSettingsControl(opts.settings);
   const files = createMockFileStore();
   const network = opts.network ?? createMockNetworkControl();
+  const eventBus = opts.eventBus ?? createMockEventBus();
   const hostDependencies = opts.hostDependencies
     ?? (opts.permissions?.includes('host:hamlib') ? createMockHostDependencies() : {});
   const logbookSync = { register() { /* no-op in mock */ } };
@@ -590,6 +645,7 @@ export function createMockContext(options?: MockPluginContextOptions): MockPlugi
     hostDependencies,
     files,
     network,
+    eventBus,
     logbookSync,
   };
 }

--- a/packages/server/src/plugin/PluginContextFactory.ts
+++ b/packages/server/src/plugin/PluginContextFactory.ts
@@ -39,6 +39,7 @@ import { PluginTimerManager } from './PluginTimerManager.js';
 import { PluginUIBridge } from './PluginUIBridge.js';
 import { HostSettingsService } from './HostSettingsService.js';
 import { evaluateAutomaticTargetEligibility } from './AutoTargetEligibility.js';
+import type { PluginEventBusOwner } from './PluginEventBusHost.js';
 import { createLogger } from '../utils/logger.js';
 import type { LoadedPlugin, PluginManagerDeps } from './types.js';
 
@@ -137,6 +138,7 @@ export class PluginContextFactory {
       path.join(pluginStorageDir, 'files'),
     );
     const networkControl = this.createNetworkControl(plugin);
+    const eventBusControl = this.createEventBusControl(plugin, operatorId, instanceScope);
 
     ctx = {
       get config() {
@@ -165,6 +167,7 @@ export class PluginContextFactory {
         ? { hamlib: HOST_HAMLIB_DEPENDENCY }
         : {},
       network: networkControl,
+      eventBus: eventBusControl,
       logbookSync: {
         register: (provider) => {
           this.validateLogbookSyncProvider(plugin, provider);
@@ -177,6 +180,36 @@ export class PluginContextFactory {
     };
 
     return ctx;
+  }
+
+  private createEventBusControl(
+    plugin: LoadedPlugin,
+    operatorId: string | undefined,
+    instanceScope: 'operator' | 'global',
+  ): PluginContext['eventBus'] {
+    if (!plugin.definition.permissions?.includes('plugin:event-bus')) {
+      return undefined;
+    }
+
+    const host = this.deps.pluginEventBusHost;
+    if (!host) {
+      return undefined;
+    }
+
+    const owner: PluginEventBusOwner = {
+      pluginName: plugin.definition.name,
+      instanceScope,
+      operatorId: instanceScope === 'operator' ? operatorId : undefined,
+    };
+
+    return {
+      publish(topic, payload) {
+        host.publish(owner, topic, payload);
+      },
+      subscribe(topic, handler) {
+        return host.subscribe(owner, topic, handler);
+      },
+    };
   }
 
 

--- a/packages/server/src/plugin/PluginEventBusHost.ts
+++ b/packages/server/src/plugin/PluginEventBusHost.ts
@@ -1,0 +1,126 @@
+import type { PluginEventBusMessage } from '@tx5dr/plugin-api';
+
+type PluginEventBusInstanceScope = 'operator' | 'global';
+
+export interface PluginEventBusOwner {
+  pluginName: string;
+  instanceScope: PluginEventBusInstanceScope;
+  operatorId?: string;
+}
+
+type SubscriptionHandler = (message: PluginEventBusMessage) => void | Promise<void>;
+
+interface SubscriptionRecord {
+  owner: PluginEventBusOwner;
+  handler: SubscriptionHandler;
+}
+
+export interface PluginEventBusLogEntry {
+  subscriber: PluginEventBusOwner;
+  message: PluginEventBusMessage;
+  error: unknown;
+}
+
+export class PluginEventBusHost {
+  private readonly subscriptionsByTopic = new Map<string, Set<SubscriptionRecord>>();
+  private readonly subscriptionsByOwnerKey = new Map<string, Set<{ topic: string; record: SubscriptionRecord }>>();
+
+  constructor(
+    private readonly onSubscriberError?: (entry: PluginEventBusLogEntry) => void,
+  ) {}
+
+  publish(owner: PluginEventBusOwner, topic: string, payload?: unknown): void {
+    const message: PluginEventBusMessage = {
+      topic,
+      payload,
+      timestamp: Date.now(),
+      publisher: {
+        pluginName: owner.pluginName,
+        instanceScope: owner.instanceScope,
+        operatorId: owner.operatorId,
+      },
+    };
+
+    const subscribers = [...(this.subscriptionsByTopic.get(topic) ?? [])];
+    for (const subscription of subscribers) {
+      let result: void | Promise<void>;
+      try {
+        result = subscription.handler(message);
+      } catch (error) {
+        this.onSubscriberError?.({
+          subscriber: subscription.owner,
+          message,
+          error,
+        });
+        continue;
+      }
+
+      void Promise.resolve(result).catch((error) => {
+        this.onSubscriberError?.({
+          subscriber: subscription.owner,
+          message,
+          error,
+        });
+      });
+    }
+  }
+
+  subscribe(
+    owner: PluginEventBusOwner,
+    topic: string,
+    handler: SubscriptionHandler,
+  ): () => void {
+    const record: SubscriptionRecord = { owner, handler };
+    const topicSubscriptions = this.subscriptionsByTopic.get(topic) ?? new Set<SubscriptionRecord>();
+    topicSubscriptions.add(record);
+    this.subscriptionsByTopic.set(topic, topicSubscriptions);
+
+    const ownerKey = this.getOwnerKey(owner);
+    const ownerSubscriptions = this.subscriptionsByOwnerKey.get(ownerKey) ?? new Set<{ topic: string; record: SubscriptionRecord }>();
+    const ownerSubscription = { topic, record };
+    ownerSubscriptions.add(ownerSubscription);
+    this.subscriptionsByOwnerKey.set(ownerKey, ownerSubscriptions);
+
+    return () => {
+      this.removeSubscription(ownerKey, ownerSubscription);
+    };
+  }
+
+  unsubscribeAll(owner: PluginEventBusOwner): void {
+    const ownerKey = this.getOwnerKey(owner);
+    const ownerSubscriptions = this.subscriptionsByOwnerKey.get(ownerKey);
+    if (!ownerSubscriptions) {
+      return;
+    }
+
+    for (const ownerSubscription of [...ownerSubscriptions]) {
+      this.removeSubscription(ownerKey, ownerSubscription);
+    }
+  }
+
+  private removeSubscription(
+    ownerKey: string,
+    ownerSubscription: { topic: string; record: SubscriptionRecord },
+  ): void {
+    const topicSubscriptions = this.subscriptionsByTopic.get(ownerSubscription.topic);
+    if (topicSubscriptions) {
+      topicSubscriptions.delete(ownerSubscription.record);
+      if (topicSubscriptions.size === 0) {
+        this.subscriptionsByTopic.delete(ownerSubscription.topic);
+      }
+    }
+
+    const ownerSubscriptions = this.subscriptionsByOwnerKey.get(ownerKey);
+    if (!ownerSubscriptions) {
+      return;
+    }
+    ownerSubscriptions.delete(ownerSubscription);
+    if (ownerSubscriptions.size === 0) {
+      this.subscriptionsByOwnerKey.delete(ownerKey);
+    }
+  }
+
+  private getOwnerKey(owner: PluginEventBusOwner): string {
+    return `${owner.pluginName}:${owner.instanceScope}:${owner.operatorId ?? '__global__'}`;
+  }
+}

--- a/packages/server/src/plugin/PluginEventBusHost.ts
+++ b/packages/server/src/plugin/PluginEventBusHost.ts
@@ -12,6 +12,7 @@ type SubscriptionHandler = (message: PluginEventBusMessage) => void | Promise<vo
 
 interface SubscriptionRecord {
   owner: PluginEventBusOwner;
+  ownerKey: string;
   handler: SubscriptionHandler;
 }
 
@@ -70,12 +71,25 @@ export class PluginEventBusHost {
     topic: string,
     handler: SubscriptionHandler,
   ): () => void {
-    const record: SubscriptionRecord = { owner, handler };
+    const ownerKey = this.getOwnerKey(owner);
     const topicSubscriptions = this.subscriptionsByTopic.get(topic) ?? new Set<SubscriptionRecord>();
+    const existingRecord = [...topicSubscriptions].find((subscription) => (
+      subscription.ownerKey === ownerKey && subscription.handler === handler
+    ));
+    if (existingRecord) {
+      const ownerSubscription = [...(this.subscriptionsByOwnerKey.get(ownerKey) ?? [])]
+        .find((subscription) => subscription.topic === topic && subscription.record === existingRecord);
+      return () => {
+        if (ownerSubscription) {
+          this.removeSubscription(ownerKey, ownerSubscription);
+        }
+      };
+    }
+
+    const record: SubscriptionRecord = { owner, ownerKey, handler };
     topicSubscriptions.add(record);
     this.subscriptionsByTopic.set(topic, topicSubscriptions);
 
-    const ownerKey = this.getOwnerKey(owner);
     const ownerSubscriptions = this.subscriptionsByOwnerKey.get(ownerKey) ?? new Set<{ topic: string; record: SubscriptionRecord }>();
     const ownerSubscription = { topic, record };
     ownerSubscriptions.add(ownerSubscription);

--- a/packages/server/src/plugin/PluginManager.ts
+++ b/packages/server/src/plugin/PluginManager.ts
@@ -35,6 +35,7 @@ import { PluginDevWatcher } from './PluginDevWatcher.js';
 import { PluginHookDispatcher } from './PluginHookDispatcher.js';
 import { DecisionOrchestrator } from './DecisionOrchestrator.js';
 import { PluginContextFactory } from './PluginContextFactory.js';
+import { PluginEventBusHost } from './PluginEventBusHost.js';
 import { LogbookSyncHost } from './LogbookSyncHost.js';
 import { PluginPageSessionStore, type PluginPageSession } from './PluginPageSessionStore.js';
 import {
@@ -92,6 +93,7 @@ export class PluginManager {
   }>>();
   private readonly panelMetaState = new Map<string, PluginPanelMetaPayload>();
   private readonly runtimePanelContributions = new Map<string, PluginUIPanelContributionGroup>();
+  private readonly pluginEventBusHost: PluginEventBusHost;
   private pluginRuntimeLogHistory: PluginLogHistoryEntry[] = [];
   private readonly recordPluginLogHistory = (entry: PluginLogEntry) => {
     this.appendPluginLogHistory({ ...entry });
@@ -113,6 +115,20 @@ export class PluginManager {
   constructor(private deps: PluginManagerDeps) {
     this.loader = new PluginLoader((event) => this.emitPluginRuntimeLog(event));
     this._logbookSyncHost = new LogbookSyncHost();
+    this.pluginEventBusHost = new PluginEventBusHost(({ subscriber, message, error }) => {
+      this.emitPluginRuntimeLog({
+        stage: 'activate',
+        level: 'warn',
+        message: 'Plugin event bus subscriber failed',
+        pluginName: subscriber.pluginName,
+        details: {
+          topic: message.topic,
+          publisher: message.publisher,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    });
+    deps.pluginEventBusHost = this.pluginEventBusHost;
     // Wire the logbook sync registration callback so plugins can register
     // providers via ctx.logbookSync.register().
     deps.registerLogbookSyncProvider = (pluginName, provider) => {
@@ -1761,6 +1777,11 @@ export class PluginManager {
     }
     this.clearPanelMetaForInstance(instance);
     this.clearRuntimePanelContributionsForInstance(instance);
+    this.pluginEventBusHost.unsubscribeAll({
+      pluginName: instance.plugin.definition.name,
+      instanceScope: instance.scope.kind,
+      operatorId: instance.scope.kind === 'operator' ? instance.scope.operatorId : undefined,
+    });
     this._logbookSyncHost.unregisterByPlugin(instance.plugin.definition.name);
     instance.ctx.timers.clearAll();
     await instance.ctx.network?.udp.closeAll().catch(() => {});

--- a/packages/server/src/plugin/__tests__/PluginContextFactory.event-bus.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginContextFactory.event-bus.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'eventemitter3';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { type DigitalRadioEngineEvents, MODES } from '@tx5dr/contracts';
+import type { LoadedPlugin, PluginManagerDeps } from '../types.js';
+import { PluginContextFactory } from '../PluginContextFactory.js';
+import { PluginEventBusHost } from '../PluginEventBusHost.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function createDeps(overrides: Partial<PluginManagerDeps> = {}): PluginManagerDeps {
+  return {
+    eventEmitter: new EventEmitter<DigitalRadioEngineEvents>(),
+    getOperators: () => [],
+    getOperatorById: () => undefined,
+    getCurrentMode: () => MODES.FT8,
+    getOperatorAutomationSnapshot: () => null,
+    requestOperatorCall: () => {},
+    getRadioFrequency: async () => null,
+    setRadioFrequency: () => {},
+    getRadioBand: () => '20m',
+    getRadioConnected: () => true,
+    getLatestSlotPack: () => null,
+    interruptOperatorTransmission: async () => {},
+    hasWorkedCallsign: async () => false,
+    resetOperatorRuntime: () => {},
+    dataDir: '/tmp',
+    ...overrides,
+  };
+}
+
+function createPlugin(permissions: LoadedPlugin['definition']['permissions'] = []): LoadedPlugin {
+  return {
+    definition: {
+      name: 'event-bus-test-plugin',
+      version: '1.0.0',
+      type: 'utility',
+      permissions,
+    },
+    isBuiltIn: false,
+  };
+}
+
+async function createContext(
+  plugin: LoadedPlugin,
+  deps: PluginManagerDeps = createDeps({ pluginEventBusHost: new PluginEventBusHost() }),
+) {
+  const storageDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-event-bus-'));
+  tempDirs.push(storageDir);
+  const factory = new PluginContextFactory(deps);
+  return factory.create(plugin, 'operator-1', 'operator', storageDir, () => {}, () => ({}));
+}
+
+describe('PluginContextFactory event bus access', () => {
+  it('does not expose ctx.eventBus without permission', async () => {
+    const ctx = await createContext(createPlugin());
+    expect(ctx.eventBus).toBeUndefined();
+  });
+
+  it('exposes ctx.eventBus with permission and forwards publisher metadata', async () => {
+    const host = new PluginEventBusHost();
+    const publisherCtx = await createContext(
+      createPlugin(['plugin:event-bus']),
+      createDeps({ pluginEventBusHost: host }),
+    );
+    const subscriberCtx = await createContext(
+      {
+        definition: {
+          name: 'subscriber-plugin',
+          version: '1.0.0',
+          type: 'utility',
+          permissions: ['plugin:event-bus'],
+        },
+        isBuiltIn: false,
+      },
+      createDeps({ pluginEventBusHost: host }),
+    );
+
+    const received = vi.fn();
+    subscriberCtx.eventBus!.subscribe('plugin.topic', received);
+    publisherCtx.eventBus!.publish('plugin.topic', { answer: 42 });
+    await Promise.resolve();
+
+    expect(received).toHaveBeenCalledWith(expect.objectContaining({
+      topic: 'plugin.topic',
+      payload: { answer: 42 },
+      publisher: {
+        pluginName: 'event-bus-test-plugin',
+        instanceScope: 'operator',
+        operatorId: 'operator-1',
+      },
+      timestamp: expect.any(Number),
+    }));
+  });
+});

--- a/packages/server/src/plugin/__tests__/PluginEventBusHost.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginEventBusHost.test.ts
@@ -45,6 +45,20 @@ describe('PluginEventBusHost', () => {
     expect(second).toHaveBeenCalledTimes(1);
   });
 
+  it('deduplicates the same handler for the same owner and topic', async () => {
+    const host = new PluginEventBusHost();
+    const owner = { pluginName: 'subscriber', instanceScope: 'operator' as const, operatorId: 'operator-1' };
+    const handler = vi.fn();
+
+    host.subscribe(owner, 'plugin.topic', handler);
+    host.subscribe(owner, 'plugin.topic', handler);
+
+    host.publish({ pluginName: 'publisher', instanceScope: 'global' }, 'plugin.topic', 'value');
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
   it('captures subscriber errors without throwing to publishers', async () => {
     const onError = vi.fn();
     const host = new PluginEventBusHost(onError);

--- a/packages/server/src/plugin/__tests__/PluginEventBusHost.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginEventBusHost.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PluginEventBusHost } from '../PluginEventBusHost.js';
+
+describe('PluginEventBusHost', () => {
+  it('delivers messages to matching subscribers', async () => {
+    const host = new PluginEventBusHost();
+    const received: unknown[] = [];
+
+    host.subscribe(
+      { pluginName: 'subscriber', instanceScope: 'operator', operatorId: 'operator-1' },
+      'plugin.topic',
+      async (message) => {
+        received.push(message.payload);
+      },
+    );
+
+    host.publish(
+      { pluginName: 'publisher', instanceScope: 'global' },
+      'plugin.topic',
+      { ok: true },
+    );
+    await Promise.resolve();
+
+    expect(received).toEqual([{ ok: true }]);
+  });
+
+  it('supports unsubscribe and unsubscribeAll', async () => {
+    const host = new PluginEventBusHost();
+    const first = vi.fn();
+    const second = vi.fn();
+    const owner = { pluginName: 'subscriber', instanceScope: 'operator' as const, operatorId: 'operator-1' };
+
+    const unsubscribe = host.subscribe(owner, 'plugin.topic', first);
+    host.subscribe(owner, 'plugin.topic', second);
+
+    unsubscribe();
+    host.publish({ pluginName: 'publisher', instanceScope: 'global' }, 'plugin.topic', 'one');
+    await Promise.resolve();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+
+    host.unsubscribeAll(owner);
+    host.publish({ pluginName: 'publisher', instanceScope: 'global' }, 'plugin.topic', 'two');
+    await Promise.resolve();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures subscriber errors without throwing to publishers', async () => {
+    const onError = vi.fn();
+    const host = new PluginEventBusHost(onError);
+
+    host.subscribe(
+      { pluginName: 'subscriber', instanceScope: 'global' },
+      'plugin.topic',
+      async () => {
+        throw new Error('boom');
+      },
+    );
+
+    expect(() => {
+      host.publish({ pluginName: 'publisher', instanceScope: 'global' }, 'plugin.topic', 'value');
+    }).not.toThrow();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      subscriber: expect.objectContaining({ pluginName: 'subscriber' }),
+      message: expect.objectContaining({
+        topic: 'plugin.topic',
+        payload: 'value',
+        publisher: expect.objectContaining({ pluginName: 'publisher' }),
+      }),
+      error: expect.any(Error),
+    }));
+  });
+});

--- a/packages/server/src/plugin/__tests__/PluginManager.event-bus.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.event-bus.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'eventemitter3';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { DigitalRadioEngineEvents } from '@tx5dr/contracts';
+import { MODES } from '@tx5dr/contracts';
+import { RadioOperator } from '@tx5dr/core';
+import { PluginManager } from '../PluginManager.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function writeUserPlugin(dataDir: string, pluginName: string, source: string): Promise<void> {
+  const pluginDir = join(dataDir, 'plugins', pluginName);
+  await mkdir(pluginDir, { recursive: true });
+  await writeFile(join(pluginDir, 'index.mjs'), source, 'utf8');
+}
+
+function createOperator(id: string, callsign: string): RadioOperator {
+  const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+  eventEmitter.on('checkHasWorkedCallsign' as any, (data: { requestId: string }) => {
+    eventEmitter.emit('hasWorkedCallsignResponse' as any, {
+      requestId: data.requestId,
+      hasWorked: false,
+    });
+  });
+
+  return new RadioOperator({
+    id,
+    mode: MODES.FT8,
+    myCallsign: callsign,
+    myGrid: 'OM96',
+    frequency: 7_074_000,
+    transmitCycles: [0],
+    maxQSOTimeoutCycles: 6,
+    maxCallAttempts: 5,
+    autoReplyToCQ: false,
+    autoResumeCQAfterFail: false,
+    autoResumeCQAfterSuccess: false,
+    replyToWorkedStations: false,
+    prioritizeNewCalls: true,
+    targetSelectionPriorityMode: 'dxcc_first',
+  }, eventEmitter);
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createPluginManager(
+  dataDir: string,
+  eventEmitter: EventEmitter<DigitalRadioEngineEvents>,
+  operator: RadioOperator,
+): PluginManager {
+  let pluginManager!: PluginManager;
+  pluginManager = new PluginManager({
+    eventEmitter,
+    getOperators: () => [operator],
+    getOperatorById: (id) => (id === operator.config.id ? operator : undefined),
+    getCurrentMode: () => operator.config.mode,
+    getOperatorAutomationSnapshot: (id) => pluginManager.getOperatorAutomationSnapshot(id),
+    requestOperatorCall: (operatorId, callsign, lastMessage) => {
+      pluginManager.requestCall(operatorId, callsign, lastMessage);
+    },
+    getRadioFrequency: async () => operator.config.frequency,
+    setRadioFrequency: () => {},
+    getRadioBand: () => '40m',
+    getRadioConnected: () => true,
+    getLatestSlotPack: () => null,
+    interruptOperatorTransmission: async () => {},
+    hasWorkedCallsign: async () => false,
+    resetOperatorRuntime: () => {},
+    dataDir,
+  });
+
+  pluginManager.loadConfig({
+    configs: {},
+    operatorStrategies: {
+      [operator.config.id]: 'standard-qso',
+    },
+    operatorSettings: {
+      [operator.config.id]: {
+        'standard-qso': {
+          autoReplyToCQ: false,
+          autoResumeCQAfterFail: false,
+          autoResumeCQAfterSuccess: false,
+          replyToWorkedStations: false,
+          targetSelectionPriorityMode: 'dxcc_first',
+          maxQSOTimeoutCycles: 6,
+          maxCallAttempts: 5,
+        },
+      },
+    },
+  });
+
+  return pluginManager;
+}
+
+describe('PluginManager event bus lifecycle', () => {
+  it('logs subscriber failures without aborting publishers', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-event-bus-errors-'));
+    tempDirs.push(dataDir);
+
+    await writeUserPlugin(dataDir, 'failing-subscriber', `
+      export default {
+        name: 'failing-subscriber',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['plugin:event-bus'],
+        onLoad(ctx) {
+          ctx.eventBus.subscribe('plugin.topic', () => {
+            throw new Error('subscriber boom');
+          });
+        },
+      };
+    `);
+
+    await writeUserPlugin(dataDir, 'publisher-plugin', `
+      export default {
+        name: 'publisher-plugin',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['plugin:event-bus'],
+        onLoad(ctx) {
+          ctx.eventBus.publish('plugin.topic', 'value');
+        },
+      };
+    `);
+
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const operator = createOperator('operator-1', 'BG4IAJ');
+    const pluginManager = createPluginManager(dataDir, eventEmitter, operator);
+    pluginManager.loadConfig({
+      configs: {
+        'qso-udp-broadcast': { enabled: false, settings: {} },
+        'failing-subscriber': { enabled: true, settings: {} },
+        'publisher-plugin': { enabled: true, settings: {} },
+      },
+      operatorStrategies: {
+        [operator.config.id]: 'standard-qso',
+      },
+      operatorSettings: {},
+    });
+
+    await pluginManager.start();
+    await flushAsyncWork();
+
+    const runtimeLogs = pluginManager.getRuntimeLogHistory().filter((entry) => (
+      'source' in entry
+      && entry.source === 'system'
+      && entry.pluginName === 'failing-subscriber'
+      && entry.message === 'Plugin event bus subscriber failed'
+    ));
+    expect(runtimeLogs.length).toBeGreaterThan(0);
+
+    await pluginManager.shutdown();
+  });
+});

--- a/packages/server/src/plugin/__tests__/PluginManager.event-bus.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.event-bus.test.ts
@@ -161,4 +161,78 @@ describe('PluginManager event bus lifecycle', () => {
 
     await pluginManager.shutdown();
   });
+
+  it('removes subscriptions when a plugin instance is deactivated', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-event-bus-cleanup-'));
+    tempDirs.push(dataDir);
+
+    await writeUserPlugin(dataDir, 'subscriber-plugin', `
+      export default {
+        name: 'subscriber-plugin',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['plugin:event-bus'],
+        onLoad(ctx) {
+          ctx.eventBus.subscribe('plugin.topic', (message) => {
+            ctx.log.info('subscriber received event', { payload: message.payload });
+          });
+        },
+      };
+    `);
+
+    await writeUserPlugin(dataDir, 'publisher-plugin', `
+      export default {
+        name: 'publisher-plugin',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['plugin:event-bus'],
+        onLoad(ctx) {
+          ctx.eventBus.publish('plugin.topic', 'published');
+        },
+      };
+    `);
+
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const operator = createOperator('operator-1', 'BG4IAJ');
+    const pluginManager = createPluginManager(dataDir, eventEmitter, operator);
+    pluginManager.loadConfig({
+      configs: {
+        'qso-udp-broadcast': { enabled: false, settings: {} },
+        'subscriber-plugin': { enabled: true, settings: {} },
+        'publisher-plugin': { enabled: false, settings: {} },
+      },
+      operatorStrategies: {
+        [operator.config.id]: 'standard-qso',
+      },
+      operatorSettings: {},
+    });
+
+    await pluginManager.start();
+
+    pluginManager.setPluginEnabled('publisher-plugin', true);
+    await flushAsyncWork();
+
+    const receivedBeforeDeactivate = pluginManager.getRuntimeLogHistory().filter((entry) => (
+      !('source' in entry)
+      && entry.pluginName === 'subscriber-plugin'
+      && entry.message === 'subscriber received event'
+    ));
+    expect(receivedBeforeDeactivate).toHaveLength(1);
+
+    pluginManager.setPluginEnabled('subscriber-plugin', false);
+    await flushAsyncWork();
+    pluginManager.setPluginEnabled('publisher-plugin', false);
+    await flushAsyncWork();
+    pluginManager.setPluginEnabled('publisher-plugin', true);
+    await flushAsyncWork();
+
+    const receivedAfterDeactivate = pluginManager.getRuntimeLogHistory().filter((entry) => (
+      !('source' in entry)
+      && entry.pluginName === 'subscriber-plugin'
+      && entry.message === 'subscriber received event'
+    ));
+    expect(receivedAfterDeactivate).toHaveLength(1);
+
+    await pluginManager.shutdown();
+  });
 });

--- a/packages/server/src/plugin/types.ts
+++ b/packages/server/src/plugin/types.ts
@@ -5,6 +5,7 @@ import type {
   KVStore,
   PluginUIInstanceTarget,
 } from '@tx5dr/plugin-api';
+import type { PluginEventBusHost } from './PluginEventBusHost.js';
 import type {
   PluginPanelMetaPayload,
   PluginUIPanelContributionGroup,
@@ -187,6 +188,7 @@ export interface PluginManagerDeps {
     instanceTarget: PluginUIInstanceTarget,
     pageId?: string,
   ) => import('./PluginPageSessionStore.js').PluginPageSession[];
+  pluginEventBusHost?: PluginEventBusHost;
 }
 
 /**

--- a/packages/web/src/i18n/locales/en/settings.json
+++ b/packages/web/src/i18n/locales/en/settings.json
@@ -622,6 +622,12 @@
         "name": "Network access",
         "description": "Allows the plugin to make HTTP requests and open UDP sockets from this machine."
       },
+      "plugin": {
+        "event-bus": {
+          "name": "Plugin event bus",
+          "description": "Allows publishing and subscribing to in-process Event Bus topics shared with other plugins."
+        }
+      },
       "host": {
         "hamlib": {
           "name": "Host Hamlib dependency",

--- a/packages/web/src/i18n/locales/ja/settings.json
+++ b/packages/web/src/i18n/locales/ja/settings.json
@@ -620,6 +620,12 @@
         "name": "ネットワークアクセス",
         "description": "このマシンから HTTP リクエストを送信し、UDP ソケットを開くことを許可します。"
       },
+      "plugin": {
+        "event-bus": {
+          "name": "プラグイン Event Bus",
+          "description": "他のプラグインと共有される同一プロセス内 Event Bus トピックの publish / subscribe を許可します。"
+        }
+      },
       "host": {
         "hamlib": {
           "name": "ホスト Hamlib 依存関係",

--- a/packages/web/src/i18n/locales/zh/settings.json
+++ b/packages/web/src/i18n/locales/zh/settings.json
@@ -622,6 +622,12 @@
         "name": "网络访问",
         "description": "允许插件从本机发起 HTTP 请求并打开 UDP Socket。"
       },
+      "plugin": {
+        "event-bus": {
+          "name": "插件事件总线",
+          "description": "允许发布和订阅与其他插件共享的进程内 Event Bus topic。"
+        }
+      },
       "host": {
         "hamlib": {
           "name": "宿主 Hamlib 依赖",


### PR DESCRIPTION
## 概述

为插件系统新增 topic-based 发布/订阅事件总线，支持同一宿主进程内的插件间松耦合通信。包含后续修复，使运行时行为与公开合约保持一致。

## 动机

当前插件之间无法直接通信，需要通过宿主中转或共享状态。Event Bus 提供轻量级的进程内消息通道，让插件可以解耦地交换数据（如 spot 通知、QSO 状态、callsign 过滤结果等）。

## 实现

### 核心设计

- **`PluginEventBusHost`**（宿主侧）：topic-based pub/sub，双索引结构（按 topic 查询用于发布，按 owner 查询用于清理）
- **`PluginEventBus`**（插件侧）：`publish(topic, payload?)` + `subscribe(topic, handler)` → 返回取消订阅函数
- **权限门控**：插件 manifest 需声明 `permissions: ['plugin:event-bus']`，否则 `ctx.eventBus` 为 `undefined`

### 关键行为

- 发布是 fire-and-forget，不等待订阅者完成
- 订阅者异常（同步/异步）被宿主捕获记录，不影响发布者
- **handler 去重**：同一 owner + 同一 topic + 同一 handler 函数实例不会被重复添加，防止 `onLoad` 重复调用导致消息重复接收
- 插件实例卸载时宿主自动清理所有订阅
- topic 精确匹配，不支持 wildcard

### 后续修复

- 去重 `subscribe(topic, sameHandler)` 的重复调用
- 对齐 `createMockEventBus()` 的发布者元数据：`operatorId` 仅在 operator 作用域的发布者中存在

## 文件变更

| 层 | 文件 | 说明 |
|----|------|------|
| contracts | `plugin.schema.ts` | 新增 `plugin:event-bus` 权限枚举 |
| plugin-api | `helpers.ts` | `PluginEventBus` / `PluginEventBusMessage` 接口 + JSDoc |
| plugin-api | `context.ts` | `PluginContext.eventBus?` 可选字段 |
| plugin-api | `testing/index.ts` | `createMockEventBus(options?)` 支持自定义 owner，global 作用域自动省略 operatorId，handler 去重 |
| server | `PluginEventBusHost.ts` | 核心 pub/sub 实现，含 handler 去重逻辑 |
| server | `PluginContextFactory.ts` | 权限检查 + owner 构建 + 代理绑定 |
| server | `PluginManager.ts` | 创建 host、注入 deps、deactivateInstance 清理 |

## 测试（35 个）

| 测试文件 | 覆盖内容 |
|---------|---------|
| `PluginEventBusHost.test.ts` | 发布/订阅、取消订阅、**handler 去重**、异常隔离 |
| `PluginContextFactory.event-bus.test.ts` | 无权限不暴露、有权限正确转发元数据 |
| `PluginManager.event-bus.test.ts` | 端到端生命周期：插件间通信 + 订阅者异常日志 + **卸载后订阅清理** |
| `testing-utils.test.ts` | Mock 工具：handler 去重、**global 作用域省略 operatorId** |

## 文档

- `packages/plugin-api/README.md` — 完整英文文档（API 说明、命名约定、跨操作员通信、测试示例）
- `docs/plugin-system.md` — 完整中文开发指南同步更新

## 验证

```bash
yarn workspace @tx5dr/server test src/plugin/__tests__/PluginEventBusHost.test.ts src/plugin/__tests__/PluginContextFactory.event-bus.test.ts src/plugin/__tests__/PluginManager.event-bus.test.ts
yarn workspace @tx5dr/plugin-api test src/__tests__/testing-utils.test.ts
```
