### PR TITLE
fix: resolve serial device path by USB serial number

### DIFF
--- a/packages/contracts/src/schema/radio.schema.ts
+++ b/packages/contracts/src/schema/radio.schema.ts
@@ -212,6 +212,7 @@ export const TciConfigSchema = z.object({
  */
 export const SerialConnectionConfigSchema = z.object({
   path: z.string(),
+  serialNumber: z.string().optional(),
   rigModel: z.number().int(),
   serialConfig: SerialConfigSchema.optional(),
   backendConfig: HamlibBackendConfigSchema.optional(),

--- a/packages/server/src/radio/__tests__/HamlibConnection.resolveSerialDevicePath.test.ts
+++ b/packages/server/src/radio/__tests__/HamlibConnection.resolveSerialDevicePath.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serialPortListMock } = vi.hoisted(() => ({
+  serialPortListMock: vi.fn(),
+}));
+
+vi.mock('serialport', () => ({
+  default: {
+    SerialPort: {
+      list: serialPortListMock,
+    },
+  },
+}));
+
+import { HamlibConnection } from '../connections/HamlibConnection.js';
+import type { RadioConnectionConfig } from '../connections/IRadioConnection.js';
+
+type ResolveAccessor = {
+  resolveSerialDevicePath(config: RadioConnectionConfig): Promise<RadioConnectionConfig>;
+};
+
+function resolveSerialDevicePath(connection: HamlibConnection, config: RadioConnectionConfig) {
+  return (connection as unknown as ResolveAccessor).resolveSerialDevicePath(config);
+}
+
+function serialConfig(path: string, serialNumber: string | undefined): RadioConnectionConfig {
+  return {
+    type: 'serial',
+    serial: {
+      path,
+      serialNumber,
+      rigModel: 1234,
+      backendConfig: { rig_pathname: path },
+    },
+  };
+}
+
+describe('HamlibConnection.resolveSerialDevicePath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the config untouched when no serial number is configured', async () => {
+    const connection = new HamlibConnection();
+    const config = serialConfig('/dev/ttyUSB0', undefined);
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+    expect(serialPortListMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps a configured macOS callout path when enumeration only reports the dialin node', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: '/dev/tty.usbserial-ABC123', serialNumber: 'SN-1' },
+    ]);
+    const config = serialConfig('/dev/cu.usbserial-ABC123', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+    expect(result.serial?.path).toBe('/dev/cu.usbserial-ABC123');
+    expect(result.serial?.backendConfig?.rig_pathname).toBe('/dev/cu.usbserial-ABC123');
+  });
+
+  it('maps a re-enumerated dialin path back to the configured callout form', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: '/dev/tty.usbserial-XYZ999', serialNumber: 'SN-1' },
+    ]);
+    const config = serialConfig('/dev/cu.usbserial-ABC123', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result.serial?.path).toBe('/dev/cu.usbserial-XYZ999');
+    expect(result.serial?.backendConfig?.rig_pathname).toBe('/dev/cu.usbserial-XYZ999');
+  });
+
+  it('rewrites the path when the device re-enumerates under a different name', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: '/dev/ttyUSB1', serialNumber: 'SN-1' },
+    ]);
+    const config = serialConfig('/dev/ttyUSB0', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result.serial?.path).toBe('/dev/ttyUSB1');
+    expect(result.serial?.backendConfig?.rig_pathname).toBe('/dev/ttyUSB1');
+  });
+
+  it('skips resolution for host:port endpoints with a stale serial number', async () => {
+    const connection = new HamlibConnection();
+    const config = serialConfig('127.0.0.1:4532', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+    expect(serialPortListMock).not.toHaveBeenCalled();
+  });
+
+  it('skips resolution for custom non-device paths with a stale serial number', async () => {
+    const connection = new HamlibConnection();
+    const config = serialConfig('rigctl-proxy', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+    expect(serialPortListMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the configured path when the serial number is not enumerated', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: '/dev/ttyUSB9', serialNumber: 'OTHER' },
+    ]);
+    const config = serialConfig('/dev/ttyUSB0', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+  });
+
+  it('falls back to the configured path when enumeration fails', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockRejectedValue(new Error('permission denied'));
+    const config = serialConfig('/dev/ttyUSB0', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+  });
+
+  it('keeps the configured path when duplicate serial numbers still include it', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: '/dev/ttyUSB0', serialNumber: 'FTDI' },
+      { path: '/dev/ttyUSB1', serialNumber: 'FTDI' },
+    ]);
+    const config = serialConfig('/dev/ttyUSB0', 'FTDI');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+  });
+
+  it('keeps the configured path when duplicate serial numbers make the target ambiguous', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: '/dev/ttyUSB1', serialNumber: 'FTDI' },
+      { path: '/dev/ttyUSB2', serialNumber: 'FTDI' },
+    ]);
+    const config = serialConfig('/dev/ttyUSB0', 'FTDI');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result).toBe(config);
+    expect(result.serial?.path).toBe('/dev/ttyUSB0');
+  });
+
+  it('matches the serial number case-insensitively', async () => {
+    const connection = new HamlibConnection();
+    serialPortListMock.mockResolvedValue([
+      { path: 'COM4', serialNumber: 'sn-1' },
+    ]);
+    const config = serialConfig('COM3', 'SN-1');
+
+    const result = await resolveSerialDevicePath(connection, config);
+
+    expect(result.serial?.path).toBe('COM4');
+    expect(result.serial?.backendConfig?.rig_pathname).toBe('COM4');
+  });
+});

