### PR TITLE
fix: sync QSL status when downloading from WaveLog

### DIFF
--- a/packages/builtin-plugins/src/wavelog-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/provider.test.ts
@@ -491,8 +491,9 @@ describe('WaveLogSyncProvider', () => {
         },
       ]),
     );
-    queryQSOs.mockImplementation(async (filter?: { callsign?: string }) => {
-      if (filter?.callsign?.toUpperCase() === 'JH0BBE') {
+    queryQSOs.mockImplementation(async (filter?: unknown) => {
+      const callsign = (filter as { callsign?: string } | undefined)?.callsign;
+      if (callsign?.toUpperCase() === 'JH0BBE') {
         return [alreadySynced];
       }
       return [];
@@ -522,6 +523,110 @@ describe('WaveLogSyncProvider', () => {
       callsign: 'JO1LVZ',
       lotwQslSent: 'Y',
     }));
+    expect(notifyUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  it('download updates only the best-scored local match when multiple candidates exist', async () => {
+    const best = createQso('local-best', {
+      callsign: 'JQ1XGV',
+      frequency: 144_460_970,
+      startTime: Date.parse('2026-07-16T03:01:00.000Z'),
+      endTime: Date.parse('2026-07-16T03:01:00.000Z'),
+    });
+    // Same callsign/band/mode/station, but 10 minutes away from the remote record.
+    const other = createQso('local-other', {
+      callsign: 'JQ1XGV',
+      frequency: 144_460_970,
+      startTime: Date.parse('2026-07-16T03:11:00.000Z'),
+      endTime: Date.parse('2026-07-16T03:11:00.000Z'),
+    });
+    const { ctx, queryQSOs, addQSO, updateQSO, notifyUpdated } = createContext(async () =>
+      adifDownloadResponse([{
+        call: 'JQ1XGV',
+        qsoDate: '20260716',
+        timeOn: '030100',
+        freq: '144.46097',
+        mode: 'FT8',
+        lotwSent: 'Y',
+        lotwSentDate: '20260716',
+      }]),
+    );
+    // Return the worse candidate first to prove the score ranking is honored.
+    queryQSOs.mockResolvedValue([other, best]);
+
+    const provider = new WaveLogSyncProvider(ctx);
+    provider.setConfig('BG5DRB', {
+      url: 'https://wavelog.example.com',
+      apiKey: 'api-key',
+      stationId: 'station-1',
+      radioName: 'TX5DR',
+      autoUploadQSO: true,
+    });
+
+    const result = await provider.download('BG5DRB');
+
+    expect(result).toEqual({
+      downloaded: 1,
+      matched: 1,
+      updated: 1,
+      imported: 0,
+      failures: undefined,
+    });
+    expect(updateQSO).toHaveBeenCalledTimes(1);
+    expect(updateQSO).toHaveBeenCalledWith('local-best', expect.objectContaining({
+      lotwQslSent: 'Y',
+    }));
+    expect(addQSO).not.toHaveBeenCalled();
+    expect(notifyUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  it('download matches a local QSO whose station callsign carries a /P suffix', async () => {
+    const local = createQso('local-portable', {
+      callsign: 'JQ1XGV',
+      myCallsign: 'BG5DRB/P',
+      frequency: 144_460_970,
+      startTime: Date.parse('2026-07-16T03:01:00.000Z'),
+      endTime: Date.parse('2026-07-16T03:01:00.000Z'),
+    });
+    const { ctx, queryQSOs, addQSO, updateQSO, notifyUpdated } = createContext(async () =>
+      adifDownloadResponse([{
+        call: 'JQ1XGV',
+        qsoDate: '20260716',
+        timeOn: '030100',
+        freq: '144.46097',
+        mode: 'FT8',
+        lotwSent: 'Y',
+        lotwSentDate: '20260716',
+        myCall: 'BG5DRB',
+      }]),
+    );
+    queryQSOs.mockResolvedValue([local]);
+
+    const provider = new WaveLogSyncProvider(ctx);
+    provider.setConfig('BG5DRB', {
+      url: 'https://wavelog.example.com',
+      apiKey: 'api-key',
+      stationId: 'station-1',
+      radioName: 'TX5DR',
+      autoUploadQSO: true,
+    });
+
+    const result = await provider.download('BG5DRB');
+
+    expect(result).toEqual({
+      downloaded: 1,
+      matched: 1,
+      updated: 1,
+      imported: 0,
+      failures: undefined,
+    });
+    expect(updateQSO).toHaveBeenCalledTimes(1);
+    expect(updateQSO).toHaveBeenCalledWith('local-portable', expect.objectContaining({
+      lotwQslSent: 'Y',
+    }));
+    // The /P station match must prevent the remote record from being
+    // imported as a duplicate.
+    expect(addQSO).not.toHaveBeenCalled();
     expect(notifyUpdated).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/builtin-plugins/src/wavelog-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/provider.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { PluginContext } from '@tx5dr/plugin-api';
 import type { QSORecord } from '@tx5dr/contracts';
-import { WaveLogSyncProvider } from './provider.js';
+import { WaveLogSyncProvider, buildWavelogQslStatusUpdates } from './provider.js';
 
-function createQso(id: string): QSORecord {
+function createQso(id: string, overrides: Partial<QSORecord> = {}): QSORecord {
   return {
     id,
     callsign: 'N0CALL',
@@ -15,12 +15,16 @@ function createQso(id: string): QSORecord {
     messageHistory: [],
     myCallsign: 'BG5DRB',
     myGrid: 'PM01AA',
+    ...overrides,
   };
 }
 
 function createContext(fetchImpl: (input: string, init?: RequestInit) => Promise<Response>) {
   const store = new Map<string, unknown>();
   const queryQSOs = vi.fn(async (_filter?: unknown) => [] as QSORecord[]);
+  const addQSO = vi.fn(async (_qso: QSORecord) => {});
+  const updateQSO = vi.fn(async (_id: string, _updates: Partial<QSORecord>) => {});
+  const notifyUpdated = vi.fn(async () => {});
   const ctx = {
     store: {
       global: {
@@ -33,6 +37,9 @@ function createContext(fetchImpl: (input: string, init?: RequestInit) => Promise
     logbook: {
       forCallsign: vi.fn(() => ({
         queryQSOs,
+        addQSO,
+        updateQSO,
+        notifyUpdated,
       })),
     },
     log: {
@@ -48,6 +55,9 @@ function createContext(fetchImpl: (input: string, init?: RequestInit) => Promise
     ctx: ctx as unknown as PluginContext,
     store,
     queryQSOs,
+    addQSO,
+    updateQSO,
+    notifyUpdated,
     fetch: ctx.fetch,
   };
 }
@@ -58,6 +68,84 @@ function okResponse(payload: unknown, status = 200): Response {
     headers: { 'Content-Type': 'application/json' },
   });
 }
+
+function adifDownloadResponse(records: Array<{
+  call: string;
+  qsoDate: string;
+  timeOn: string;
+  freq: string;
+  mode: string;
+  lotwSent?: string;
+  lotwRcvd?: string;
+  lotwSentDate?: string;
+  lotwRcvdDate?: string;
+  myCall?: string;
+}>): Response {
+  const body = records.map((record) => {
+    const fields = [
+      `<call:${record.call.length}>${record.call}`,
+      `<qso_date:8>${record.qsoDate}`,
+      `<time_on:6>${record.timeOn}`,
+      `<freq:${record.freq.length}>${record.freq}`,
+      `<mode:${record.mode.length}>${record.mode}`,
+      `<station_callsign:${(record.myCall || 'BG5DRB').length}>${record.myCall || 'BG5DRB'}`,
+    ];
+    if (record.lotwSent) {
+      fields.push(`<lotw_qsl_sent:${record.lotwSent.length}>${record.lotwSent}`);
+    }
+    if (record.lotwRcvd) {
+      fields.push(`<lotw_qsl_rcvd:${record.lotwRcvd.length}>${record.lotwRcvd}`);
+    }
+    if (record.lotwSentDate) {
+      fields.push(`<lotw_qslsdate:8>${record.lotwSentDate}`);
+    }
+    if (record.lotwRcvdDate) {
+      fields.push(`<lotw_qslrdate:8>${record.lotwRcvdDate}`);
+    }
+    return `${fields.join('')}<eor>`;
+  }).join('\n');
+
+  return okResponse({
+    status: 'successful',
+    message: 'Export successful',
+    exported_qsos: records.length,
+    adif: body,
+  });
+}
+
+describe('buildWavelogQslStatusUpdates', () => {
+  it('merges higher-priority LoTW status from remote WaveLog records', () => {
+    const local = createQso('local-1');
+    const remote = createQso('remote-1', {
+      lotwQslSent: 'Y',
+      lotwQslReceived: 'Y',
+      lotwQslSentDate: Date.parse('2026-07-16T00:00:00.000Z'),
+      lotwQslReceivedDate: Date.parse('2026-07-16T00:00:00.000Z'),
+    });
+
+    expect(buildWavelogQslStatusUpdates(local, remote)).toEqual({
+      lotwQslSent: 'Y',
+      lotwQslReceived: 'Y',
+      lotwQslSentDate: Date.parse('2026-07-16T00:00:00.000Z'),
+      lotwQslReceivedDate: Date.parse('2026-07-16T00:00:00.000Z'),
+    });
+  });
+
+  it('does not downgrade existing confirmed LoTW status', () => {
+    const local = createQso('local-1', {
+      lotwQslSent: 'Y',
+      lotwQslReceived: 'Y',
+      lotwQslReceivedDate: Date.parse('2026-07-10T00:00:00.000Z'),
+    });
+    const remote = createQso('remote-1', {
+      lotwQslSent: 'N',
+      lotwQslReceived: 'R',
+      lotwQslReceivedDate: Date.parse('2026-07-01T00:00:00.000Z'),
+    });
+
+    expect(buildWavelogQslStatusUpdates(local, remote)).toBeNull();
+  });
+});
 
 describe('WaveLogSyncProvider', () => {
   it('single auto-upload uses explicit records without querying the whole logbook', async () => {
@@ -323,5 +411,117 @@ describe('WaveLogSyncProvider', () => {
       code: 'wavelog_upload_failed',
       message: 'Network request failed: check URL, network, and firewall',
     }));
+  });
+
+  it('download updates LoTW status on existing local matches instead of skipping', async () => {
+    const local = createQso('local-jq1xgv', {
+      callsign: 'JQ1XGV',
+      frequency: 144_460_970,
+      startTime: Date.parse('2026-07-16T03:01:00.000Z'),
+      endTime: Date.parse('2026-07-16T03:01:00.000Z'),
+    });
+    const { ctx, queryQSOs, addQSO, updateQSO, notifyUpdated } = createContext(async () =>
+      adifDownloadResponse([{
+        call: 'JQ1XGV',
+        qsoDate: '20260716',
+        timeOn: '030100',
+        freq: '144.46097',
+        mode: 'FT8',
+        lotwSent: 'Y',
+        lotwRcvd: 'Y',
+        lotwSentDate: '20260716',
+        lotwRcvdDate: '20260716',
+      }]),
+    );
+    queryQSOs.mockResolvedValue([local]);
+
+    const provider = new WaveLogSyncProvider(ctx);
+    provider.setConfig('BG5DRB', {
+      url: 'https://wavelog.example.com',
+      apiKey: 'api-key',
+      stationId: 'station-1',
+      radioName: 'TX5DR',
+      autoUploadQSO: true,
+    });
+
+    const result = await provider.download('BG5DRB');
+
+    expect(result).toEqual({
+      downloaded: 1,
+      matched: 1,
+      updated: 1,
+      imported: 0,
+      failures: undefined,
+    });
+    expect(addQSO).not.toHaveBeenCalled();
+    expect(updateQSO).toHaveBeenCalledWith('local-jq1xgv', expect.objectContaining({
+      lotwQslSent: 'Y',
+      lotwQslReceived: 'Y',
+    }));
+    expect(notifyUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  it('download imports unmatched remote QSOs and skips noop status merges', async () => {
+    const alreadySynced = createQso('local-synced', {
+      callsign: 'JH0BBE',
+      frequency: 144_460_970,
+      startTime: Date.parse('2026-07-16T03:03:00.000Z'),
+      endTime: Date.parse('2026-07-16T03:03:00.000Z'),
+      lotwQslSent: 'Y',
+      lotwQslSentDate: Date.parse('2026-07-16T00:00:00.000Z'),
+    });
+    const { ctx, queryQSOs, addQSO, updateQSO, notifyUpdated } = createContext(async () =>
+      adifDownloadResponse([
+        {
+          call: 'JH0BBE',
+          qsoDate: '20260716',
+          timeOn: '030300',
+          freq: '144.46097',
+          mode: 'FT8',
+          lotwSent: 'Y',
+          lotwSentDate: '20260716',
+        },
+        {
+          call: 'JO1LVZ',
+          qsoDate: '20260716',
+          timeOn: '025100',
+          freq: '144.460964',
+          mode: 'FT8',
+          lotwSent: 'Y',
+        },
+      ]),
+    );
+    queryQSOs.mockImplementation(async (filter?: { callsign?: string }) => {
+      if (filter?.callsign?.toUpperCase() === 'JH0BBE') {
+        return [alreadySynced];
+      }
+      return [];
+    });
+
+    const provider = new WaveLogSyncProvider(ctx);
+    provider.setConfig('BG5DRB', {
+      url: 'https://wavelog.example.com',
+      apiKey: 'api-key',
+      stationId: 'station-1',
+      radioName: 'TX5DR',
+      autoUploadQSO: true,
+    });
+
+    const result = await provider.download('BG5DRB');
+
+    expect(result).toEqual({
+      downloaded: 2,
+      matched: 1,
+      updated: 0,
+      imported: 1,
+      failures: undefined,
+    });
+    expect(updateQSO).not.toHaveBeenCalled();
+    expect(addQSO).toHaveBeenCalledTimes(1);
+    expect(addQSO.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      callsign: 'JO1LVZ',
+      lotwQslSent: 'Y',
+    }));
+    expect(notifyUpdated).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/builtin-plugins/src/wavelog-sync/provider.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/provider.ts
@@ -21,6 +21,7 @@ import {
   normalizeCallsign,
   sanitizeSyncFailureText,
 } from '@tx5dr/plugin-api';
+import { getBandFromFrequency } from '@tx5dr/core';
 
 /**
  * Per-callsign WaveLog configuration stored in plugin KVStore.
@@ -53,6 +54,135 @@ interface BatchUploadResult {
 const CONFIG_KEY_PREFIX = 'config:';
 const WAVELOG_BATCH_MAX_QSOS = 100;
 const WAVELOG_BATCH_MAX_PAYLOAD_BYTES = 512 * 1024;
+/** Match remote WaveLog QSOs to local records within this window. */
+const WAVELOG_DOWNLOAD_MATCH_TOLERANCE_MS = 15 * 60 * 1000;
+
+const LOTW_SENT_PRIORITY: Record<string, number> = {
+  I: 1,
+  N: 2,
+  R: 3,
+  Q: 4,
+  Y: 5,
+};
+
+const LOTW_RECEIVED_PRIORITY: Record<string, number> = {
+  I: 1,
+  N: 2,
+  R: 3,
+  Y: 4,
+  V: 5,
+};
+
+const QRZ_PRIORITY: Record<string, number> = {
+  N: 1,
+  Y: 2,
+};
+
+function normalizeQsoCallsign(value?: string): string {
+  return (value || '').trim().toUpperCase();
+}
+
+function normalizeQsoMode(value?: string): string {
+  const mode = (value || '').trim().toUpperCase();
+  if (mode === 'USB' || mode === 'LSB') return 'SSB';
+  return mode;
+}
+
+function matchBand(qso: QSORecord): string {
+  const band = getBandFromFrequency(qso.frequency);
+  return band === 'Unknown' ? '' : band.toUpperCase();
+}
+
+function matchMode(qso: QSORecord): string {
+  return normalizeQsoMode(qso.mode);
+}
+
+function mergeStatusValue<T extends string | undefined>(
+  current: T,
+  incoming: T,
+  priority: Record<string, number>,
+): T {
+  if (!incoming) {
+    return current;
+  }
+  if (!current) {
+    return incoming;
+  }
+  return (priority[incoming] || 0) > (priority[current] || 0) ? incoming : current;
+}
+
+function mergeTimestampValue(current?: number, incoming?: number): number | undefined {
+  if (!Number.isFinite(incoming)) {
+    return current;
+  }
+  if (!Number.isFinite(current)) {
+    return incoming;
+  }
+  return Math.max(current!, incoming!);
+}
+
+/**
+ * Build a partial update that merges remote WaveLog QSL status into a local QSO.
+ * Returns null when nothing would change.
+ */
+export function buildWavelogQslStatusUpdates(
+  local: QSORecord,
+  remote: QSORecord,
+): Partial<QSORecord> | null {
+  const updates: Partial<QSORecord> = {};
+
+  const nextLotwSent = mergeStatusValue(local.lotwQslSent, remote.lotwQslSent, LOTW_SENT_PRIORITY);
+  if (nextLotwSent !== local.lotwQslSent) {
+    updates.lotwQslSent = nextLotwSent;
+  }
+
+  const nextLotwReceived = mergeStatusValue(
+    local.lotwQslReceived,
+    remote.lotwQslReceived,
+    LOTW_RECEIVED_PRIORITY,
+  );
+  if (nextLotwReceived !== local.lotwQslReceived) {
+    updates.lotwQslReceived = nextLotwReceived;
+  }
+
+  const nextQrzSent = mergeStatusValue(local.qrzQslSent, remote.qrzQslSent, QRZ_PRIORITY);
+  if (nextQrzSent !== local.qrzQslSent) {
+    updates.qrzQslSent = nextQrzSent;
+  }
+
+  const nextQrzReceived = mergeStatusValue(local.qrzQslReceived, remote.qrzQslReceived, QRZ_PRIORITY);
+  if (nextQrzReceived !== local.qrzQslReceived) {
+    updates.qrzQslReceived = nextQrzReceived;
+  }
+
+  const nextLotwSentDate = mergeTimestampValue(local.lotwQslSentDate, remote.lotwQslSentDate);
+  if (nextLotwSentDate !== local.lotwQslSentDate) {
+    updates.lotwQslSentDate = nextLotwSentDate;
+  }
+
+  const nextLotwReceivedDate = mergeTimestampValue(
+    local.lotwQslReceivedDate,
+    remote.lotwQslReceivedDate,
+  );
+  if (nextLotwReceivedDate !== local.lotwQslReceivedDate) {
+    updates.lotwQslReceivedDate = nextLotwReceivedDate;
+  }
+
+  const nextQrzSentDate = mergeTimestampValue(local.qrzQslSentDate, remote.qrzQslSentDate);
+  if (nextQrzSentDate !== local.qrzQslSentDate) {
+    updates.qrzQslSentDate = nextQrzSentDate;
+  }
+
+  const nextQrzReceivedDate = mergeTimestampValue(
+    local.qrzQslReceivedDate,
+    remote.qrzQslReceivedDate,
+  );
+  if (nextQrzReceivedDate !== local.qrzQslReceivedDate) {
+    updates.qrzQslReceivedDate = nextQrzReceivedDate;
+  }
+
+  return Object.keys(updates).length > 0 ? updates : null;
+}
 
 /**
  * WaveLog sync provider — implements LogbookSyncProvider.
@@ -228,27 +358,28 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
 
     try {
       const records = await this.downloadQSOs(config);
-      let stored = 0;
-      let skipped = 0;
+      let matched = 0;
+      let updated = 0;
+      let imported = 0;
       const failures: SyncFailure[] = [];
 
       for (const remoteQSO of records) {
         try {
-          // Check for existing QSO with same callsign and time
-          const existing = await logbook.queryQSOs({
-            callsign: remoteQSO.callsign,
-            timeRange: {
-              start: remoteQSO.startTime,
-              end: remoteQSO.endTime || remoteQSO.startTime,
-            },
-            limit: 1,
-          });
+          const localMatches = await this.findLocalMatches(logbook, remoteQSO, callsign);
 
-          if (existing.length > 0) {
-            skipped++;
+          if (localMatches.length > 0) {
+            matched++;
+            for (const localMatch of localMatches) {
+              const statusUpdates = buildWavelogQslStatusUpdates(localMatch, remoteQSO);
+              if (!statusUpdates) {
+                continue;
+              }
+              await logbook.updateQSO(localMatch.id, statusUpdates);
+              updated++;
+            }
           } else {
             await logbook.addQSO(remoteQSO);
-            stored++;
+            imported++;
           }
         } catch (err) {
           failures.push(createSyncFailure({
@@ -265,18 +396,18 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
             callsign: remoteQSO.callsign,
             error: err instanceof Error ? err.message : String(err),
           });
-          skipped++;
         }
       }
 
-      if (stored > 0) {
+      if (updated > 0 || imported > 0) {
         await logbook.notifyUpdated();
       }
 
       return {
         downloaded: records.length,
-        matched: skipped,
-        updated: stored,
+        matched,
+        updated,
+        imported,
         failures: failures.length > 0 ? failures : undefined,
       };
     } catch (err) {
@@ -287,6 +418,60 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
         failures: [this.errorFailure(err, 'download', 'wavelog_download_failed', config)],
       };
     }
+  }
+
+  /**
+   * Find all local QSO matches for a WaveLog download record.
+   * Returns every candidate that passes station/band/mode filters within the
+   * time window, ranked by score. Callers should merge QSL status into all of
+   * them so previously-imported duplicates and original locals both update.
+   */
+  private async findLocalMatches(
+    logbook: ReturnType<PluginContext['logbook']['forCallsign']>,
+    remote: QSORecord,
+    fallbackCallsign: string,
+  ): Promise<QSORecord[]> {
+    const candidates = await logbook.queryQSOs({
+      callsign: remote.callsign,
+      timeRange: {
+        start: remote.startTime - WAVELOG_DOWNLOAD_MATCH_TOLERANCE_MS,
+        end: (remote.endTime || remote.startTime) + WAVELOG_DOWNLOAD_MATCH_TOLERANCE_MS,
+      },
+      limit: 25,
+    });
+
+    if (candidates.length === 0) {
+      return [];
+    }
+
+    const remoteStation = normalizeQsoCallsign(remote.myCallsign || fallbackCallsign);
+    const remoteBand = matchBand(remote);
+    const remoteMode = matchMode(remote);
+
+    return candidates
+      .map((local) => {
+        let score = 0;
+        const localStation = normalizeQsoCallsign(local.myCallsign || fallbackCallsign);
+        if (remoteStation && localStation === remoteStation) score += 8;
+        if (remoteBand && matchBand(local) === remoteBand) score += 5;
+        if (remoteMode && matchMode(local) === remoteMode) score += 5;
+        const frequencyDelta = Math.abs((local.frequency || 0) - (remote.frequency || 0));
+        if (frequencyDelta <= 3000) score += 2;
+        const timeDelta = Math.abs((local.startTime || 0) - (remote.startTime || 0));
+        score += Math.max(0, 3 - Math.floor(timeDelta / (5 * 60 * 1000)));
+        // Prefer originals that still lack LoTW status over already-synced copies.
+        if (!local.lotwQslSent && !local.lotwQslReceived) score += 4;
+        return { local, score, timeDelta };
+      })
+      .filter(({ local }) => {
+        const localStation = normalizeQsoCallsign(local.myCallsign || fallbackCallsign);
+        if (remoteStation && localStation && localStation !== remoteStation) return false;
+        if (remoteBand && matchBand(local) && matchBand(local) !== remoteBand) return false;
+        if (remoteMode && matchMode(local) && matchMode(local) !== remoteMode) return false;
+        return true;
+      })
+      .sort((left, right) => right.score - left.score || left.timeDelta - right.timeDelta)
+      .map(({ local }) => local);
   }
 
   // ===== HTTP client methods (extracted from WaveLogService) =====

--- a/packages/builtin-plugins/src/wavelog-sync/provider.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/provider.ts
@@ -78,8 +78,14 @@ const QRZ_PRIORITY: Record<string, number> = {
   Y: 2,
 };
 
-function normalizeQsoCallsign(value?: string): string {
-  return (value || '').trim().toUpperCase();
+/**
+ * Normalize the station (own) callsign for matching. Uses normalizeCallsign
+ * so portable/mobile suffixes are stripped ("BG5DRB/P" matches "BG5DRB"),
+ * consistent with configKey. Only used for the station side — the contacted
+ * callsign keeps its exact-match semantics in the logbook query filter.
+ */
+function normalizeStationCallsign(value?: string): string {
+  return normalizeCallsign(value || '');
 }
 
 function normalizeQsoMode(value?: string): string {
@@ -131,9 +137,15 @@ export function buildWavelogQslStatusUpdates(
 ): Partial<QSORecord> | null {
   const updates: Partial<QSORecord> = {};
 
+  // Dates are merged only together with a status set/upgrade, so a record
+  // never carries a QSL date that belongs to a different status value.
   const nextLotwSent = mergeStatusValue(local.lotwQslSent, remote.lotwQslSent, LOTW_SENT_PRIORITY);
   if (nextLotwSent !== local.lotwQslSent) {
     updates.lotwQslSent = nextLotwSent;
+    const nextLotwSentDate = mergeTimestampValue(local.lotwQslSentDate, remote.lotwQslSentDate);
+    if (nextLotwSentDate !== local.lotwQslSentDate) {
+      updates.lotwQslSentDate = nextLotwSentDate;
+    }
   }
 
   const nextLotwReceived = mergeStatusValue(
@@ -143,42 +155,34 @@ export function buildWavelogQslStatusUpdates(
   );
   if (nextLotwReceived !== local.lotwQslReceived) {
     updates.lotwQslReceived = nextLotwReceived;
+    const nextLotwReceivedDate = mergeTimestampValue(
+      local.lotwQslReceivedDate,
+      remote.lotwQslReceivedDate,
+    );
+    if (nextLotwReceivedDate !== local.lotwQslReceivedDate) {
+      updates.lotwQslReceivedDate = nextLotwReceivedDate;
+    }
   }
 
   const nextQrzSent = mergeStatusValue(local.qrzQslSent, remote.qrzQslSent, QRZ_PRIORITY);
   if (nextQrzSent !== local.qrzQslSent) {
     updates.qrzQslSent = nextQrzSent;
+    const nextQrzSentDate = mergeTimestampValue(local.qrzQslSentDate, remote.qrzQslSentDate);
+    if (nextQrzSentDate !== local.qrzQslSentDate) {
+      updates.qrzQslSentDate = nextQrzSentDate;
+    }
   }
 
   const nextQrzReceived = mergeStatusValue(local.qrzQslReceived, remote.qrzQslReceived, QRZ_PRIORITY);
   if (nextQrzReceived !== local.qrzQslReceived) {
     updates.qrzQslReceived = nextQrzReceived;
-  }
-
-  const nextLotwSentDate = mergeTimestampValue(local.lotwQslSentDate, remote.lotwQslSentDate);
-  if (nextLotwSentDate !== local.lotwQslSentDate) {
-    updates.lotwQslSentDate = nextLotwSentDate;
-  }
-
-  const nextLotwReceivedDate = mergeTimestampValue(
-    local.lotwQslReceivedDate,
-    remote.lotwQslReceivedDate,
-  );
-  if (nextLotwReceivedDate !== local.lotwQslReceivedDate) {
-    updates.lotwQslReceivedDate = nextLotwReceivedDate;
-  }
-
-  const nextQrzSentDate = mergeTimestampValue(local.qrzQslSentDate, remote.qrzQslSentDate);
-  if (nextQrzSentDate !== local.qrzQslSentDate) {
-    updates.qrzQslSentDate = nextQrzSentDate;
-  }
-
-  const nextQrzReceivedDate = mergeTimestampValue(
-    local.qrzQslReceivedDate,
-    remote.qrzQslReceivedDate,
-  );
-  if (nextQrzReceivedDate !== local.qrzQslReceivedDate) {
-    updates.qrzQslReceivedDate = nextQrzReceivedDate;
+    const nextQrzReceivedDate = mergeTimestampValue(
+      local.qrzQslReceivedDate,
+      remote.qrzQslReceivedDate,
+    );
+    if (nextQrzReceivedDate !== local.qrzQslReceivedDate) {
+      updates.qrzQslReceivedDate = nextQrzReceivedDate;
+    }
   }
 
   return Object.keys(updates).length > 0 ? updates : null;
@@ -365,15 +369,12 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
 
       for (const remoteQSO of records) {
         try {
-          const localMatches = await this.findLocalMatches(logbook, remoteQSO, callsign);
+          const localMatch = await this.findBestLocalMatch(logbook, remoteQSO, callsign);
 
-          if (localMatches.length > 0) {
+          if (localMatch) {
             matched++;
-            for (const localMatch of localMatches) {
-              const statusUpdates = buildWavelogQslStatusUpdates(localMatch, remoteQSO);
-              if (!statusUpdates) {
-                continue;
-              }
+            const statusUpdates = buildWavelogQslStatusUpdates(localMatch, remoteQSO);
+            if (statusUpdates) {
               await logbook.updateQSO(localMatch.id, statusUpdates);
               updated++;
             }
@@ -421,16 +422,17 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
   }
 
   /**
-   * Find all local QSO matches for a WaveLog download record.
-   * Returns every candidate that passes station/band/mode filters within the
-   * time window, ranked by score. Callers should merge QSL status into all of
-   * them so previously-imported duplicates and original locals both update.
+   * Find the single best local QSO match for a WaveLog download record.
+   * Candidates must pass station/band/mode filters within the time window and
+   * are ranked by score; only the top candidate is returned so one remote
+   * record never stamps QSL status onto multiple local QSOs (same convention
+   * as lotw-sync's findLotwLocalMatch).
    */
-  private async findLocalMatches(
+  private async findBestLocalMatch(
     logbook: ReturnType<PluginContext['logbook']['forCallsign']>,
     remote: QSORecord,
     fallbackCallsign: string,
-  ): Promise<QSORecord[]> {
+  ): Promise<QSORecord | null> {
     const candidates = await logbook.queryQSOs({
       callsign: remote.callsign,
       timeRange: {
@@ -441,17 +443,17 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
     });
 
     if (candidates.length === 0) {
-      return [];
+      return null;
     }
 
-    const remoteStation = normalizeQsoCallsign(remote.myCallsign || fallbackCallsign);
+    const remoteStation = normalizeStationCallsign(remote.myCallsign || fallbackCallsign);
     const remoteBand = matchBand(remote);
     const remoteMode = matchMode(remote);
 
-    return candidates
+    const scored = candidates
       .map((local) => {
         let score = 0;
-        const localStation = normalizeQsoCallsign(local.myCallsign || fallbackCallsign);
+        const localStation = normalizeStationCallsign(local.myCallsign || fallbackCallsign);
         if (remoteStation && localStation === remoteStation) score += 8;
         if (remoteBand && matchBand(local) === remoteBand) score += 5;
         if (remoteMode && matchMode(local) === remoteMode) score += 5;
@@ -464,14 +466,15 @@ export class WaveLogSyncProvider implements LogbookSyncProvider {
         return { local, score, timeDelta };
       })
       .filter(({ local }) => {
-        const localStation = normalizeQsoCallsign(local.myCallsign || fallbackCallsign);
+        const localStation = normalizeStationCallsign(local.myCallsign || fallbackCallsign);
         if (remoteStation && localStation && localStation !== remoteStation) return false;
         if (remoteBand && matchBand(local) && matchBand(local) !== remoteBand) return false;
         if (remoteMode && matchMode(local) && matchMode(local) !== remoteMode) return false;
         return true;
       })
-      .sort((left, right) => right.score - left.score || left.timeDelta - right.timeDelta)
-      .map(({ local }) => local);
+      .sort((left, right) => right.score - left.score || left.timeDelta - right.timeDelta);
+
+    return scored[0]?.local ?? null;
   }
 
   // ===== HTTP client methods (extracted from WaveLogService) =====


### PR DESCRIPTION
## Summary
- WaveLog download path now syncs QSL status that previously stayed stale.

## Test plan
- [ ] Download QSOs from WaveLog and confirm QSL fields update
- [ ] Run WaveLog provider tests

Split from #57 / follow-up.