### PR TITLE
fix(web): make About update status follow backend runtime target

### DIFF
--- a/packages/web/src/components/app/DesktopUpdateCard.tsx
+++ b/packages/web/src/components/app/DesktopUpdateCard.tsx
@@ -6,6 +6,12 @@ import type { SystemUpdateStatus } from '@tx5dr/contracts';
 import { createLogger } from '../../utils/logger';
 import type { DesktopUpdateStatus } from '../../types/electron';
 import { useUpdateNotification, type UpdateStatusWithDownloads } from './UpdateNotificationProvider';
+import {
+  canAutoDownloadDesktopUpdate,
+  canInstallDownloadedDesktopUpdate,
+  isElectronUpdateTarget,
+  resolveUpdateTargetLabelKey,
+} from './updateTargetPresentation';
 
 const logger = createLogger('DesktopUpdateCard');
 const DESKTOP_UPDATE_COMMITS_URL = 'https://github.com/boybook/tx-5dr/commits/main';
@@ -60,7 +66,7 @@ function formatVersionValue(value?: string | null): string {
 export function DesktopUpdateCard() {
   const { t } = useTranslation('common');
   const updateNotification = useUpdateNotification();
-  const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
+  const hasElectronUpdater = typeof window !== 'undefined' && !!window.electronAPI?.updater;
   const [desktopUpdateStatus, setDesktopUpdateStatus] = useState<DesktopUpdateState | null>(null);
   const [desktopUpdateBusyAction, setDesktopUpdateBusyAction] = useState<'check' | 'download' | 'install' | 'openWebsite' | 'openCommits' | null>(null);
   const [desktopUpdateError, setDesktopUpdateError] = useState('');
@@ -71,14 +77,6 @@ export function DesktopUpdateCard() {
       if (updateNotification.status) {
         setDesktopUpdateStatus(updateNotification.status as DesktopUpdateState);
         setDesktopUpdateError(updateNotification.status.errorMessage || '');
-        setDesktopUpdateExpanded(false);
-        return;
-      }
-
-      if (window.electronAPI?.updater?.getStatus) {
-        const status = await window.electronAPI.updater.getStatus();
-        setDesktopUpdateStatus(status as DesktopUpdateState);
-        setDesktopUpdateError(status.errorMessage || '');
         setDesktopUpdateExpanded(false);
         return;
       }
@@ -104,28 +102,13 @@ export function DesktopUpdateCard() {
     }
   }, [updateNotification.status]);
 
-  useEffect(() => {
-    if (!window.electronAPI?.updater?.onStatus) return undefined;
-    const handleStatus = (status: DesktopUpdateStatus) => {
-      setDesktopUpdateStatus(status as DesktopUpdateState);
-      setDesktopUpdateError(status.errorMessage || '');
-    };
-    window.electronAPI.updater.onStatus(handleStatus);
-    return () => {
-      window.electronAPI?.updater?.offStatus?.(handleStatus);
-    };
-  }, []);
-
   const handleCheckDesktopUpdate = useCallback(async () => {
     setDesktopUpdateBusyAction('check');
     setDesktopUpdateError('');
     try {
-      let status: UpdateStatusWithDownloads | SystemUpdateStatus | DesktopUpdateStatus | null = null;
+      let status: UpdateStatusWithDownloads | SystemUpdateStatus | null = null;
       if (updateNotification.refresh) {
         status = await updateNotification.refresh();
-      }
-      if (!status && window.electronAPI?.updater?.check) {
-        status = await window.electronAPI.updater.check();
       }
       if (!status) {
         status = await api.getSystemUpdateStatus();
@@ -216,22 +199,18 @@ export function DesktopUpdateCard() {
   const desktopUpdateProgressLabel = desktopUpdateProgress
     ? `${Math.round(desktopUpdateProgress.percent)}%`
     : '';
-  const canAutoDownloadDesktopUpdate = Boolean(
-    isElectron
-    && desktopUpdateStatus?.updateAvailable
-    && desktopUpdateStatus?.autoUpdateSupported
-    && desktopUpdatePhase !== 'downloaded'
-    && desktopUpdatePhase !== 'installing',
-  );
-  const canInstallDownloadedDesktopUpdate = Boolean(isElectron && (desktopUpdateStatus?.downloaded || desktopUpdatePhase === 'downloaded'));
-  const isElectronUpdateTarget = isElectron || desktopUpdateStatus?.target === 'electron-app';
-  const updateTargetLabel = isElectronUpdateTarget
-    ? t('system.updateTargetElectron', 'Electron')
-    : desktopUpdateStatus?.target === 'docker'
-      ? t('system.updateTargetDocker', 'Docker')
-      : desktopUpdateStatus?.target === 'android-runtime'
-        ? t('system.updateTargetAndroidRuntime', 'Android Runtime')
-        : t('system.updateTargetLinuxServer', 'Linux Server');
+  const canAutoDownload = canAutoDownloadDesktopUpdate(desktopUpdateStatus, hasElectronUpdater);
+  const canInstallDownloaded = canInstallDownloadedDesktopUpdate(desktopUpdateStatus, hasElectronUpdater);
+  const isElectronTarget = isElectronUpdateTarget(desktopUpdateStatus);
+  const updateTargetLabel = t(resolveUpdateTargetLabelKey(desktopUpdateStatus), {
+    defaultValue: isElectronTarget
+      ? 'Electron'
+      : desktopUpdateStatus?.target === 'docker'
+        ? 'Docker'
+        : desktopUpdateStatus?.target === 'android-runtime'
+          ? 'Android Runtime'
+          : 'Linux Server',
+  });
   const desktopRecentCommits = desktopUpdateStatus?.recentCommits || [];
 
   return (
@@ -241,7 +220,7 @@ export function DesktopUpdateCard() {
           <div>
             <h4 className={CARD_TITLE_CLASS}>{t('system.updateTitle', 'Version Updates')}</h4>
             <p className={`mt-1 ${CARD_DESC_CLASS}`}>
-              {isElectronUpdateTarget
+              {isElectronTarget
                 ? t('system.desktopUpdateDesc')
                 : t('system.updateWebsiteOnlyDesc', 'Checks whether a newer build exists. This deployment is updated outside the web UI; use the official website for instructions.')}
             </p>
@@ -413,7 +392,7 @@ export function DesktopUpdateCard() {
             {t('system.desktopUpdateCheck')}
           </Button>
 
-          {isElectronUpdateTarget && canAutoDownloadDesktopUpdate && (
+          {isElectronTarget && canAutoDownload && (
             <Button
               color="primary"
               onPress={() => { void handleDownloadDesktopUpdate(); }}
@@ -424,7 +403,7 @@ export function DesktopUpdateCard() {
             </Button>
           )}
 
-          {isElectronUpdateTarget && canInstallDownloadedDesktopUpdate && (
+          {isElectronTarget && canInstallDownloaded && (
             <Button
               color="success"
               onPress={() => { void handleInstallDesktopUpdate(); }}
@@ -435,7 +414,7 @@ export function DesktopUpdateCard() {
             </Button>
           )}
 
-          {isElectronUpdateTarget && !canAutoDownloadDesktopUpdate && !canInstallDownloadedDesktopUpdate && (
+          {isElectronTarget && !canAutoDownload && !canInstallDownloaded && (
             <Button
               color="primary"
               onPress={() => { void handleOpenUpdateWebsite(); }}
@@ -446,7 +425,7 @@ export function DesktopUpdateCard() {
             </Button>
           )}
 
-          {!isElectronUpdateTarget && (
+          {!isElectronTarget && (
             <Button
               color="primary"
               onPress={() => { void handleOpenUpdateWebsite(); }}

--- a/packages/web/src/components/app/UpdateNotificationProvider.tsx
+++ b/packages/web/src/components/app/UpdateNotificationProvider.tsx
@@ -63,19 +63,7 @@ function isSeen(status: SystemUpdateStatus): boolean {
   }
 }
 
-function normalizeElectronStatus(status: DesktopUpdateStatus): UpdateStatusWithDownloads {
-  return {
-    ...status,
-    currentDigest: null,
-    latestDigest: null,
-    websiteUrl: status.websiteUrl || 'https://tx5dr.com',
-  };
-}
-
 async function fetchUpdateStatus(): Promise<UpdateStatusWithDownloads | null> {
-  if (window.electronAPI?.updater?.check) {
-    return normalizeElectronStatus(await window.electronAPI.updater.check());
-  }
   return api.getSystemUpdateStatus();
 }
 

--- a/packages/web/src/components/app/updateTargetPresentation.test.ts
+++ b/packages/web/src/components/app/updateTargetPresentation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canAutoDownloadDesktopUpdate,
+  canInstallDownloadedDesktopUpdate,
+  isElectronUpdateTarget,
+  resolveUpdateTargetLabelKey,
+} from './updateTargetPresentation';
+
+describe('updateTargetPresentation', () => {
+  it('resolves backend targets without treating non-electron deployments as electron', () => {
+    expect(isElectronUpdateTarget({ target: 'docker' })).toBe(false);
+    expect(resolveUpdateTargetLabelKey({ target: 'docker' })).toBe('system.updateTargetDocker');
+    expect(resolveUpdateTargetLabelKey({ target: 'linux-server' })).toBe('system.updateTargetLinuxServer');
+    expect(resolveUpdateTargetLabelKey({ target: 'android-runtime' })).toBe('system.updateTargetAndroidRuntime');
+  });
+
+  it('only allows auto download for electron targets with updater support', () => {
+    expect(canAutoDownloadDesktopUpdate({
+      target: 'docker',
+      updateAvailable: true,
+      autoUpdateSupported: true,
+      phase: 'available',
+    }, true)).toBe(false);
+
+    expect(canAutoDownloadDesktopUpdate({
+      target: 'electron-app',
+      updateAvailable: true,
+      autoUpdateSupported: true,
+      phase: 'available',
+    }, true)).toBe(true);
+  });
+
+  it('only allows install for downloaded electron targets with updater support', () => {
+    expect(canInstallDownloadedDesktopUpdate({
+      target: 'linux-server',
+      updateAvailable: true,
+      downloaded: true,
+      phase: 'downloaded',
+    }, true)).toBe(false);
+
+    expect(canInstallDownloadedDesktopUpdate({
+      target: 'electron-app',
+      updateAvailable: true,
+      downloaded: true,
+      phase: 'downloaded',
+    }, true)).toBe(true);
+  });
+});

--- a/packages/web/src/components/app/updateTargetPresentation.ts
+++ b/packages/web/src/components/app/updateTargetPresentation.ts
@@ -1,0 +1,40 @@
+import type { SystemUpdateStatus } from '@tx5dr/contracts';
+import type { DesktopUpdateStatus } from '../../types/electron';
+
+type UpdateTargetStatus = Pick<SystemUpdateStatus, 'target' | 'updateAvailable'> & {
+  autoUpdateSupported?: boolean;
+  downloaded?: boolean;
+  phase?: DesktopUpdateStatus['phase'];
+};
+
+export function isElectronUpdateTarget(status?: Pick<SystemUpdateStatus, 'target'> | null): boolean {
+  return status?.target === 'electron-app';
+}
+
+export function resolveUpdateTargetLabelKey(status?: Pick<SystemUpdateStatus, 'target'> | null):
+  | 'system.updateTargetElectron'
+  | 'system.updateTargetDocker'
+  | 'system.updateTargetAndroidRuntime'
+  | 'system.updateTargetLinuxServer' {
+  if (status?.target === 'electron-app') return 'system.updateTargetElectron';
+  if (status?.target === 'docker') return 'system.updateTargetDocker';
+  if (status?.target === 'android-runtime') return 'system.updateTargetAndroidRuntime';
+  return 'system.updateTargetLinuxServer';
+}
+
+export function canAutoDownloadDesktopUpdate(
+  status: UpdateTargetStatus | null,
+  hasElectronUpdater: boolean,
+): boolean {
+  if (!hasElectronUpdater || !isElectronUpdateTarget(status)) return false;
+  if (!status?.updateAvailable || !status.autoUpdateSupported) return false;
+  return status.phase !== 'downloaded' && status.phase !== 'installing';
+}
+
+export function canInstallDownloadedDesktopUpdate(
+  status: UpdateTargetStatus | null,
+  hasElectronUpdater: boolean,
+): boolean {
+  if (!hasElectronUpdater || !isElectronUpdateTarget(status)) return false;
+  return Boolean(status.downloaded || status.phase === 'downloaded');
+}


### PR DESCRIPTION
## 变更说明

修复“设置 -> 关于 -> 版本更新”卡片错误根据前端运行环境显示更新状态的问题。

此前该卡片在 Electron 或特定浏览器环境下，会优先使用客户端 updater 状态，因此可能把实际运行在 `docker`、`linux-server` 或 `android-runtime` 的后端错误显示成桌面端更新状态。  
本次修改后，关于页版本更新信息统一以后端 `/api/system/update-status` 返回结果为准。

## 主要修改

- `DesktopUpdateCard`
  - 初始加载与“检查更新”固定调用后端更新状态接口
  - 移除 Electron updater 对关于页卡片状态的覆盖
  - 更新目标类型判断仅基于后端返回的 `target`
  - 自动下载/安装按钮仅在后端明确返回 `electron-app` 且前端存在 updater 能力时显示

- `UpdateNotificationProvider`
  - 统一通过后端接口获取更新状态，避免通知状态混入客户端 Electron updater 结果

- 测试
  - 新增前端单元测试，覆盖 Docker / Linux Server / Android Runtime 场景
  - 验证这些后端目标不会被 Electron 客户端误判为 `electron-app`

## 影响范围

- 设置页“关于”中的版本更新卡片
- 更新状态通知的数据来源

## 验证

- `yarn workspace @tx5dr/web lint`
- `yarn test src/components/app/updateTargetPresentation.test.ts`
- `yarn build`

## 预期结果

在 Electron 或浏览器访问远端服务时，关于页版本更新卡片将正确显示后端真实运行形态，例如：

- `Docker`
- `Linux Server`
- `Android Runtime`

而不会再根据前端客户端系统错误切换显示。