--- a/packages/server/src/radio/connections/HamlibConnection.ts
+++ b/packages/server/src/radio/connections/HamlibConnection.ts
@@ -28,6 +28,11 @@ import { createLogger } from '../../utils/logger.js';
 import { isProcessShuttingDown } from '../../utils/process-shutdown.js';
 import { isRecoverableOptionalRadioError } from '../optionalRadioError.js';
 import { buildBackendConfig } from '../hamlibConfigUtils.js';
+import {
+  darwinCalloutPathFromDialin,
+  isSameDarwinSerialDevice,
+  looksLikeLocalSerialDevicePath,
+} from '../serialPortPath.js';
 import { RADIO_IO_SKIPPED, RadioIoQueue, type RadioIoTaskContext, type RadioIoTaskOptions } from './RadioIoQueue.js';
 import {
   type ApplyOperatingStateRequest,
@@ -576,39 +581,66 @@ export class HamlibConnection
       return config;
     }
 
+    // 防线：network（host:port）或自定义路径端点在数据模型上也是 type: 'serial'，
+    // 其中残留的 serialNumber 不应把端点"劫持"回本机 USB 设备
+    const configuredPath = config.serial.backendConfig?.rig_pathname ?? config.serial.path;
+    if (!looksLikeLocalSerialDevicePath(configuredPath)) {
+      return config;
+    }
+
     try {
       const ports = await SerialPort.list();
-      const exactMatch = ports.find((port) => port.serialNumber?.trim() === targetSerial);
       const normalizedTarget = targetSerial.toLowerCase();
-      const normalizedMatch = exactMatch
-        ?? ports.find((port) => port.serialNumber?.trim().toLowerCase() === normalizedTarget);
+      const matches = ports.filter((port) => port.serialNumber?.trim().toLowerCase() === normalizedTarget);
+      const exactMatches = matches.filter((port) => port.serialNumber?.trim() === targetSerial);
+      const candidates = exactMatches.length > 0 ? exactMatches : matches;
 
-      if (!normalizedMatch?.path) {
+      if (candidates.length === 0) {
         logger.warn('Configured serial number not found in current port list', {
           serialNumber: targetSerial,
-          configuredPath: config.serial.path,
+          configuredPath,
         });
         return config;
       }
 
-      if (normalizedMatch.path === config.serial.path) {
+      // 已配置路径仍在匹配集合中时保持不变——尤其避免把用户显式选择的
+      // macOS /dev/cu.* callout 端口改写为同一设备的 /dev/tty.* dialin 节点
+      if (candidates.some((port) => port.path === configuredPath || isSameDarwinSerialDevice(port.path, configuredPath))) {
         return config;
       }
 
+      // 多个设备共享同一 serialNumber（未烧录序列号的 FTDI/CH340 常见）时无法
+      // 确定目标设备，放弃重写、回退原配置
+      if (candidates.length > 1) {
+        logger.warn('Multiple serial ports share the configured serial number, keeping configured path', {
+          serialNumber: targetSerial,
+          configuredPath,
+          matchedPaths: candidates.map((port) => port.path),
+        });
+        return config;
+      }
+
+      const matchedPath = candidates[0]!.path;
+      // 设备重新枚举（端口名变化）需要重写时，优先映射回与配置相同的 cu/tty 形态
+      const calloutPath = configuredPath.startsWith('/dev/cu.')
+        ? darwinCalloutPathFromDialin(matchedPath)
+        : null;
+      const resolvedPath = calloutPath ?? matchedPath;
+
       logger.info('Resolved serial device path from serial number', {
         serialNumber: targetSerial,
-        previousPath: config.serial.path,
-        resolvedPath: normalizedMatch.path,
+        previousPath: configuredPath,
+        resolvedPath,
       });
 
       return {
         ...config,
         serial: {
           ...config.serial,
-          path: normalizedMatch.path,
+          path: resolvedPath,
           backendConfig: {
             ...(config.serial.backendConfig ?? {}),
-            rig_pathname: normalizedMatch.path,
+            rig_pathname: resolvedPath,
           },
         },
       };

--- a/packages/server/src/radio/connections/HamlibConnection.ts
+++ b/packages/server/src/radio/connections/HamlibConnection.ts
@@ -13,6 +13,7 @@ import { HamLib } from 'hamlib';
 import type { PttType } from 'hamlib';
 import { SpectrumController } from 'hamlib/spectrum';
 import type { ManagedSpectrumConfig, SpectrumLine, SpectrumSupportSummary } from 'hamlib/spectrum';
+import serialport from 'serialport';
 import type { LevelMeterReading, MeterCapabilities, SerialConfig } from '@tx5dr/contracts';
 import {
   type MeterDecodeStrategy,
@@ -47,6 +48,7 @@ import {
 
 const logger = createLogger('HamlibConnection');
 const HAMLIB_POLLING_OPERATION_TIMEOUT_MS = 5000;
+const { SerialPort } = serialport;
 
 // RigMetadata is imported from meter/types.ts
 
@@ -461,8 +463,12 @@ export class HamlibConnection
       });
     }
 
+    const effectiveConfig = config.type === 'serial'
+      ? await this.resolveSerialDevicePath(config)
+      : config;
+
     // 验证必需参数
-    if (config.type === 'network' && (!config.network || !config.network.host || !config.network.port)) {
+    if (effectiveConfig.type === 'network' && (!effectiveConfig.network || !effectiveConfig.network.host || !effectiveConfig.network.port)) {
       throw new RadioError({
         code: RadioErrorCode.INVALID_CONFIG,
         message: 'Hamlib network configuration missing required fields: network.host, network.port',
@@ -471,7 +477,7 @@ export class HamlibConnection
       });
     }
 
-    if (config.type === 'serial' && (!config.serial || !config.serial.path || !config.serial.rigModel)) {
+    if (effectiveConfig.type === 'serial' && (!effectiveConfig.serial || !effectiveConfig.serial.path || !effectiveConfig.serial.rigModel)) {
       throw new RadioError({
         code: RadioErrorCode.INVALID_CONFIG,
         message: 'Hamlib serial configuration missing required fields: serial.path, serial.rigModel',
@@ -481,7 +487,7 @@ export class HamlibConnection
     }
 
     // 保存配置
-    this.currentConfig = config;
+    this.currentConfig = effectiveConfig;
     this.ioSessionId += 1;
     this.backgroundTasksStarted = false;
 
@@ -490,15 +496,15 @@ export class HamlibConnection
 
     try {
       logger.debug(
-        `Connecting to Hamlib radio: ${config.type === 'network' ? `${config.network!.host}:${config.network!.port}` : config.serial!.path}`
+        `Connecting to Hamlib radio: ${effectiveConfig.type === 'network' ? `${effectiveConfig.network!.host}:${effectiveConfig.network!.port}` : effectiveConfig.serial!.path}`
       );
 
       // 确定连接参数
       const port =
-        config.type === 'network'
-          ? `${config.network!.host}:${config.network!.port}`
+        effectiveConfig.type === 'network'
+          ? `${effectiveConfig.network!.host}:${effectiveConfig.network!.port}`
           : undefined;
-      const model = config.type === 'network' ? 2 : config.serial!.rigModel;
+      const model = effectiveConfig.type === 'network' ? 2 : effectiveConfig.serial!.rigModel;
 
       // 创建 HamLib 实例
       const rig = new HamLib(model as any, port as any) as HamLib;
@@ -506,7 +512,7 @@ export class HamlibConnection
       this.spectrumController = new SpectrumController(rig);
 
       // 配置 PTT 类型（必须在 open() 前调用）
-      this.pttMethod = config.pttMethod || 'cat';
+      this.pttMethod = effectiveConfig.pttMethod || 'cat';
       const pttTypeMap: Record<string, PttType> = {
         'cat': 'RIG',
         'vox': 'NONE',
@@ -518,8 +524,8 @@ export class HamlibConnection
       await rig.setPttType(hamlibPttType);
 
       // 应用 Hamlib backend 配置（如果有）
-      if (config.type === 'serial' && config.serial) {
-        await this.applyBackendConfig(config.serial);
+      if (effectiveConfig.type === 'serial' && effectiveConfig.serial) {
+        await this.applyBackendConfig(effectiveConfig.serial);
       }
 
       // 打开连接（带超时保护）
@@ -557,6 +563,61 @@ export class HamlibConnection
 
       // 转换错误
       throw this.convertError(error, 'connect');
+    }
+  }
+
+  private async resolveSerialDevicePath(config: RadioConnectionConfig): Promise<RadioConnectionConfig> {
+    if (config.type !== 'serial' || !config.serial?.serialNumber) {
+      return config;
+    }
+
+    const targetSerial = config.serial.serialNumber.trim();
+    if (!targetSerial) {
+      return config;
+    }
+
+    try {
+      const ports = await SerialPort.list();
+      const exactMatch = ports.find((port) => port.serialNumber?.trim() === targetSerial);
+      const normalizedTarget = targetSerial.toLowerCase();
+      const normalizedMatch = exactMatch
+        ?? ports.find((port) => port.serialNumber?.trim().toLowerCase() === normalizedTarget);
+
+      if (!normalizedMatch?.path) {
+        logger.warn('Configured serial number not found in current port list', {
+          serialNumber: targetSerial,
+          configuredPath: config.serial.path,
+        });
+        return config;
+      }
+
+      if (normalizedMatch.path === config.serial.path) {
+        return config;
+      }
+
+      logger.info('Resolved serial device path from serial number', {
+        serialNumber: targetSerial,
+        previousPath: config.serial.path,
+        resolvedPath: normalizedMatch.path,
+      });
+
+      return {
+        ...config,
+        serial: {
+          ...config.serial,
+          path: normalizedMatch.path,
+          backendConfig: {
+            ...(config.serial.backendConfig ?? {}),
+            rig_pathname: normalizedMatch.path,
+          },
+        },
+      };
+    } catch (error) {
+      logger.warn('Failed to resolve serial path from serial number', {
+        serialNumber: targetSerial,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return config;
     }
   }
 

--- a/packages/server/src/radio/hamlibConfigUtils.ts
+++ b/packages/server/src/radio/hamlibConfigUtils.ts
@@ -76,6 +76,7 @@ export function normalizeSerialConnectionConfig(serial?: Partial<SerialConnectio
 
   return {
     path: normalizedPath,
+    serialNumber: serial.serialNumber,
     rigModel: serial.rigModel ?? 0,
     serialConfig: serial.serialConfig,
     backendConfig,

--- a/packages/server/src/radio/serialPortPath.ts
+++ b/packages/server/src/radio/serialPortPath.ts
@@ -1,0 +1,49 @@
+/**
+ * 串口设备路径工具
+ *
+ * macOS 为同一物理串口设备同时提供 callout（/dev/cu.X）与
+ * dialin（/dev/tty.X）两个设备节点，二者在 DCD 阻塞语义上有差异，
+ * 因此路径比较/改写时需要把仅 cu/tty 前缀不同的路径视为同一设备。
+ */
+
+const DARWIN_DEVICE_PREFIX = /^\/dev\/(?:cu|tty)\./;
+
+/**
+ * 提取 macOS 串口设备名（去掉 /dev/cu. 或 /dev/tty. 前缀）。
+ * 非 macOS cu/tty 形态的路径返回 null。
+ */
+export function darwinSerialDeviceKey(path: string): string | null {
+  const match = DARWIN_DEVICE_PREFIX.exec(path);
+  return match ? path.slice(match[0].length) : null;
+}
+
+/**
+ * 判断两个路径是否指向同一 macOS 物理串口设备（仅 cu/tty 前缀不同）。
+ */
+export function isSameDarwinSerialDevice(a: string, b: string): boolean {
+  const keyA = darwinSerialDeviceKey(a);
+  return keyA !== null && keyA === darwinSerialDeviceKey(b);
+}
+
+/**
+ * 把 /dev/tty.X dialin 路径转换为 /dev/cu.X callout 路径。
+ * 非 /dev/tty. 形态的路径返回 null。
+ */
+export function darwinCalloutPathFromDialin(path: string): string | null {
+  if (!path.startsWith('/dev/tty.')) {
+    return null;
+  }
+  return `/dev/cu.${path.slice('/dev/tty.'.length)}`;
+}
+
+/**
+ * 判断路径是否是本机串口设备形态（/dev/* 或 Windows COMn）。
+ * host:port 等 network 端点、自定义路径返回 false。
+ */
+export function looksLikeLocalSerialDevicePath(path: string | undefined): boolean {
+  if (!path) {
+    return false;
+  }
+  const trimmed = path.trim();
+  return trimmed.startsWith('/dev/') || /^COM\d+$/i.test(trimmed);
+}

--- a/packages/server/src/routes/radio.ts
+++ b/packages/server/src/routes/radio.ts
@@ -31,6 +31,7 @@ import {
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { RadioError, RadioErrorCode, RadioErrorSeverity } from '../utils/errors/RadioError.js';
 import { normalizeHamlibConfig } from '../radio/hamlibConfigUtils.js';
+import { darwinCalloutPathFromDialin } from '../radio/serialPortPath.js';
 import { buildRadioStatusPayload } from '../radio/buildRadioStatusPayload.js';
 import { canReadFullProfiles, redactHamlibConfigForRead } from '../security/profileRedaction.js';
 
@@ -42,12 +43,13 @@ export {
 type SerialPortInfo = Awaited<ReturnType<typeof SerialPort.list>>[number];
 
 function buildDarwinCalloutPortFromDialin(port: SerialPortInfo): SerialPortInfo | null {
-  if (!port.path.startsWith('/dev/tty.')) {
+  const calloutPath = darwinCalloutPathFromDialin(port.path);
+  if (!calloutPath) {
     return null;
   }
   return {
     ...port,
-    path: `/dev/cu.${port.path.slice('/dev/tty.'.length)}`,
+    path: calloutPath,
   };
 }
 

--- a/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
+++ b/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
@@ -493,6 +493,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
         ...prev,
         serial: {
           path,
+          serialNumber: prevSerial?.serialNumber,
           rigModel: prevSerial?.rigModel ?? 0,
           serialConfig: prevSerial?.serialConfig,
           backendConfig,
@@ -1084,6 +1085,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: rigPath,
+                            serialNumber: config.serial?.serialNumber,
                             rigModel: nextRigModel,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: rigPath ? { rig_pathname: rigPath } : {},
@@ -1128,6 +1130,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: value,
+                            serialNumber: config.serial?.serialNumber,
                             rigModel: config.serial?.rigModel ?? 0,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: {
@@ -1151,6 +1154,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: value,
+                            serialNumber: config.serial?.serialNumber,
                             rigModel: config.serial?.rigModel ?? 0,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: {
@@ -1175,6 +1179,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: value,
+                            serialNumber: ports.find((port) => port.path === value)?.serialNumber,
                             rigModel: config.serial?.rigModel ?? 0,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: {
@@ -1186,14 +1191,17 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                       }}
                       onSelectionChange={selectedKey => {
                         if (selectedKey !== null) {
+                          const selectedPath = String(selectedKey);
+                          const selectedPort = ports.find((port) => port.path === selectedPath);
                           updateConfig({
                             serial: {
-                              path: String(selectedKey),
+                              path: selectedPath,
+                              serialNumber: selectedPort?.serialNumber,
                               rigModel: config.serial?.rigModel ?? 0,
                               serialConfig: config.serial?.serialConfig,
                               backendConfig: {
                                 ...(config.serial?.backendConfig || {}),
-                                rig_pathname: String(selectedKey),
+                                rig_pathname: selectedPath,
                               },
                             }
                           });

--- a/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
+++ b/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
@@ -314,6 +314,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                     serial: {
                       ...prev.serial,
                       path: '',
+                      serialNumber: undefined,
                       backendConfig: nextBackendConfig,
                     },
                   };
@@ -489,11 +490,17 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
         ? (value || '')
         : (prevSerial?.path ?? backendConfig.rig_pathname ?? '');
 
+      // rig_pathname 被改为非枚举端口的值时清除 serialNumber，
+      // 避免陈旧序列号在连接时被解析到其他 USB 设备
+      const serialNumber = name === 'rig_pathname'
+        ? ports.find((port) => port.path === path)?.serialNumber
+        : prevSerial?.serialNumber;
+
       const next = {
         ...prev,
         serial: {
           path,
-          serialNumber: prevSerial?.serialNumber,
+          serialNumber,
           rigModel: prevSerial?.rigModel ?? 0,
           serialConfig: prevSerial?.serialConfig,
           backendConfig,
@@ -1085,7 +1092,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: rigPath,
-                            serialNumber: config.serial?.serialNumber,
+                            serialNumber: ports.find((port) => port.path === rigPath)?.serialNumber,
                             rigModel: nextRigModel,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: rigPath ? { rig_pathname: rigPath } : {},
@@ -1130,7 +1137,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: value,
-                            serialNumber: config.serial?.serialNumber,
+                            serialNumber: ports.find((port) => port.path === value)?.serialNumber,
                             rigModel: config.serial?.rigModel ?? 0,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: {
@@ -1154,7 +1161,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
                         updateConfig({
                           serial: {
                             path: value,
-                            serialNumber: config.serial?.serialNumber,
+                            serialNumber: ports.find((port) => port.path === value)?.serialNumber,
                             rigModel: config.serial?.rigModel ?? 0,
                             serialConfig: config.serial?.serialConfig,
                             backendConfig: {


### PR DESCRIPTION
## Summary
- Persist selected port `serialNumber` in radio serial config.
- At connect time, re-resolve the current tty path from serial number so USB re-enumeration does not break Hamlib serial links.

## Test plan
- [ ] Select a USB serial port in radio settings and confirm serialNumber is stored
- [ ] Replug / renumber the port and reconnect; path should resolve via serialNumber

Split from #57 WIP.