### PR TITLE
feat(layout): add resizable digital right workspace for FT8/FT4 operators

### DIFF
--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -921,9 +921,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       className="relative border border-divider rounded-lg overflow-hidden transition-all duration-300 ease-in-out cursor-default select-none"
       style={{
         transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)',
-        boxShadow: operators.length > 1 && currentOperatorId === operatorStatus.id
-          ? '0 0 0 2px rgba(255, 166, 0, 0.5)'
-          : 'none',
+        boxShadow: operators.length > 1 && currentOperatorId === operatorStatus.id ? '0 0 0 2px rgba(255, 166, 0, 0.5)' : 'none'
       }}
       onClick={() => {
         setCurrentOperatorId(operatorStatus.id);

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -921,7 +921,9 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       className="relative border border-divider rounded-lg overflow-hidden transition-all duration-300 ease-in-out cursor-default select-none"
       style={{
         transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)',
-        boxShadow: operators.length > 1 && currentOperatorId === operatorStatus.id ? '0 0 0 2px rgba(255, 166, 0, 0.5)' : 'none'
+        boxShadow: operators.length > 1 && currentOperatorId === operatorStatus.id
+          ? 'inset 0 0 0 2px rgba(255, 166, 0, 0.5)'
+          : 'none',
       }}
       onClick={() => {
         setCurrentOperatorId(operatorStatus.id);

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -922,7 +922,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       style={{
         transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)',
         boxShadow: operators.length > 1 && currentOperatorId === operatorStatus.id
-          ? 'inset 0 0 0 2px rgba(255, 166, 0, 0.5)'
+          ? '0 0 0 2px rgba(255, 166, 0, 0.5)'
           : 'none',
       }}
       onClick={() => {

--- a/packages/web/src/i18n/locales/en/common.json
+++ b/packages/web/src/i18n/locales/en/common.json
@@ -34,6 +34,9 @@
     "operator": "Operator",
     "admin": "Admin"
   },
+  "rightLayout": {
+    "resetSplitToAuto": "Double-click to restore adaptive layout"
+  },
   "status": {
     "loading": "Loading...",
     "connected": "Connected",

--- a/packages/web/src/i18n/locales/ja/common.json
+++ b/packages/web/src/i18n/locales/ja/common.json
@@ -34,6 +34,9 @@
     "operator": "オペレーター",
     "admin": "管理者"
   },
+  "rightLayout": {
+    "resetSplitToAuto": "ダブルクリックで自動レイアウトに戻す"
+  },
   "status": {
     "loading": "読み込み中...",
     "connected": "接続済み",

--- a/packages/web/src/i18n/locales/zh/common.json
+++ b/packages/web/src/i18n/locales/zh/common.json
@@ -34,6 +34,9 @@
     "operator": "操作员",
     "admin": "管理员"
   },
+  "rightLayout": {
+    "resetSplitToAuto": "双击恢复自适应布局"
+  },
   "status": {
     "loading": "加载中...",
     "connected": "已连接",

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -373,10 +373,10 @@ export const RightLayout: React.FC = () => {
       <div className="flex-1 p-2 pt-0 md:p-5 md:pt-0 flex flex-col gap-2 md:gap-4 min-h-0 overflow-hidden">
         {isMobile ? (
           <>
-            <div className="relative z-0 flex-1 min-h-0 overflow-hidden">
+            <div className="relative z-0 min-h-0 flex-1 overflow-hidden">
               <MyRelatedFramesTable className="h-full" />
             </div>
-            <div className="relative z-10 flex-shrink-0">
+            <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain">
               <RadioOperatorList onCreateOperator={handleCreateOperator} />
             </div>
           </>

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -84,6 +84,7 @@ export const RightLayout: React.FC = () => {
   const activeSplitPointerIdRef = useRef<number | null>(null);
   const dragStartYRef = useRef(0);
   const dragStartSplitPercentRef = useRef(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+  const wasDraggingSplitRef = useRef(false);
   const showAuthenticatedIdentity = Boolean(authState.role) && (Boolean(authState.jwt) || !authState.authEnabled);
   const showLoginEntry = authState.authEnabled && !authState.jwt && authState.isPublicViewer;
   const automationOperatorId = currentOperatorId || operators[0]?.id;
@@ -241,7 +242,14 @@ export const RightLayout: React.FC = () => {
   }, [handleSplitPointerEnd, handleSplitPointerMove, isDraggingSplit]);
 
   useEffect(() => {
-    if (!shouldPersistRightLayoutSplit({ isMobile, isDraggingSplit })) {
+    const wasDraggingSplit = wasDraggingSplitRef.current;
+    wasDraggingSplitRef.current = isDraggingSplit;
+
+    if (!shouldPersistRightLayoutSplit({
+      isMobile,
+      wasDraggingSplit,
+      isDraggingSplit,
+    })) {
       return;
     }
 

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -373,7 +373,7 @@ export const RightLayout: React.FC = () => {
                 isDragging={isDraggingSplit}
                 onMouseDown={handleSplitMouseDown}
               />
-              <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+              <div className="relative z-10 min-h-0 flex-1 overflow-y-scroll overscroll-contain [scrollbar-gutter:stable]">
                 <RadioOperatorList onCreateOperator={handleCreateOperator} />
               </div>
             </div>

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -24,9 +24,12 @@ import {
   clampRightLayoutSplitPercent,
   DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
   getStoredRightLayoutSplitPercent,
+  isActiveRightLayoutSplitPointer,
   getRightLayoutPaneHeights,
   RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX,
   saveRightLayoutSplitPercent,
+  shouldPersistRightLayoutSplit,
+  shouldStartRightLayoutSplitPointerDrag,
 } from './rightLayoutSplitPreferences';
 
 function RightLayoutPaneDivider({
@@ -172,13 +175,12 @@ export const RightLayout: React.FC = () => {
   }, [isMobile, workspaceHeight]);
 
   const handleSplitPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (isMobile) {
-      return;
-    }
-    if (!event.isPrimary) {
-      return;
-    }
-    if (event.pointerType === 'mouse' && event.button !== 0) {
+    if (!shouldStartRightLayoutSplitPointerDrag({
+      isMobile,
+      isPrimary: event.isPrimary,
+      pointerType: event.pointerType,
+      button: event.button,
+    })) {
       return;
     }
 
@@ -191,7 +193,7 @@ export const RightLayout: React.FC = () => {
   }, [isMobile, splitPercent]);
 
   const handleSplitPointerEnd = useCallback((event: PointerEvent) => {
-    if (activeSplitPointerIdRef.current !== event.pointerId) {
+    if (!isActiveRightLayoutSplitPointer(activeSplitPointerIdRef.current, event.pointerId)) {
       return;
     }
     activeSplitPointerIdRef.current = null;
@@ -199,7 +201,7 @@ export const RightLayout: React.FC = () => {
   }, []);
 
   const handleSplitPointerMove = useCallback((event: PointerEvent) => {
-    if (activeSplitPointerIdRef.current !== event.pointerId) {
+    if (!isActiveRightLayoutSplitPointer(activeSplitPointerIdRef.current, event.pointerId)) {
       return;
     }
     if (!splitWorkspaceRef.current) {
@@ -239,7 +241,7 @@ export const RightLayout: React.FC = () => {
   }, [handleSplitPointerEnd, handleSplitPointerMove, isDraggingSplit]);
 
   useEffect(() => {
-    if (isMobile || isDraggingSplit) {
+    if (!shouldPersistRightLayoutSplit({ isMobile, isDraggingSplit })) {
       return;
     }
 

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -22,8 +22,10 @@ import { useTranslation } from 'react-i18next';
 import { OPEN_ACCOUNT_SECURITY_MODAL_EVENT } from '../components/app/GlobalModalHost';
 import {
   clampRightLayoutSplitPercent,
+  clearRightLayoutSplitPercent,
   DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
   getStoredRightLayoutSplitPercent,
+  hasStoredRightLayoutSplit,
   isActiveRightLayoutSplitPointer,
   getRightLayoutPaneHeights,
   RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX,
@@ -35,9 +37,13 @@ import {
 function RightLayoutPaneDivider({
   isDragging,
   onPointerDown,
+  onDoubleClick,
+  resetHint,
 }: {
   isDragging: boolean;
   onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onDoubleClick: () => void;
+  resetHint: string;
 }) {
   return (
     <div
@@ -47,6 +53,8 @@ function RightLayoutPaneDivider({
       ].join(' ')}
       style={{ height: `${RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX}px` }}
       onPointerDown={onPointerDown}
+      onDoubleClick={onDoubleClick}
+      title={resetHint}
     >
       <div className="relative h-full w-full">
         <div
@@ -76,11 +84,15 @@ export const RightLayout: React.FC = () => {
   const { state: authState, logout } = useAuth();
   const [selectedMode, setSelectedMode] = useState<string>('auto5');
   const [loginPopoverOpen, setLoginPopoverOpen] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
   const [splitPercent, setSplitPercent] = useState(() => getStoredRightLayoutSplitPercent());
+  // 用户未拖拽过分割条时保持 main 的经典布局（表格占据剩余空间、操作员区内容自然高度），
+  // 仅在用户手动拖拽后切换到固定比例分割模式。
+  const [hasCustomSplit, setHasCustomSplit] = useState(() => hasStoredRightLayoutSplit());
   const [workspaceHeight, setWorkspaceHeight] = useState(0);
   const [isDraggingSplit, setIsDraggingSplit] = useState(false);
   const splitWorkspaceRef = useRef<HTMLDivElement | null>(null);
+  const topPaneRef = useRef<HTMLDivElement | null>(null);
+  const pendingAutoConvertRef = useRef<number | null>(null);
   const activeSplitPointerIdRef = useRef<number | null>(null);
   const dragStartYRef = useRef(0);
   const dragStartSplitPercentRef = useRef(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
@@ -115,25 +127,6 @@ export const RightLayout: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const mediaQuery = window.matchMedia('(max-width: 767px)');
-    setIsMobile(mediaQuery.matches);
-
-    const handleChange = (event: MediaQueryListEvent) => {
-      setIsMobile(event.matches);
-    };
-
-    mediaQuery.addEventListener('change', handleChange);
-    return () => {
-      mediaQuery.removeEventListener('change', handleChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isMobile) {
-      setWorkspaceHeight(0);
-      return;
-    }
-
     const measureWorkspace = () => {
       const nextHeight = splitWorkspaceRef.current?.clientHeight ?? 0;
       setWorkspaceHeight((currentHeight) => currentHeight === nextHeight ? currentHeight : nextHeight);
@@ -156,10 +149,10 @@ export const RightLayout: React.FC = () => {
       resizeObserver?.disconnect();
       window.removeEventListener('resize', measureWorkspace);
     };
-  }, [isMobile]);
+  }, []);
 
   useEffect(() => {
-    if (isMobile) {
+    if (!hasCustomSplit) {
       return;
     }
 
@@ -173,11 +166,10 @@ export const RightLayout: React.FC = () => {
         containerHeight: workspaceHeight,
       });
     });
-  }, [isMobile, workspaceHeight]);
+  }, [hasCustomSplit, workspaceHeight]);
 
   const handleSplitPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (!shouldStartRightLayoutSplitPointerDrag({
-      isMobile,
       hasActivePointer: activeSplitPointerIdRef.current !== null,
       isPrimary: event.isPrimary,
       pointerType: event.pointerType,
@@ -191,16 +183,43 @@ export const RightLayout: React.FC = () => {
     event.currentTarget.setPointerCapture(event.pointerId);
     activeSplitPointerIdRef.current = event.pointerId;
     dragStartYRef.current = event.clientY;
-    dragStartSplitPercentRef.current = splitPercent;
+
+    // 首次从自适应布局开始拖拽时，按当前实际像素高度换算起始比例；
+    // 仅当指针真正移动后才切换为手动模式（pendingAutoConvertRef 在 move 中消费），
+    // 避免单击分割条（零位移）就退出自适应并写入 localStorage
+    let startSplitPercent = splitPercent;
+    if (!hasCustomSplit) {
+      const containerHeight = splitWorkspaceRef.current?.clientHeight ?? 0;
+      const topPaneHeight = topPaneRef.current?.clientHeight ?? 0;
+      // 与 getRightLayoutPaneHeights 保持一致：以扣除分割条后的可用高度为基准换算
+      const usableHeight = containerHeight - RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX;
+      if (usableHeight > 0 && topPaneHeight > 0) {
+        startSplitPercent = clampRightLayoutSplitPercent({
+          splitPercent: (topPaneHeight / usableHeight) * 100,
+          containerHeight,
+        });
+      }
+      pendingAutoConvertRef.current = startSplitPercent;
+    }
+
+    dragStartSplitPercentRef.current = startSplitPercent;
     setIsDraggingSplit(true);
-  }, [isMobile, splitPercent]);
+  }, [hasCustomSplit, splitPercent]);
 
   const handleSplitPointerEnd = useCallback((event: PointerEvent) => {
     if (!isActiveRightLayoutSplitPointer(activeSplitPointerIdRef.current, event.pointerId)) {
       return;
     }
     activeSplitPointerIdRef.current = null;
+    pendingAutoConvertRef.current = null;
     setIsDraggingSplit(false);
+  }, []);
+
+  // 双击分割条：清除持久化的分割比例，恢复自适应（经典）布局
+  const handleSplitDividerDoubleClick = useCallback(() => {
+    clearRightLayoutSplitPercent();
+    setSplitPercent(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+    setHasCustomSplit(false);
   }, []);
 
   const handleSplitPointerMove = useCallback((event: PointerEvent) => {
@@ -218,6 +237,13 @@ export const RightLayout: React.FC = () => {
     const containerHeight = splitWorkspaceRef.current.clientHeight;
     if (containerHeight <= 0) {
       return;
+    }
+
+    // 指针真正移动时才从自适应切换为手动模式（单击不切换）
+    if (pendingAutoConvertRef.current !== null) {
+      setSplitPercent(pendingAutoConvertRef.current);
+      setHasCustomSplit(true);
+      pendingAutoConvertRef.current = null;
     }
 
     const deltaPercent = ((event.clientY - dragStartYRef.current) / containerHeight) * 100;
@@ -252,15 +278,19 @@ export const RightLayout: React.FC = () => {
     wasDraggingSplitRef.current = isDraggingSplit;
 
     if (!shouldPersistRightLayoutSplit({
-      isMobile,
       wasDraggingSplit,
       isDraggingSplit,
     })) {
       return;
     }
 
+    // 单击未拖动（未切换手动模式）时不落盘
+    if (!hasCustomSplit) {
+      return;
+    }
+
     saveRightLayoutSplitPercent(splitPercent);
-  }, [isDraggingSplit, isMobile, splitPercent]);
+  }, [isDraggingSplit, hasCustomSplit, splitPercent]);
 
   const desktopPaneHeights = getRightLayoutPaneHeights({
     splitPercent,
@@ -383,39 +413,58 @@ export const RightLayout: React.FC = () => {
         </div>
       </div>
       
-      {/* 主内容区域 */}
+      {/* 主内容区域（移动端与桌面端统一：自适应默认 + 可拖拽手动分割 + 双击恢复） */}
       <div className="flex-1 p-2 pt-0 md:p-5 md:pt-0 flex flex-col gap-2 md:gap-4 min-h-0 overflow-hidden">
-        {isMobile ? (
-          <>
-            <div className="relative z-0 min-h-0 flex-1 overflow-hidden">
-              <MyRelatedFramesTable className="h-full" />
-            </div>
-            <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pt-1 pb-2">
-              <RadioOperatorList onCreateOperator={handleCreateOperator} />
-            </div>
-          </>
-        ) : (
-          <div ref={splitWorkspaceRef} className="flex-1 min-h-0 overflow-hidden">
-            <div className="flex h-full min-h-0 flex-col overflow-hidden">
-              <div
-                className="relative z-0 min-h-0 overflow-hidden"
-                style={workspaceHeight > 0 ? { height: `${desktopPaneHeights.topPaneHeightPx}px` } : { height: `${splitPercent}%` }}
-              >
-                <MyRelatedFramesTable className="h-full" />
-              </div>
-              <RightLayoutPaneDivider
-                isDragging={isDraggingSplit}
-                onPointerDown={handleSplitPointerDown}
-              />
-              <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pt-1 pb-2 [scrollbar-gutter:stable]">
-                <RadioOperatorList onCreateOperator={handleCreateOperator} />
-              </div>
-            </div>
+        <div ref={splitWorkspaceRef} className="flex-1 min-h-0 overflow-hidden">
+          <div className="flex h-full min-h-0 flex-col overflow-hidden">
+            {hasCustomSplit ? (
+              <>
+                {/* 手动模式：分割比例即顶栏精确高度；底部容器（操作员区 + RadioControl）占据剩余空间 */}
+                {/* 拖拽可整体调整底部容器大小，卡片与 RadioControl 间距由拖拽决定，单个操作员时也可消除 */}
+                <div
+                  ref={topPaneRef}
+                  className="relative z-0 min-h-0 overflow-hidden"
+                  style={workspaceHeight > 0 ? { height: `${desktopPaneHeights.topPaneHeightPx}px` } : { height: `${splitPercent}%` }}
+                >
+                  <MyRelatedFramesTable className="h-full" />
+                </div>
+                <RightLayoutPaneDivider
+                  isDragging={isDraggingSplit}
+                  onPointerDown={handleSplitPointerDown}
+                  onDoubleClick={handleSplitDividerDoubleClick}
+                  resetHint={t('rightLayout.resetSplitToAuto')}
+                />
+                <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pt-2 pb-4 [scrollbar-gutter:stable]">
+                  <RadioOperatorList onCreateOperator={handleCreateOperator} />
+                </div>
+                <div className="relative z-10 flex-shrink-0">
+                  <RadioControl onOpenRadioSettings={handleOpenRadioSettings} />
+                </div>
+              </>
+            ) : (
+              <>
+                {/* 默认自适应布局：表格占据剩余空间，底部容器（操作员区 + RadioControl）跟随内容自然高度（上限 70%），同 main 经典行为 */}
+                <div ref={topPaneRef} className="relative z-0 flex-1 min-h-0 overflow-hidden">
+                  <MyRelatedFramesTable className="h-full" />
+                </div>
+                <RightLayoutPaneDivider
+                  isDragging={isDraggingSplit}
+                  onPointerDown={handleSplitPointerDown}
+                  onDoubleClick={handleSplitDividerDoubleClick}
+                  resetHint={t('rightLayout.resetSplitToAuto')}
+                />
+                <div className="relative z-10 flex-shrink-0 min-h-0 max-h-[70%] flex flex-col overflow-hidden">
+                  {/* 间距与 main 对齐：分割条 8px + pt-2 8px = 16px（原 gap-4）；pb-4 16px 同理 */}
+                  <div className="min-h-0 overflow-y-auto overscroll-contain px-1 pt-2 pb-4 [scrollbar-gutter:stable]">
+                    <RadioOperatorList onCreateOperator={handleCreateOperator} />
+                  </div>
+                  <div className="relative z-10 flex-shrink-0">
+                    <RadioControl onOpenRadioSettings={handleOpenRadioSettings} />
+                  </div>
+                </div>
+              </>
+            )}
           </div>
-        )}
-
-        <div className="relative z-10 flex-shrink-0">
-          <RadioControl onOpenRadioSettings={handleOpenRadioSettings} />
         </div>
       </div>
       </div>

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -178,6 +178,7 @@ export const RightLayout: React.FC = () => {
   const handleSplitPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (!shouldStartRightLayoutSplitPointerDrag({
       isMobile,
+      hasActivePointer: activeSplitPointerIdRef.current !== null,
       isPrimary: event.isPrimary,
       pointerType: event.pointerType,
       button: event.button,
@@ -187,6 +188,7 @@ export const RightLayout: React.FC = () => {
 
     event.preventDefault();
     event.stopPropagation();
+    event.currentTarget.setPointerCapture(event.pointerId);
     activeSplitPointerIdRef.current = event.pointerId;
     dragStartYRef.current = event.clientY;
     dragStartSplitPercentRef.current = splitPercent;
@@ -205,6 +207,10 @@ export const RightLayout: React.FC = () => {
     if (!isActiveRightLayoutSplitPointer(activeSplitPointerIdRef.current, event.pointerId)) {
       return;
     }
+    if (event.buttons === 0) {
+      handleSplitPointerEnd(event);
+      return;
+    }
     if (!splitWorkspaceRef.current) {
       return;
     }
@@ -219,7 +225,7 @@ export const RightLayout: React.FC = () => {
       splitPercent: dragStartSplitPercentRef.current + deltaPercent,
       containerHeight,
     }));
-  }, []);
+  }, [handleSplitPointerEnd]);
 
   useEffect(() => {
     if (!isDraggingSplit) {

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -31,19 +31,19 @@ import {
 
 function RightLayoutPaneDivider({
   isDragging,
-  onMouseDown,
+  onPointerDown,
 }: {
   isDragging: boolean;
-  onMouseDown: (event: React.MouseEvent) => void;
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
 }) {
   return (
     <div
       className={[
-        'group flex-shrink-0 cursor-row-resize transition-all duration-200',
+        'group touch-none flex-shrink-0 cursor-row-resize transition-all duration-200',
         isDragging ? 'bg-primary-400' : 'bg-transparent hover:bg-primary-200',
       ].join(' ')}
       style={{ height: `${RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX}px` }}
-      onMouseDown={onMouseDown}
+      onPointerDown={onPointerDown}
     >
       <div className="relative h-full w-full">
         <div
@@ -78,6 +78,7 @@ export const RightLayout: React.FC = () => {
   const [workspaceHeight, setWorkspaceHeight] = useState(0);
   const [isDraggingSplit, setIsDraggingSplit] = useState(false);
   const splitWorkspaceRef = useRef<HTMLDivElement | null>(null);
+  const activeSplitPointerIdRef = useRef<number | null>(null);
   const dragStartYRef = useRef(0);
   const dragStartSplitPercentRef = useRef(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
   const showAuthenticatedIdentity = Boolean(authState.role) && (Boolean(authState.jwt) || !authState.authEnabled);
@@ -170,22 +171,37 @@ export const RightLayout: React.FC = () => {
     });
   }, [isMobile, workspaceHeight]);
 
-  const handleSplitMouseDown = useCallback((event: React.MouseEvent) => {
+  const handleSplitPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (isMobile) {
+      return;
+    }
+    if (!event.isPrimary) {
+      return;
+    }
+    if (event.pointerType === 'mouse' && event.button !== 0) {
       return;
     }
 
     event.preventDefault();
+    event.stopPropagation();
+    activeSplitPointerIdRef.current = event.pointerId;
     dragStartYRef.current = event.clientY;
     dragStartSplitPercentRef.current = splitPercent;
     setIsDraggingSplit(true);
   }, [isMobile, splitPercent]);
 
-  const handleSplitMouseUp = useCallback(() => {
+  const handleSplitPointerEnd = useCallback((event: PointerEvent) => {
+    if (activeSplitPointerIdRef.current !== event.pointerId) {
+      return;
+    }
+    activeSplitPointerIdRef.current = null;
     setIsDraggingSplit(false);
   }, []);
 
-  const handleSplitMouseMove = useCallback((event: MouseEvent) => {
+  const handleSplitPointerMove = useCallback((event: PointerEvent) => {
+    if (activeSplitPointerIdRef.current !== event.pointerId) {
+      return;
+    }
     if (!splitWorkspaceRef.current) {
       return;
     }
@@ -207,18 +223,20 @@ export const RightLayout: React.FC = () => {
       return;
     }
 
-    document.addEventListener('mousemove', handleSplitMouseMove);
-    document.addEventListener('mouseup', handleSplitMouseUp);
+    document.addEventListener('pointermove', handleSplitPointerMove);
+    document.addEventListener('pointerup', handleSplitPointerEnd);
+    document.addEventListener('pointercancel', handleSplitPointerEnd);
     document.body.style.cursor = 'row-resize';
     document.body.style.userSelect = 'none';
 
     return () => {
-      document.removeEventListener('mousemove', handleSplitMouseMove);
-      document.removeEventListener('mouseup', handleSplitMouseUp);
+      document.removeEventListener('pointermove', handleSplitPointerMove);
+      document.removeEventListener('pointerup', handleSplitPointerEnd);
+      document.removeEventListener('pointercancel', handleSplitPointerEnd);
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
-  }, [handleSplitMouseMove, handleSplitMouseUp, isDraggingSplit]);
+  }, [handleSplitPointerEnd, handleSplitPointerMove, isDraggingSplit]);
 
   useEffect(() => {
     if (isMobile) {
@@ -371,7 +389,7 @@ export const RightLayout: React.FC = () => {
               </div>
               <RightLayoutPaneDivider
                 isDragging={isDraggingSplit}
-                onMouseDown={handleSplitMouseDown}
+                onPointerDown={handleSplitPointerDown}
               />
               <div className="relative z-10 min-h-0 flex-1 overflow-y-scroll overscroll-contain [scrollbar-gutter:stable]">
                 <RadioOperatorList onCreateOperator={handleCreateOperator} />

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import {
   Button,
   Popover,
@@ -20,6 +20,44 @@ import { ServerHealthButton } from '../components/system/ServerHealthButton';
 import { SettingsButton } from '../components/common/SettingsButton';
 import { useTranslation } from 'react-i18next';
 import { OPEN_ACCOUNT_SECURITY_MODAL_EVENT } from '../components/app/GlobalModalHost';
+import {
+  clampRightLayoutSplitPercent,
+  DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
+  getRightLayoutPaneHeights,
+  RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX,
+} from './rightLayoutSplitPreferences';
+
+function RightLayoutPaneDivider({
+  isDragging,
+  onMouseDown,
+}: {
+  isDragging: boolean;
+  onMouseDown: (event: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      className={[
+        'group flex-shrink-0 cursor-row-resize transition-all duration-200',
+        isDragging ? 'bg-primary-400' : 'bg-transparent hover:bg-primary-200',
+      ].join(' ')}
+      style={{ height: `${RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX}px` }}
+      onMouseDown={onMouseDown}
+    >
+      <div className="relative h-full w-full">
+        <div
+          className={[
+            'absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 transform gap-1 transition-opacity duration-200',
+            isDragging ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+          ].join(' ')}
+        >
+          <div className="h-0.5 w-6 rounded-full bg-default-600"></div>
+          <div className="h-0.5 w-6 rounded-full bg-default-600"></div>
+          <div className="h-0.5 w-6 rounded-full bg-default-600"></div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export const RightLayout: React.FC = () => {
   const { t } = useTranslation('common');
@@ -33,6 +71,13 @@ export const RightLayout: React.FC = () => {
   const { state: authState, logout } = useAuth();
   const [selectedMode, setSelectedMode] = useState<string>('auto5');
   const [loginPopoverOpen, setLoginPopoverOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [splitPercent, setSplitPercent] = useState(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+  const [workspaceHeight, setWorkspaceHeight] = useState(0);
+  const [isDraggingSplit, setIsDraggingSplit] = useState(false);
+  const splitWorkspaceRef = useRef<HTMLDivElement | null>(null);
+  const dragStartYRef = useRef(0);
+  const dragStartSplitPercentRef = useRef(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
   const showAuthenticatedIdentity = Boolean(authState.role) && (Boolean(authState.jwt) || !authState.authEnabled);
   const showLoginEntry = authState.authEnabled && !authState.jwt && authState.isPublicViewer;
   const automationOperatorId = currentOperatorId || operators[0]?.id;
@@ -62,8 +107,111 @@ export const RightLayout: React.FC = () => {
     window.dispatchEvent(new Event(OPEN_ACCOUNT_SECURITY_MODAL_EVENT));
   }, []);
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 767px)');
+    setIsMobile(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isMobile) {
+      setWorkspaceHeight(0);
+      return;
+    }
+
+    const measureWorkspace = () => {
+      const nextHeight = splitWorkspaceRef.current?.clientHeight ?? 0;
+      setWorkspaceHeight((currentHeight) => currentHeight === nextHeight ? currentHeight : nextHeight);
+    };
+
+    measureWorkspace();
+
+    const resizeObserver = typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(() => {
+        measureWorkspace();
+      });
+
+    if (resizeObserver && splitWorkspaceRef.current) {
+      resizeObserver.observe(splitWorkspaceRef.current);
+    }
+
+    window.addEventListener('resize', measureWorkspace);
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', measureWorkspace);
+    };
+  }, [isMobile]);
+
+  const handleSplitMouseDown = useCallback((event: React.MouseEvent) => {
+    if (isMobile) {
+      return;
+    }
+
+    event.preventDefault();
+    dragStartYRef.current = event.clientY;
+    dragStartSplitPercentRef.current = splitPercent;
+    setIsDraggingSplit(true);
+  }, [isMobile, splitPercent]);
+
+  const handleSplitMouseUp = useCallback(() => {
+    setIsDraggingSplit(false);
+  }, []);
+
+  const handleSplitMouseMove = useCallback((event: MouseEvent) => {
+    if (!splitWorkspaceRef.current) {
+      return;
+    }
+
+    const containerHeight = splitWorkspaceRef.current.clientHeight;
+    if (containerHeight <= 0) {
+      return;
+    }
+
+    const deltaPercent = ((event.clientY - dragStartYRef.current) / containerHeight) * 100;
+    setSplitPercent(clampRightLayoutSplitPercent({
+      splitPercent: dragStartSplitPercentRef.current + deltaPercent,
+      containerHeight,
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (!isDraggingSplit) {
+      return;
+    }
+
+    document.addEventListener('mousemove', handleSplitMouseMove);
+    document.addEventListener('mouseup', handleSplitMouseUp);
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+
+    return () => {
+      document.removeEventListener('mousemove', handleSplitMouseMove);
+      document.removeEventListener('mouseup', handleSplitMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [handleSplitMouseMove, handleSplitMouseUp, isDraggingSplit]);
+
+  const desktopPaneHeights = getRightLayoutPaneHeights({
+    splitPercent,
+    containerHeight: workspaceHeight,
+  });
+
   return (
-    <div className="h-full min-h-0 overflow-hidden flex flex-col">
+    <>
+      {isDraggingSplit && (
+        <div className="fixed inset-0 z-[9999] cursor-row-resize bg-transparent" />
+      )}
+      <div className="h-full min-h-0 overflow-hidden flex flex-col">
       {/* 顶部工具栏 */}
       <div
         className="flex-shrink-0 flex justify-between items-center p-1 px-2 md:p-2 md:px-3"
@@ -176,21 +324,40 @@ export const RightLayout: React.FC = () => {
       
       {/* 主内容区域 */}
       <div className="flex-1 p-2 pt-0 md:p-5 md:pt-0 flex flex-col gap-2 md:gap-4 min-h-0 overflow-hidden">
-        {/* 和我有关的通联信息 - 占据剩余空间 */}
-        <div className="relative z-0 flex-1 min-h-0 overflow-hidden">
-          <MyRelatedFramesTable className="h-full" />
-        </div>
-        
-        {/* 操作员列表 - 固定高度 */}
-        <div className="relative z-10 flex-shrink-0">
-          <RadioOperatorList onCreateOperator={handleCreateOperator} />
-        </div>
-        
-        {/* 电台控制 - 固定高度 */}
+        {isMobile ? (
+          <>
+            <div className="relative z-0 flex-1 min-h-0 overflow-hidden">
+              <MyRelatedFramesTable className="h-full" />
+            </div>
+            <div className="relative z-10 flex-shrink-0">
+              <RadioOperatorList onCreateOperator={handleCreateOperator} />
+            </div>
+          </>
+        ) : (
+          <div ref={splitWorkspaceRef} className="flex-1 min-h-0 overflow-hidden">
+            <div className="flex h-full min-h-0 flex-col overflow-hidden">
+              <div
+                className="relative z-0 min-h-0 overflow-hidden"
+                style={workspaceHeight > 0 ? { height: `${desktopPaneHeights.topPaneHeightPx}px` } : { height: `${splitPercent}%` }}
+              >
+                <MyRelatedFramesTable className="h-full" />
+              </div>
+              <RightLayoutPaneDivider
+                isDragging={isDraggingSplit}
+                onMouseDown={handleSplitMouseDown}
+              />
+              <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                <RadioOperatorList onCreateOperator={handleCreateOperator} />
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className="relative z-10 flex-shrink-0">
           <RadioControl onOpenRadioSettings={handleOpenRadioSettings} />
         </div>
       </div>
-    </div>
+      </div>
+    </>
   );
 };

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -376,7 +376,7 @@ export const RightLayout: React.FC = () => {
             <div className="relative z-0 min-h-0 flex-1 overflow-hidden">
               <MyRelatedFramesTable className="h-full" />
             </div>
-            <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pt-1 pb-2">
               <RadioOperatorList onCreateOperator={handleCreateOperator} />
             </div>
           </>
@@ -393,7 +393,7 @@ export const RightLayout: React.FC = () => {
                 isDragging={isDraggingSplit}
                 onPointerDown={handleSplitPointerDown}
               />
-              <div className="relative z-10 min-h-0 flex-1 overflow-y-scroll overscroll-contain [scrollbar-gutter:stable]">
+              <div className="relative z-10 min-h-0 flex-1 overflow-y-auto overscroll-contain px-1 pt-1 pb-2 [scrollbar-gutter:stable]">
                 <RadioOperatorList onCreateOperator={handleCreateOperator} />
               </div>
             </div>

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -239,12 +239,12 @@ export const RightLayout: React.FC = () => {
   }, [handleSplitPointerEnd, handleSplitPointerMove, isDraggingSplit]);
 
   useEffect(() => {
-    if (isMobile) {
+    if (isMobile || isDraggingSplit) {
       return;
     }
 
     saveRightLayoutSplitPercent(splitPercent);
-  }, [isMobile, splitPercent]);
+  }, [isDraggingSplit, isMobile, splitPercent]);
 
   const desktopPaneHeights = getRightLayoutPaneHeights({
     splitPercent,

--- a/packages/web/src/layout/RightLayout.tsx
+++ b/packages/web/src/layout/RightLayout.tsx
@@ -23,8 +23,10 @@ import { OPEN_ACCOUNT_SECURITY_MODAL_EVENT } from '../components/app/GlobalModal
 import {
   clampRightLayoutSplitPercent,
   DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
+  getStoredRightLayoutSplitPercent,
   getRightLayoutPaneHeights,
   RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX,
+  saveRightLayoutSplitPercent,
 } from './rightLayoutSplitPreferences';
 
 function RightLayoutPaneDivider({
@@ -72,7 +74,7 @@ export const RightLayout: React.FC = () => {
   const [selectedMode, setSelectedMode] = useState<string>('auto5');
   const [loginPopoverOpen, setLoginPopoverOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
-  const [splitPercent, setSplitPercent] = useState(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+  const [splitPercent, setSplitPercent] = useState(() => getStoredRightLayoutSplitPercent());
   const [workspaceHeight, setWorkspaceHeight] = useState(0);
   const [isDraggingSplit, setIsDraggingSplit] = useState(false);
   const splitWorkspaceRef = useRef<HTMLDivElement | null>(null);
@@ -151,6 +153,23 @@ export const RightLayout: React.FC = () => {
     };
   }, [isMobile]);
 
+  useEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
+    setSplitPercent((currentSplitPercent) => {
+      if (workspaceHeight <= 0) {
+        return currentSplitPercent;
+      }
+
+      return clampRightLayoutSplitPercent({
+        splitPercent: currentSplitPercent,
+        containerHeight: workspaceHeight,
+      });
+    });
+  }, [isMobile, workspaceHeight]);
+
   const handleSplitMouseDown = useCallback((event: React.MouseEvent) => {
     if (isMobile) {
       return;
@@ -200,6 +219,14 @@ export const RightLayout: React.FC = () => {
       document.body.style.userSelect = '';
     };
   }, [handleSplitMouseMove, handleSplitMouseUp, isDraggingSplit]);
+
+  useEffect(() => {
+    if (isMobile) {
+      return;
+    }
+
+    saveRightLayoutSplitPercent(splitPercent);
+  }, [isMobile, splitPercent]);
 
   const desktopPaneHeights = getRightLayoutPaneHeights({
     splitPercent,

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPersistence.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPersistence.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldPersistRightLayoutSplit } from '../rightLayoutSplitPreferences';
+
+describe('right layout split persistence gating', () => {
+  it('skips persistence while dragging on desktop', () => {
+    expect(shouldPersistRightLayoutSplit({
+      isMobile: false,
+      isDraggingSplit: true,
+    })).toBe(false);
+  });
+
+  it('skips persistence on mobile even when not dragging', () => {
+    expect(shouldPersistRightLayoutSplit({
+      isMobile: true,
+      isDraggingSplit: false,
+    })).toBe(false);
+  });
+
+  it('allows persistence after dragging ends on desktop', () => {
+    expect(shouldPersistRightLayoutSplit({
+      isMobile: false,
+      isDraggingSplit: false,
+    })).toBe(true);
+  });
+});

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPersistence.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPersistence.test.ts
@@ -1,37 +1,103 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { shouldPersistRightLayoutSplit } from '../rightLayoutSplitPreferences';
+import {
+  clearRightLayoutSplitPercent,
+  hasStoredRightLayoutSplit,
+  RIGHT_LAYOUT_SPLIT_STORAGE_KEY,
+  shouldPersistRightLayoutSplit,
+} from '../rightLayoutSplitPreferences';
 
 describe('right layout split persistence gating', () => {
-  it('skips persistence for initial desktop renders and resize clamps', () => {
+  it('skips persistence for initial renders and resize clamps', () => {
     expect(shouldPersistRightLayoutSplit({
-      isMobile: false,
       wasDraggingSplit: false,
       isDraggingSplit: false,
     })).toBe(false);
   });
 
-  it('skips persistence while dragging on desktop', () => {
+  it('skips persistence while dragging', () => {
     expect(shouldPersistRightLayoutSplit({
-      isMobile: false,
       wasDraggingSplit: false,
       isDraggingSplit: true,
     })).toBe(false);
   });
 
-  it('skips persistence on mobile even when not dragging', () => {
+  it('allows persistence only after a drag ends', () => {
     expect(shouldPersistRightLayoutSplit({
-      isMobile: true,
-      wasDraggingSplit: true,
-      isDraggingSplit: false,
-    })).toBe(false);
-  });
-
-  it('allows persistence only after a desktop drag ends', () => {
-    expect(shouldPersistRightLayoutSplit({
-      isMobile: false,
       wasDraggingSplit: true,
       isDraggingSplit: false,
     })).toBe(true);
+  });
+});
+
+describe('hasStoredRightLayoutSplit', () => {
+  const originalLocalStorage = globalThis.localStorage;
+
+  afterEach(() => {
+    if (typeof originalLocalStorage === 'undefined') {
+      delete (globalThis as { localStorage?: Storage }).localStorage;
+    } else {
+      Object.defineProperty(globalThis, 'localStorage', { value: originalLocalStorage, configurable: true, writable: true });
+    }
+  });
+
+  function stubLocalStorage(initial: Record<string, string>) {
+    const map = new Map(Object.entries(initial));
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (key: string) => map.get(key) ?? null,
+        setItem: (key: string, value: string) => { map.set(key, value); },
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  it('returns false when localStorage is unavailable', () => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    expect(hasStoredRightLayoutSplit()).toBe(false);
+  });
+
+  it('returns false when no split ratio was ever stored', () => {
+    stubLocalStorage({});
+    expect(hasStoredRightLayoutSplit()).toBe(false);
+  });
+
+  it('returns false when the stored value is not numeric', () => {
+    stubLocalStorage({ [RIGHT_LAYOUT_SPLIT_STORAGE_KEY]: 'not-a-number' });
+    expect(hasStoredRightLayoutSplit()).toBe(false);
+  });
+
+  it('returns true when a split ratio was stored by a previous drag', () => {
+    stubLocalStorage({ [RIGHT_LAYOUT_SPLIT_STORAGE_KEY]: '65' });
+    expect(hasStoredRightLayoutSplit()).toBe(true);
+  });
+});
+
+describe('clearRightLayoutSplitPercent', () => {
+  it('removes the stored ratio so hasStoredRightLayoutSplit returns false again', () => {
+    const map = new Map([[RIGHT_LAYOUT_SPLIT_STORAGE_KEY, '65']]);
+    const originalLocalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (key: string) => map.get(key) ?? null,
+        setItem: (key: string, value: string) => { map.set(key, value); },
+        removeItem: (key: string) => { map.delete(key); },
+      },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(hasStoredRightLayoutSplit()).toBe(true);
+      clearRightLayoutSplitPercent();
+      expect(hasStoredRightLayoutSplit()).toBe(false);
+      expect(map.has(RIGHT_LAYOUT_SPLIT_STORAGE_KEY)).toBe(false);
+    } finally {
+      if (typeof originalLocalStorage === 'undefined') {
+        delete (globalThis as { localStorage?: Storage }).localStorage;
+      } else {
+        Object.defineProperty(globalThis, 'localStorage', { value: originalLocalStorage, configurable: true, writable: true });
+      }
+    }
   });
 });

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPersistence.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPersistence.test.ts
@@ -3,9 +3,18 @@ import { describe, expect, it } from 'vitest';
 import { shouldPersistRightLayoutSplit } from '../rightLayoutSplitPreferences';
 
 describe('right layout split persistence gating', () => {
+  it('skips persistence for initial desktop renders and resize clamps', () => {
+    expect(shouldPersistRightLayoutSplit({
+      isMobile: false,
+      wasDraggingSplit: false,
+      isDraggingSplit: false,
+    })).toBe(false);
+  });
+
   it('skips persistence while dragging on desktop', () => {
     expect(shouldPersistRightLayoutSplit({
       isMobile: false,
+      wasDraggingSplit: false,
       isDraggingSplit: true,
     })).toBe(false);
   });
@@ -13,13 +22,15 @@ describe('right layout split persistence gating', () => {
   it('skips persistence on mobile even when not dragging', () => {
     expect(shouldPersistRightLayoutSplit({
       isMobile: true,
+      wasDraggingSplit: true,
       isDraggingSplit: false,
     })).toBe(false);
   });
 
-  it('allows persistence after dragging ends on desktop', () => {
+  it('allows persistence only after a desktop drag ends', () => {
     expect(shouldPersistRightLayoutSplit({
       isMobile: false,
+      wasDraggingSplit: true,
       isDraggingSplit: false,
     })).toBe(true);
   });

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPointer.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPointer.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isActiveRightLayoutSplitPointer,
+  shouldStartRightLayoutSplitPointerDrag,
+} from '../rightLayoutSplitPreferences';
+
+describe('right layout split pointer gating', () => {
+  it('allows primary touch pointers on desktop', () => {
+    expect(shouldStartRightLayoutSplitPointerDrag({
+      isMobile: false,
+      isPrimary: true,
+      pointerType: 'touch',
+      button: 0,
+    })).toBe(true);
+  });
+
+  it('allows only primary left mouse button on desktop', () => {
+    expect(shouldStartRightLayoutSplitPointerDrag({
+      isMobile: false,
+      isPrimary: true,
+      pointerType: 'mouse',
+      button: 0,
+    })).toBe(true);
+
+    expect(shouldStartRightLayoutSplitPointerDrag({
+      isMobile: false,
+      isPrimary: true,
+      pointerType: 'mouse',
+      button: 1,
+    })).toBe(false);
+  });
+
+  it('rejects non-primary pointers and mobile layout drags', () => {
+    expect(shouldStartRightLayoutSplitPointerDrag({
+      isMobile: false,
+      isPrimary: false,
+      pointerType: 'touch',
+      button: 0,
+    })).toBe(false);
+
+    expect(shouldStartRightLayoutSplitPointerDrag({
+      isMobile: true,
+      isPrimary: true,
+      pointerType: 'touch',
+      button: 0,
+    })).toBe(false);
+  });
+
+  it('matches only the active pointer id', () => {
+    expect(isActiveRightLayoutSplitPointer(7, 7)).toBe(true);
+    expect(isActiveRightLayoutSplitPointer(7, 8)).toBe(false);
+    expect(isActiveRightLayoutSplitPointer(null, 7)).toBe(false);
+  });
+});

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPointer.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPointer.test.ts
@@ -9,6 +9,7 @@ describe('right layout split pointer gating', () => {
   it('allows primary touch pointers on desktop', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
       isMobile: false,
+      hasActivePointer: false,
       isPrimary: true,
       pointerType: 'touch',
       button: 0,
@@ -18,6 +19,7 @@ describe('right layout split pointer gating', () => {
   it('allows only primary left mouse button on desktop', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
       isMobile: false,
+      hasActivePointer: false,
       isPrimary: true,
       pointerType: 'mouse',
       button: 0,
@@ -25,6 +27,7 @@ describe('right layout split pointer gating', () => {
 
     expect(shouldStartRightLayoutSplitPointerDrag({
       isMobile: false,
+      hasActivePointer: false,
       isPrimary: true,
       pointerType: 'mouse',
       button: 1,
@@ -34,6 +37,7 @@ describe('right layout split pointer gating', () => {
   it('rejects non-primary pointers and mobile layout drags', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
       isMobile: false,
+      hasActivePointer: false,
       isPrimary: false,
       pointerType: 'touch',
       button: 0,
@@ -41,6 +45,17 @@ describe('right layout split pointer gating', () => {
 
     expect(shouldStartRightLayoutSplitPointerDrag({
       isMobile: true,
+      hasActivePointer: false,
+      isPrimary: true,
+      pointerType: 'touch',
+      button: 0,
+    })).toBe(false);
+  });
+
+  it('rejects a second pointer while a drag is active', () => {
+    expect(shouldStartRightLayoutSplitPointerDrag({
+      isMobile: false,
+      hasActivePointer: true,
       isPrimary: true,
       pointerType: 'touch',
       button: 0,

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPointer.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPointer.test.ts
@@ -6,9 +6,8 @@ import {
 } from '../rightLayoutSplitPreferences';
 
 describe('right layout split pointer gating', () => {
-  it('allows primary touch pointers on desktop', () => {
+  it('allows primary touch pointers', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
-      isMobile: false,
       hasActivePointer: false,
       isPrimary: true,
       pointerType: 'touch',
@@ -16,9 +15,8 @@ describe('right layout split pointer gating', () => {
     })).toBe(true);
   });
 
-  it('allows only primary left mouse button on desktop', () => {
+  it('allows only primary left mouse button', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
-      isMobile: false,
       hasActivePointer: false,
       isPrimary: true,
       pointerType: 'mouse',
@@ -26,7 +24,6 @@ describe('right layout split pointer gating', () => {
     })).toBe(true);
 
     expect(shouldStartRightLayoutSplitPointerDrag({
-      isMobile: false,
       hasActivePointer: false,
       isPrimary: true,
       pointerType: 'mouse',
@@ -34,19 +31,10 @@ describe('right layout split pointer gating', () => {
     })).toBe(false);
   });
 
-  it('rejects non-primary pointers and mobile layout drags', () => {
+  it('rejects non-primary pointers', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
-      isMobile: false,
       hasActivePointer: false,
       isPrimary: false,
-      pointerType: 'touch',
-      button: 0,
-    })).toBe(false);
-
-    expect(shouldStartRightLayoutSplitPointerDrag({
-      isMobile: true,
-      hasActivePointer: false,
-      isPrimary: true,
       pointerType: 'touch',
       button: 0,
     })).toBe(false);
@@ -54,7 +42,6 @@ describe('right layout split pointer gating', () => {
 
   it('rejects a second pointer while a drag is active', () => {
     expect(shouldStartRightLayoutSplitPointerDrag({
-      isMobile: false,
       hasActivePointer: true,
       isPrimary: true,
       pointerType: 'touch',

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPreferences.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPreferences.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clampRightLayoutSplitPercent,
+  DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
+  getRightLayoutPaneHeights,
+  getStoredRightLayoutSplitPercent,
+  RIGHT_LAYOUT_SPLIT_STORAGE_KEY,
+  saveRightLayoutSplitPercent,
+} from '../rightLayoutSplitPreferences';
+
+function createStorageStub(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => { store.delete(key); },
+    setItem: (key: string, value: string) => { store.set(key, value); },
+  };
+}
+
+describe('right layout split preferences', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createStorageStub());
+  });
+
+  it('uses the default split when storage is missing or invalid', () => {
+    expect(getStoredRightLayoutSplitPercent()).toBe(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+
+    localStorage.setItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY, 'bad-value');
+    expect(getStoredRightLayoutSplitPercent()).toBe(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+  });
+
+  it('clamps split values to keep both panes usable', () => {
+    expect(clampRightLayoutSplitPercent({
+      splitPercent: 5,
+      containerHeight: 600,
+    })).toBeGreaterThan(5);
+
+    expect(clampRightLayoutSplitPercent({
+      splitPercent: 95,
+      containerHeight: 600,
+    })).toBeLessThan(95);
+  });
+
+  it('falls back to 50/50 when the workspace is too short for two minimum panes', () => {
+    expect(clampRightLayoutSplitPercent({
+      splitPercent: 70,
+      containerHeight: 320,
+    })).toBe(DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+  });
+
+  it('returns pane heights that respect the clamped split', () => {
+    expect(getRightLayoutPaneHeights({
+      splitPercent: 90,
+      containerHeight: 600,
+    })).toEqual({
+      splitPercent: clampRightLayoutSplitPercent({
+        splitPercent: 90,
+        containerHeight: 600,
+      }),
+      topPaneHeightPx: 412,
+      operatorPaneHeightPx: 180,
+    });
+  });
+
+  it('saves a normalized split and reloads it from storage', () => {
+    expect(saveRightLayoutSplitPercent(63.7)).toBe(63.7);
+    expect(localStorage.getItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY)).toBe('63.7');
+    expect(getStoredRightLayoutSplitPercent()).toBe(63.7);
+
+    expect(saveRightLayoutSplitPercent(0)).toBe(1);
+    expect(getStoredRightLayoutSplitPercent()).toBe(1);
+  });
+});

--- a/packages/web/src/layout/__tests__/rightLayoutSplitPreferences.test.ts
+++ b/packages/web/src/layout/__tests__/rightLayoutSplitPreferences.test.ts
@@ -66,6 +66,17 @@ describe('right layout split preferences', () => {
     });
   });
 
+  it('returns a balanced split when the workspace is too short to avoid pane clipping', () => {
+    expect(getRightLayoutPaneHeights({
+      splitPercent: 85,
+      containerHeight: 320,
+    })).toEqual({
+      splitPercent: DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
+      topPaneHeightPx: 156,
+      operatorPaneHeightPx: 156,
+    });
+  });
+
   it('saves a normalized split and reloads it from storage', () => {
     expect(saveRightLayoutSplitPercent(63.7)).toBe(63.7);
     expect(localStorage.getItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY)).toBe('63.7');

--- a/packages/web/src/layout/rightLayoutSplitPreferences.ts
+++ b/packages/web/src/layout/rightLayoutSplitPreferences.ts
@@ -28,6 +28,16 @@ function getLocalStorage(): Storage | null {
   return globalThis.localStorage ?? null;
 }
 
+export function hasStoredRightLayoutSplit(): boolean {
+  try {
+    const storage = getLocalStorage();
+    const raw = storage?.getItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY);
+    return raw != null && Number.isFinite(Number(raw));
+  } catch {
+    return false;
+  }
+}
+
 export function getStoredRightLayoutSplitPercent(): number {
   try {
     const storage = getLocalStorage();
@@ -51,22 +61,28 @@ export function saveRightLayoutSplitPercent(splitPercent: number): number {
   return normalized;
 }
 
+export function clearRightLayoutSplitPercent(): void {
+  try {
+    getLocalStorage()?.removeItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures; the in-memory state is reset by the caller anyway.
+  }
+}
+
 export function shouldPersistRightLayoutSplit(params: {
-  isMobile: boolean;
   wasDraggingSplit: boolean;
   isDraggingSplit: boolean;
 }): boolean {
-  return !params.isMobile && params.wasDraggingSplit && !params.isDraggingSplit;
+  return params.wasDraggingSplit && !params.isDraggingSplit;
 }
 
 export function shouldStartRightLayoutSplitPointerDrag(params: {
-  isMobile: boolean;
   hasActivePointer: boolean;
   isPrimary: boolean;
   pointerType: string;
   button: number;
 }): boolean {
-  if (params.isMobile || params.hasActivePointer || !params.isPrimary) {
+  if (params.hasActivePointer || !params.isPrimary) {
     return false;
   }
 

--- a/packages/web/src/layout/rightLayoutSplitPreferences.ts
+++ b/packages/web/src/layout/rightLayoutSplitPreferences.ts
@@ -51,6 +51,37 @@ export function saveRightLayoutSplitPercent(splitPercent: number): number {
   return normalized;
 }
 
+export function shouldPersistRightLayoutSplit(params: {
+  isMobile: boolean;
+  isDraggingSplit: boolean;
+}): boolean {
+  return !params.isMobile && !params.isDraggingSplit;
+}
+
+export function shouldStartRightLayoutSplitPointerDrag(params: {
+  isMobile: boolean;
+  isPrimary: boolean;
+  pointerType: string;
+  button: number;
+}): boolean {
+  if (params.isMobile || !params.isPrimary) {
+    return false;
+  }
+
+  if (params.pointerType === 'mouse' && params.button !== 0) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isActiveRightLayoutSplitPointer(
+  activePointerId: number | null,
+  pointerId: number,
+): boolean {
+  return activePointerId === pointerId;
+}
+
 export function clampRightLayoutSplitPercent(params: {
   splitPercent: number;
   containerHeight: number;

--- a/packages/web/src/layout/rightLayoutSplitPreferences.ts
+++ b/packages/web/src/layout/rightLayoutSplitPreferences.ts
@@ -61,11 +61,12 @@ export function shouldPersistRightLayoutSplit(params: {
 
 export function shouldStartRightLayoutSplitPointerDrag(params: {
   isMobile: boolean;
+  hasActivePointer: boolean;
   isPrimary: boolean;
   pointerType: string;
   button: number;
 }): boolean {
-  if (params.isMobile || !params.isPrimary) {
+  if (params.isMobile || params.hasActivePointer || !params.isPrimary) {
     return false;
   }
 

--- a/packages/web/src/layout/rightLayoutSplitPreferences.ts
+++ b/packages/web/src/layout/rightLayoutSplitPreferences.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT = 50;
 export const RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX = 8;
 export const RIGHT_LAYOUT_MIN_PANE_HEIGHT_PX = 180;
+export const RIGHT_LAYOUT_SPLIT_STORAGE_KEY = 'tx5dr_right_layout_split_percent';
 
 export function normalizeRightLayoutSplitPercent(
   value: unknown,
@@ -17,6 +18,37 @@ export function normalizeRightLayoutSplitPercent(
   }
 
   return Math.min(99, Math.max(1, numeric));
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof globalThis === 'undefined' || !('localStorage' in globalThis)) {
+    return null;
+  }
+
+  return globalThis.localStorage ?? null;
+}
+
+export function getStoredRightLayoutSplitPercent(): number {
+  try {
+    const storage = getLocalStorage();
+    const raw = storage?.getItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY);
+    return normalizeRightLayoutSplitPercent(raw, DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+  } catch {
+    return DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT;
+  }
+}
+
+export function saveRightLayoutSplitPercent(splitPercent: number): number {
+  const normalized = normalizeRightLayoutSplitPercent(splitPercent, DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT);
+
+  try {
+    const storage = getLocalStorage();
+    storage?.setItem(RIGHT_LAYOUT_SPLIT_STORAGE_KEY, String(normalized));
+  } catch {
+    // Ignore storage write failures and keep the in-memory split.
+  }
+
+  return normalized;
 }
 
 export function clampRightLayoutSplitPercent(params: {

--- a/packages/web/src/layout/rightLayoutSplitPreferences.ts
+++ b/packages/web/src/layout/rightLayoutSplitPreferences.ts
@@ -1,0 +1,91 @@
+export const DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT = 50;
+export const RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX = 8;
+export const RIGHT_LAYOUT_MIN_PANE_HEIGHT_PX = 180;
+
+export function normalizeRightLayoutSplitPercent(
+  value: unknown,
+  fallback = DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT,
+): number {
+  const numeric = typeof value === 'number'
+    ? value
+    : typeof value === 'string'
+      ? Number(value)
+      : Number.NaN;
+
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  return Math.min(99, Math.max(1, numeric));
+}
+
+export function clampRightLayoutSplitPercent(params: {
+  splitPercent: number;
+  containerHeight: number;
+  minPaneHeightPx?: number;
+  dividerHeightPx?: number;
+}): number {
+  const {
+    splitPercent,
+    containerHeight,
+    minPaneHeightPx = RIGHT_LAYOUT_MIN_PANE_HEIGHT_PX,
+    dividerHeightPx = RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX,
+  } = params;
+  const normalizedSplitPercent = normalizeRightLayoutSplitPercent(splitPercent);
+
+  if (!Number.isFinite(containerHeight) || containerHeight <= 0) {
+    return normalizedSplitPercent;
+  }
+
+  const usableHeight = Math.max(containerHeight - dividerHeightPx, 0);
+  if (usableHeight <= 0) {
+    return normalizedSplitPercent;
+  }
+
+  if (usableHeight <= minPaneHeightPx * 2) {
+    return DEFAULT_RIGHT_LAYOUT_SPLIT_PERCENT;
+  }
+
+  const minPercent = (minPaneHeightPx / usableHeight) * 100;
+  return Math.min(100 - minPercent, Math.max(minPercent, normalizedSplitPercent));
+}
+
+export function getRightLayoutPaneHeights(params: {
+  splitPercent: number;
+  containerHeight: number;
+  minPaneHeightPx?: number;
+  dividerHeightPx?: number;
+}): {
+  splitPercent: number;
+  topPaneHeightPx: number;
+  operatorPaneHeightPx: number;
+} {
+  const {
+    containerHeight,
+    minPaneHeightPx = RIGHT_LAYOUT_MIN_PANE_HEIGHT_PX,
+    dividerHeightPx = RIGHT_LAYOUT_SPLIT_DIVIDER_HEIGHT_PX,
+  } = params;
+
+  if (!Number.isFinite(containerHeight) || containerHeight <= 0) {
+    return {
+      splitPercent: normalizeRightLayoutSplitPercent(params.splitPercent),
+      topPaneHeightPx: 0,
+      operatorPaneHeightPx: 0,
+    };
+  }
+
+  const usableHeight = Math.max(containerHeight - dividerHeightPx, 0);
+  const splitPercent = clampRightLayoutSplitPercent({
+    splitPercent: params.splitPercent,
+    containerHeight,
+    minPaneHeightPx,
+    dividerHeightPx,
+  });
+  const topPaneHeightPx = Math.round((usableHeight * splitPercent) / 100);
+
+  return {
+    splitPercent,
+    topPaneHeightPx,
+    operatorPaneHeightPx: Math.max(usableHeight - topPaneHeightPx, 0),
+  };
+}

--- a/packages/web/src/layout/rightLayoutSplitPreferences.ts
+++ b/packages/web/src/layout/rightLayoutSplitPreferences.ts
@@ -53,9 +53,10 @@ export function saveRightLayoutSplitPercent(splitPercent: number): number {
 
 export function shouldPersistRightLayoutSplit(params: {
   isMobile: boolean;
+  wasDraggingSplit: boolean;
   isDraggingSplit: boolean;
 }): boolean {
-  return !params.isMobile && !params.isDraggingSplit;
+  return !params.isMobile && params.wasDraggingSplit && !params.isDraggingSplit;
 }
 
 export function shouldStartRightLayoutSplitPointerDrag(params: {


### PR DESCRIPTION
## 背景

为 FT8/FT4 数字模式右侧面板增加更稳定的工作区布局：

- 桌面端支持上下可拖拽分割
- 操作员区独立滚动，不再把顶部内容整体顶出视口
- 分割比例支持持久化恢复
- 平板/触屏设备支持拖拽分割
- 移动端保持无拖拽，但将顶部信息区与操作员区按 `50/50` 分配，并让操作员区独立滚动

## 主要改动

### 1. 数字模式右侧工作区支持上下分割

在 `packages/web/src/layout/RightLayout.tsx` 中重构 FT8/FT4 右侧布局：

- 顶部继续显示 `MyRelatedFramesTable`
- 中部显示操作员列表
- 底部 `RadioControl` 继续固定可见
- 桌面端为顶部与操作员区之间新增上下分割条
- 默认分割比例为 `50/50`

### 2. 操作员区改为独立滚动

右侧操作员列表不再依赖整体页面高度自然撑开，而是放入独立滚动容器：

- 桌面端操作员区支持独立纵向滚动
- 滚动条预留稳定 gutter，避免选中高亮被裁切
- 移动端操作员区同样独立滚动

### 3. 分割比例持久化与约束逻辑

新增 `packages/web/src/layout/rightLayoutSplitPreferences.ts`，集中处理：

- 默认分割比例
- `localStorage` 读写
- 过小容器时的比例回退
- 最小面板高度约束
- pointer 启动/活跃指针/持久化门控等纯逻辑

这样 `RightLayout` 只负责渲染和交互，比例规则保持在独立模块中。

### 4. 触摸/触控设备支持拖拽

桌面宽度下的分割条交互从鼠标事件迁移到 `pointer` 事件：

- `pointerdown`
- `pointermove`
- `pointerup`
- `pointercancel`

并增加：

- 活跃指针约束，避免多指串扰
- `touch-none` 防止触控拖拽时被浏览器解释为滚动
- 仅在拖拽结束后持久化最终比例，避免拖拽过程中频繁写入 `localStorage`

## 测试与验证

已完成：

- `yarn workspace @tx5dr/web eslint src/layout/RightLayout.tsx`
- `yarn workspace @tx5dr/web eslint src/layout/RightLayout.tsx src/layout/rightLayoutSplitPreferences.ts src/layout/__tests__/rightLayoutSplitPreferences.test.ts src/layout/__tests__/rightLayoutSplitPersistence.test.ts src/layout/__tests__/rightLayoutSplitPointer.test.ts`
- `yarn test src/layout/__tests__/rightLayoutSplitPreferences.test.ts src/layout/__tests__/rightLayoutSplitPersistence.test.ts src/layout/__tests__/rightLayoutSplitPointer.test.ts src/layout/__tests__/voiceRightResponsive.test.ts`

测试覆盖包括：

- 默认分割比例与非法存储回退
- 面板高度约束与比例 clamp
- 分割比例保存与恢复
- 拖拽期间不持久化、拖拽结束后持久化
- pointer 拖拽启动条件
- 活跃指针匹配逻辑

## 影响范围

本次改动主要影响数字模式右侧面板：

- `packages/web/src/layout/RightLayout.tsx`
- `packages/web/src/layout/rightLayoutSplitPreferences.ts`

不涉及：

- Voice 模式右侧布局
- CW 模式右侧布局
- 左侧总解码表行为
- 服务端协议或公开 API

## 备注

- 当前移动端没有引入上下拖拽分割，只做了 `50/50` 区域划分和操作员区独立滚动。
- 分割比例持久化只在桌面端生效，且只保存拖拽结束后的最终值。
