### PR TITLE
fix: remember last band per profile and share switch path with power control

### DIFF
--- a/packages/server/src/config/ProfileManager.ts
+++ b/packages/server/src/config/ProfileManager.ts
@@ -179,7 +179,15 @@ export class ProfileManager {
     }
 
     // 阶段2：切换配置（原子操作）
+    // Persist previous profile's operating state, then load the target profile's
+    // memory into globals so bootstrap restores the correct band for this radio.
+    if (previousProfileId && previousProfileId !== id) {
+      await configManager.snapshotOperatingMemoryForProfile(previousProfileId);
+    }
     await configManager.setActiveProfileId(id);
+    if (previousProfileId !== id) {
+      await configManager.loadOperatingMemoryForProfile(id);
+    }
     engine.getAudioStreamManager().reloadAudioConfig();
     logger.info(`Profile activated: "${profile.name}" (id: ${id})`);
 

--- a/packages/server/src/config/ProfileManager.ts
+++ b/packages/server/src/config/ProfileManager.ts
@@ -178,7 +178,7 @@ export class ProfileManager {
       }
     }
 
-    // 阶段2：切换配置（原子操作：snapshot → setActive → load）
+    // 阶段2：切换配置（经 ConfigManager 串行化：snapshot → setActive → load）
     await configManager.switchActiveProfile(id);
     engine.getAudioStreamManager().reloadAudioConfig();
     logger.info(`Profile activated: "${profile.name}" (id: ${id})`);

--- a/packages/server/src/config/ProfileManager.ts
+++ b/packages/server/src/config/ProfileManager.ts
@@ -147,7 +147,7 @@ export class ProfileManager {
    * 激活 Profile（核心流程）
    *
    * 1. 安全停止引擎（如果运行中）
-   * 2. 切换配置（原子操作）
+   * 2. 经 ConfigManager 串行化切换配置（snapshot → setActive → load）
    * 3. 广播事件通知前端
    * 4. 如果之前在运行，自动重启引擎（使用新 Profile 配置）
    */

--- a/packages/server/src/config/ProfileManager.ts
+++ b/packages/server/src/config/ProfileManager.ts
@@ -178,16 +178,8 @@ export class ProfileManager {
       }
     }
 
-    // 阶段2：切换配置（原子操作）
-    // Persist previous profile's operating state, then load the target profile's
-    // memory into globals so bootstrap restores the correct band for this radio.
-    if (previousProfileId && previousProfileId !== id) {
-      await configManager.snapshotOperatingMemoryForProfile(previousProfileId);
-    }
-    await configManager.setActiveProfileId(id);
-    if (previousProfileId !== id) {
-      await configManager.loadOperatingMemoryForProfile(id);
-    }
+    // 阶段2：切换配置（原子操作：snapshot → setActive → load）
+    await configManager.switchActiveProfile(id);
     engine.getAudioStreamManager().reloadAudioConfig();
     logger.info(`Profile activated: "${profile.name}" (id: ${id})`);
 

--- a/packages/server/src/config/RuntimeStateManager.ts
+++ b/packages/server/src/config/RuntimeStateManager.ts
@@ -32,6 +32,15 @@ export interface LastCWFrequencyState {
   description?: string;
 }
 
+/** Per-radio-profile operating snapshot used when switching profiles. */
+export interface ProfileOperatingMemory {
+  lastSelectedFrequency?: LastSelectedFrequencyState | null;
+  lastVoiceFrequency?: LastVoiceFrequencyState | null;
+  lastCWFrequency?: LastCWFrequencyState | null;
+  lastEngineMode?: 'digital' | 'voice' | 'cw';
+  lastDigitalModeName?: string;
+}
+
 export interface RuntimeState {
   lastSelectedFrequency?: LastSelectedFrequencyState | null;
   lastVoiceFrequency?: LastVoiceFrequencyState | null;
@@ -40,6 +49,8 @@ export interface RuntimeState {
   volumeGainMap?: Record<string, { gain: number; gainDb: number }> | null;
   lastEngineMode?: 'digital' | 'voice' | 'cw';
   lastDigitalModeName?: string;
+  /** Last digital/voice/CW frequency + mode, keyed by RadioProfile id. */
+  profileOperatingMemory?: Record<string, ProfileOperatingMemory> | null;
   pskreporterStats?: Partial<PSKReporterStats>;
   authLastUsedAt?: Record<string, number>;
 }

--- a/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
+++ b/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
@@ -126,6 +126,44 @@ describe('ConfigManager profile operating memory', () => {
     });
   });
 
+  it('switchActiveProfile snapshots previous memory then loads the target bucket', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+    });
+    await configManager.setLastEngineMode('digital');
+
+    await configManager.setActiveProfileId('profile-7610');
+    await configManager.updateLastSelectedFrequency({
+      frequency: 14_074_000,
+      mode: 'FT8',
+      band: '20m',
+    });
+
+    // Put globals back on 9700 without going through switchActiveProfile,
+    // then exercise the atomic helper as RadioPowerController would.
+    await configManager.setActiveProfileId('profile-9700');
+    await configManager.loadOperatingMemoryForProfile('profile-9700');
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+    });
+
+    const result = await configManager.switchActiveProfile('profile-7610');
+
+    expect(result).toEqual({ previousProfileId: 'profile-9700', profileId: 'profile-7610' });
+    expect(configManager.getActiveProfileId()).toBe('profile-7610');
+    expect(configManager.getLastSelectedFrequency()).toMatchObject({
+      frequency: 14_074_000,
+      band: '20m',
+    });
+    expect(configManager.getProfileOperatingMemory('profile-9700')).toMatchObject({
+      lastSelectedFrequency: expect.objectContaining({ frequency: 144_460_000 }),
+    });
+  });
+
   it('removes operating memory when a profile is deleted', async () => {
     await configManager.updateLastSelectedFrequency({
       frequency: 14_074_000,

--- a/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
+++ b/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigManager } from '../config-manager.js';
+import { RuntimeStateManager } from '../RuntimeStateManager.js';
+import { PersistenceCoordinator } from '../../utils/persistence/index.js';
+
+function resetSingletons(): void {
+  (ConfigManager as unknown as { instance?: ConfigManager | null }).instance = null;
+  RuntimeStateManager.getInstance().disposeForTests();
+  (RuntimeStateManager as unknown as { instance?: RuntimeStateManager | null }).instance = null;
+  PersistenceCoordinator.getInstance().allowNewMutationsForTests();
+}
+
+describe('ConfigManager profile operating memory', () => {
+  const previousConfigDir = process.env.TX5DR_CONFIG_DIR;
+  let configDir: string;
+  let configManager: ConfigManager;
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(join(tmpdir(), 'tx5dr-profile-freq-memory-'));
+    process.env.TX5DR_CONFIG_DIR = configDir;
+    resetSingletons();
+    configManager = ConfigManager.getInstance();
+    await configManager.initialize();
+    await configManager.addProfile({
+      id: 'profile-9700',
+      name: 'IC-9700',
+      radio: { type: 'serial' } as any,
+      audio: {
+        inputSampleRate: 48000,
+        outputSampleRate: 48000,
+        inputBufferSize: 1024,
+        outputBufferSize: 1024,
+      },
+      audioLockedToRadio: false,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await configManager.addProfile({
+      id: 'profile-7610',
+      name: 'IC-7610',
+      radio: { type: 'serial' } as any,
+      audio: {
+        inputSampleRate: 48000,
+        outputSampleRate: 48000,
+        inputBufferSize: 1024,
+        outputBufferSize: 1024,
+      },
+      audioLockedToRadio: false,
+      createdAt: 2,
+      updatedAt: 2,
+    });
+    await configManager.setActiveProfileId('profile-9700');
+  });
+
+  afterEach(async () => {
+    await RuntimeStateManager.getInstance().flush();
+    resetSingletons();
+    if (previousConfigDir === undefined) {
+      delete process.env.TX5DR_CONFIG_DIR;
+    } else {
+      process.env.TX5DR_CONFIG_DIR = previousConfigDir;
+    }
+    await rm(configDir, { recursive: true, force: true });
+  });
+
+  it('mirrors last frequency updates into the active profile memory', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+      description: '144.460 FT8',
+    });
+    await configManager.setLastEngineMode('digital');
+
+    expect(configManager.getProfileOperatingMemory('profile-9700')).toMatchObject({
+      lastSelectedFrequency: expect.objectContaining({ frequency: 144_460_000, mode: 'FT8' }),
+      lastEngineMode: 'digital',
+    });
+  });
+
+  it('keeps previous profile memory and clears globals when loading an empty profile', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+      description: '144.460 FT8',
+    });
+    await configManager.setLastEngineMode('digital');
+
+    await configManager.snapshotOperatingMemoryForProfile('profile-9700');
+    await configManager.setActiveProfileId('profile-7610');
+    await configManager.loadOperatingMemoryForProfile('profile-7610');
+
+    expect(configManager.getLastSelectedFrequency()).toBeNull();
+    expect(configManager.getLastEngineMode()).toBe('digital');
+    expect(configManager.getProfileOperatingMemory('profile-9700')).toMatchObject({
+      lastSelectedFrequency: expect.objectContaining({ frequency: 144_460_000 }),
+    });
+  });
+
+  it('restores a profile memory bucket into globals on load', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+    });
+    await configManager.snapshotOperatingMemoryForProfile('profile-9700');
+
+    await configManager.setActiveProfileId('profile-7610');
+    await configManager.updateLastSelectedFrequency({
+      frequency: 14_074_000,
+      mode: 'FT8',
+      band: '20m',
+    });
+    await configManager.snapshotOperatingMemoryForProfile('profile-7610');
+
+    await configManager.setActiveProfileId('profile-9700');
+    await configManager.loadOperatingMemoryForProfile('profile-9700');
+
+    expect(configManager.getLastSelectedFrequency()).toMatchObject({
+      frequency: 144_460_000,
+      band: '2m',
+    });
+  });
+
+  it('removes operating memory when a profile is deleted', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 14_074_000,
+      mode: 'FT8',
+      band: '20m',
+    });
+    expect(configManager.getProfileOperatingMemory('profile-9700')).not.toBeNull();
+
+    await configManager.setActiveProfileId('profile-7610');
+    await configManager.deleteProfile('profile-9700');
+
+    expect(configManager.getProfileOperatingMemory('profile-9700')).toBeNull();
+  });
+});

--- a/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
+++ b/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
@@ -88,7 +88,7 @@ describe('ConfigManager profile operating memory', () => {
       band: '2m',
       description: '144.460 FT8',
     });
-    await configManager.setLastEngineMode('digital');
+    await configManager.setLastEngineMode('voice');
 
     await configManager.snapshotOperatingMemoryForProfile('profile-9700');
     await configManager.setActiveProfileId('profile-7610');
@@ -98,6 +98,7 @@ describe('ConfigManager profile operating memory', () => {
     expect(configManager.getLastEngineMode()).toBe('digital');
     expect(configManager.getProfileOperatingMemory('profile-9700')).toMatchObject({
       lastSelectedFrequency: expect.objectContaining({ frequency: 144_460_000 }),
+      lastEngineMode: 'voice',
     });
   });
 
@@ -142,7 +143,7 @@ describe('ConfigManager profile operating memory', () => {
     });
 
     // Put globals back on 9700 without going through switchActiveProfile,
-    // then exercise the atomic helper as RadioPowerController would.
+    // then exercise the helper as RadioPowerController would.
     await configManager.setActiveProfileId('profile-9700');
     await configManager.loadOperatingMemoryForProfile('profile-9700');
     await configManager.updateLastSelectedFrequency({
@@ -162,6 +163,51 @@ describe('ConfigManager profile operating memory', () => {
     expect(configManager.getProfileOperatingMemory('profile-9700')).toMatchObject({
       lastSelectedFrequency: expect.objectContaining({ frequency: 144_460_000 }),
     });
+  });
+
+  it('skips snapshot/load when switchActiveProfile targets the already-active profile', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+    });
+    await configManager.setLastEngineMode('voice');
+
+    const result = await configManager.switchActiveProfile('profile-9700');
+
+    expect(result).toEqual({ previousProfileId: 'profile-9700', profileId: 'profile-9700' });
+    expect(configManager.getLastSelectedFrequency()).toMatchObject({ frequency: 144_460_000 });
+    expect(configManager.getLastEngineMode()).toBe('voice');
+    expect(configManager.getActiveProfileId()).toBe('profile-9700');
+  });
+
+  it('serializes concurrent switchActiveProfile calls without corrupting buckets', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+    });
+    await configManager.setLastEngineMode('digital');
+
+    const first = configManager.switchActiveProfile('profile-7610');
+    const second = configManager.switchActiveProfile('profile-9700');
+    await Promise.all([first, second]);
+
+    expect(configManager.getActiveProfileId()).toBe('profile-9700');
+    expect(configManager.getLastSelectedFrequency()).toMatchObject({
+      frequency: 144_460_000,
+      band: '2m',
+    });
+    expect(configManager.getProfileOperatingMemory('profile-9700')).toMatchObject({
+      lastSelectedFrequency: expect.objectContaining({ frequency: 144_460_000 }),
+    });
+  });
+
+  it('throws when switchActiveProfile targets a missing profile', async () => {
+    await expect(configManager.switchActiveProfile('missing-profile')).rejects.toThrow(
+      'Profile missing-profile does not exist',
+    );
+    expect(configManager.getActiveProfileId()).toBe('profile-9700');
   });
 
   it('removes operating memory when a profile is deleted', async () => {

--- a/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
+++ b/packages/server/src/config/__tests__/ConfigManager.profileOperatingMemory.test.ts
@@ -210,6 +210,39 @@ describe('ConfigManager profile operating memory', () => {
     expect(configManager.getActiveProfileId()).toBe('profile-9700');
   });
 
+  it('loads target memory without snapshot when activating with no previous profile', async () => {
+    await configManager.updateLastSelectedFrequency({
+      frequency: 14_074_000,
+      mode: 'FT8',
+      band: '20m',
+    });
+    await configManager.setLastEngineMode('voice');
+    await configManager.snapshotOperatingMemoryForProfile('profile-7610');
+
+    // Simulate first activate: no active profile yet.
+    await configManager.setActiveProfileId(null);
+    await configManager.updateLastSelectedFrequency({
+      frequency: 144_460_000,
+      mode: 'FT8',
+      band: '2m',
+    });
+
+    const result = await configManager.switchActiveProfile('profile-7610');
+
+    expect(result).toEqual({ previousProfileId: null, profileId: 'profile-7610' });
+    expect(configManager.getActiveProfileId()).toBe('profile-7610');
+    expect(configManager.getLastSelectedFrequency()).toMatchObject({
+      frequency: 14_074_000,
+      band: '20m',
+    });
+    expect(configManager.getLastEngineMode()).toBe('voice');
+    // Orphan globals from the null-active window must not pollute the target bucket.
+    expect(configManager.getProfileOperatingMemory('profile-7610')).toMatchObject({
+      lastSelectedFrequency: expect.objectContaining({ frequency: 14_074_000 }),
+      lastEngineMode: 'voice',
+    });
+  });
+
   it('removes operating memory when a profile is deleted', async () => {
     await configManager.updateLastSelectedFrequency({
       frequency: 14_074_000,

--- a/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
+++ b/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
@@ -34,8 +34,8 @@ const { state, mockConfigManager, mockEngine, mockReloadAudioConfig } = vi.hoist
     setActiveProfileId: vi.fn(async (id: string | null) => {
       testState.activeProfileId = id;
     }),
-    snapshotOperatingMemoryForProfile: vi.fn(async () => {}),
-    loadOperatingMemoryForProfile: vi.fn(async () => {}),
+    snapshotOperatingMemoryForProfile: vi.fn(async (_id: string) => {}),
+    loadOperatingMemoryForProfile: vi.fn(async (_id: string) => {}),
     switchActiveProfile: vi.fn(async (id: string) => {
       const previousProfileId = testState.activeProfileId;
       if (previousProfileId && previousProfileId !== id) {
@@ -47,7 +47,7 @@ const { state, mockConfigManager, mockEngine, mockReloadAudioConfig } = vi.hoist
       }
       return { previousProfileId, profileId: id };
     }),
-    deleteProfileOperatingMemory: vi.fn(async () => {}),
+    deleteProfileOperatingMemory: vi.fn(async (_id: string) => {}),
     getProfiles: vi.fn(() => testState.profiles),
     getActiveProfile: vi.fn(() => testState.profiles.find((profile) => profile.id === testState.activeProfileId) ?? null),
     reorderProfiles: vi.fn(),
@@ -354,7 +354,7 @@ describe('ProfileManager audio runtime config application', () => {
     expect(mockReloadAudioConfig.mock.invocationCallOrder[0]).toBeLessThan(mockEngine.start.mock.invocationCallOrder[0]);
   });
 
-  it('snapshots previous profile operating memory then loads the new profile memory', async () => {
+  it('delegates profile activation to ConfigManager.switchActiveProfile', async () => {
     state.profiles = [
       makeProfile({ id: 'profile-9700', name: 'IC-9700' }),
       makeProfile({ id: 'profile-7610', name: 'IC-7610' }),
@@ -365,24 +365,5 @@ describe('ProfileManager audio runtime config application', () => {
     await manager.activateProfile('profile-7610');
 
     expect(mockConfigManager.switchActiveProfile).toHaveBeenCalledWith('profile-7610');
-    expect(mockConfigManager.snapshotOperatingMemoryForProfile).toHaveBeenCalledWith('profile-9700');
-    expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-7610');
-    expect(mockConfigManager.loadOperatingMemoryForProfile).toHaveBeenCalledWith('profile-7610');
-    expect(mockConfigManager.snapshotOperatingMemoryForProfile.mock.invocationCallOrder[0])
-      .toBeLessThan(mockConfigManager.setActiveProfileId.mock.invocationCallOrder[0]);
-    expect(mockConfigManager.setActiveProfileId.mock.invocationCallOrder[0])
-      .toBeLessThan(mockConfigManager.loadOperatingMemoryForProfile.mock.invocationCallOrder[0]);
-  });
-
-  it('does not swap operating memory when re-activating the same profile', async () => {
-    state.activeProfileId = 'profile-1';
-    const manager = ProfileManager.getInstance();
-
-    await manager.activateProfile('profile-1');
-
-    expect(mockConfigManager.switchActiveProfile).toHaveBeenCalledWith('profile-1');
-    expect(mockConfigManager.snapshotOperatingMemoryForProfile).not.toHaveBeenCalled();
-    expect(mockConfigManager.loadOperatingMemoryForProfile).not.toHaveBeenCalled();
-    expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-1');
   });
 });

--- a/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
+++ b/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
@@ -34,6 +34,9 @@ const { state, mockConfigManager, mockEngine, mockReloadAudioConfig } = vi.hoist
     setActiveProfileId: vi.fn(async (id: string | null) => {
       testState.activeProfileId = id;
     }),
+    snapshotOperatingMemoryForProfile: vi.fn(async () => {}),
+    loadOperatingMemoryForProfile: vi.fn(async () => {}),
+    deleteProfileOperatingMemory: vi.fn(async () => {}),
     getProfiles: vi.fn(() => testState.profiles),
     getActiveProfile: vi.fn(() => testState.profiles.find((profile) => profile.id === testState.activeProfileId) ?? null),
     reorderProfiles: vi.fn(),
@@ -338,5 +341,35 @@ describe('ProfileManager audio runtime config application', () => {
     expect(mockReloadAudioConfig).toHaveBeenCalledTimes(1);
     expect(mockEngine.start).toHaveBeenCalledTimes(1);
     expect(mockReloadAudioConfig.mock.invocationCallOrder[0]).toBeLessThan(mockEngine.start.mock.invocationCallOrder[0]);
+  });
+
+  it('snapshots previous profile operating memory then loads the new profile memory', async () => {
+    state.profiles = [
+      makeProfile({ id: 'profile-9700', name: 'IC-9700' }),
+      makeProfile({ id: 'profile-7610', name: 'IC-7610' }),
+    ];
+    state.activeProfileId = 'profile-9700';
+    const manager = ProfileManager.getInstance();
+
+    await manager.activateProfile('profile-7610');
+
+    expect(mockConfigManager.snapshotOperatingMemoryForProfile).toHaveBeenCalledWith('profile-9700');
+    expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-7610');
+    expect(mockConfigManager.loadOperatingMemoryForProfile).toHaveBeenCalledWith('profile-7610');
+    expect(mockConfigManager.snapshotOperatingMemoryForProfile.mock.invocationCallOrder[0])
+      .toBeLessThan(mockConfigManager.setActiveProfileId.mock.invocationCallOrder[0]);
+    expect(mockConfigManager.setActiveProfileId.mock.invocationCallOrder[0])
+      .toBeLessThan(mockConfigManager.loadOperatingMemoryForProfile.mock.invocationCallOrder[0]);
+  });
+
+  it('does not swap operating memory when re-activating the same profile', async () => {
+    state.activeProfileId = 'profile-1';
+    const manager = ProfileManager.getInstance();
+
+    await manager.activateProfile('profile-1');
+
+    expect(mockConfigManager.snapshotOperatingMemoryForProfile).not.toHaveBeenCalled();
+    expect(mockConfigManager.loadOperatingMemoryForProfile).not.toHaveBeenCalled();
+    expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-1');
   });
 });

--- a/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
+++ b/packages/server/src/config/__tests__/ProfileManager.audioConfig.test.ts
@@ -36,6 +36,17 @@ const { state, mockConfigManager, mockEngine, mockReloadAudioConfig } = vi.hoist
     }),
     snapshotOperatingMemoryForProfile: vi.fn(async () => {}),
     loadOperatingMemoryForProfile: vi.fn(async () => {}),
+    switchActiveProfile: vi.fn(async (id: string) => {
+      const previousProfileId = testState.activeProfileId;
+      if (previousProfileId && previousProfileId !== id) {
+        await configManager.snapshotOperatingMemoryForProfile(previousProfileId);
+      }
+      await configManager.setActiveProfileId(id);
+      if (previousProfileId !== id) {
+        await configManager.loadOperatingMemoryForProfile(id);
+      }
+      return { previousProfileId, profileId: id };
+    }),
     deleteProfileOperatingMemory: vi.fn(async () => {}),
     getProfiles: vi.fn(() => testState.profiles),
     getActiveProfile: vi.fn(() => testState.profiles.find((profile) => profile.id === testState.activeProfileId) ?? null),
@@ -337,7 +348,7 @@ describe('ProfileManager audio runtime config application', () => {
 
     await manager.activateProfile('profile-1');
 
-    expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-1');
+    expect(mockConfigManager.switchActiveProfile).toHaveBeenCalledWith('profile-1');
     expect(mockReloadAudioConfig).toHaveBeenCalledTimes(1);
     expect(mockEngine.start).toHaveBeenCalledTimes(1);
     expect(mockReloadAudioConfig.mock.invocationCallOrder[0]).toBeLessThan(mockEngine.start.mock.invocationCallOrder[0]);
@@ -353,6 +364,7 @@ describe('ProfileManager audio runtime config application', () => {
 
     await manager.activateProfile('profile-7610');
 
+    expect(mockConfigManager.switchActiveProfile).toHaveBeenCalledWith('profile-7610');
     expect(mockConfigManager.snapshotOperatingMemoryForProfile).toHaveBeenCalledWith('profile-9700');
     expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-7610');
     expect(mockConfigManager.loadOperatingMemoryForProfile).toHaveBeenCalledWith('profile-7610');
@@ -368,6 +380,7 @@ describe('ProfileManager audio runtime config application', () => {
 
     await manager.activateProfile('profile-1');
 
+    expect(mockConfigManager.switchActiveProfile).toHaveBeenCalledWith('profile-1');
     expect(mockConfigManager.snapshotOperatingMemoryForProfile).not.toHaveBeenCalled();
     expect(mockConfigManager.loadOperatingMemoryForProfile).not.toHaveBeenCalled();
     expect(mockConfigManager.setActiveProfileId).toHaveBeenCalledWith('profile-1');

--- a/packages/server/src/config/config-manager.ts
+++ b/packages/server/src/config/config-manager.ts
@@ -373,6 +373,10 @@ export class ConfigManager {
   private configStore: JsonFileStore<Record<string, unknown>> | null = null;
   private runtimeState = RuntimeStateManager.getInstance();
   private unregisterPersistence: (() => void) | null = null;
+  /** Serializes profile switches so concurrent callers cannot corrupt memory buckets. */
+  private profileSwitchQueue: Promise<unknown> = Promise.resolve();
+  /** Suspends mirror-to-bucket while a switch is between setActive and load. */
+  private profileSwitchInProgress = false;
 
   private constructor() {
     this.config = { ...DEFAULT_CONFIG };
@@ -871,23 +875,53 @@ export class ConfigManager {
   }
 
   /**
-   * Atomically switch the active profile and its operating memory.
+   * Switch the active profile and its operating memory.
    *
-   * All profile-switch callers (ProfileManager, RadioPowerController, …) must
-   * use this entry so snapshot → setActive → load stays ordered and complete.
+   * Serialized across callers (ProfileManager, RadioPowerController, …) so
+   * concurrent switches cannot interleave snapshot → setActive → load.
+   * Mirror-to-bucket is suspended for the duration of each switch.
    */
   async switchActiveProfile(id: string): Promise<{ previousProfileId: string | null; profileId: string }> {
+    const run = this.profileSwitchQueue.then(() => this.performSwitchActiveProfile(id));
+    // Keep the queue alive even if a switch fails, so later callers still serialize.
+    this.profileSwitchQueue = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private async performSwitchActiveProfile(
+    id: string,
+  ): Promise<{ previousProfileId: string | null; profileId: string }> {
     if (!this.config.profiles.find((profile) => profile.id === id)) {
       throw new Error(`Profile ${id} does not exist`);
     }
 
     const previousProfileId = this.getActiveProfileId();
-    if (previousProfileId && previousProfileId !== id) {
-      await this.snapshotOperatingMemoryForProfile(previousProfileId);
+    if (previousProfileId === id) {
+      await this.setActiveProfileId(id);
+      return { previousProfileId, profileId: id };
     }
-    await this.setActiveProfileId(id);
-    if (previousProfileId !== id) {
-      await this.loadOperatingMemoryForProfile(id);
+
+    this.profileSwitchInProgress = true;
+    try {
+      if (previousProfileId) {
+        await this.snapshotOperatingMemoryForProfile(previousProfileId);
+      }
+      await this.setActiveProfileId(id);
+      try {
+        await this.loadOperatingMemoryForProfile(id);
+      } catch (error) {
+        logger.error('Failed to load operating memory after profile switch; clearing globals', {
+          profileId: id,
+          error,
+        });
+        await this.setRuntimeValue('lastSelectedFrequency', null);
+        await this.setRuntimeValue('lastVoiceFrequency', null);
+        await this.setRuntimeValue('lastCWFrequency', null);
+        await this.setRuntimeValue('lastEngineMode', 'digital');
+        await this.setRuntimeValue('lastDigitalModeName', 'FT8');
+      }
+    } finally {
+      this.profileSwitchInProgress = false;
     }
 
     return { previousProfileId, profileId: id };
@@ -1287,7 +1321,21 @@ export class ConfigManager {
 
   getProfileOperatingMemory(profileId: string): ProfileOperatingMemory | null {
     const memory = this.getRuntimeValue('profileOperatingMemory')?.[profileId];
-    return memory ? { ...memory } : null;
+    if (!memory) {
+      return null;
+    }
+    return {
+      ...memory,
+      lastSelectedFrequency: memory.lastSelectedFrequency
+        ? { ...memory.lastSelectedFrequency }
+        : memory.lastSelectedFrequency,
+      lastVoiceFrequency: memory.lastVoiceFrequency
+        ? { ...memory.lastVoiceFrequency }
+        : memory.lastVoiceFrequency,
+      lastCWFrequency: memory.lastCWFrequency
+        ? { ...memory.lastCWFrequency }
+        : memory.lastCWFrequency,
+    };
   }
 
   /**
@@ -1365,6 +1413,9 @@ export class ConfigManager {
   private async mirrorOperatingFieldToActiveProfile(
     patch: Partial<ProfileOperatingMemory>,
   ): Promise<void> {
+    if (this.profileSwitchInProgress) {
+      return;
+    }
     const profileId = this.getActiveProfileId();
     if (!profileId) {
       return;

--- a/packages/server/src/config/config-manager.ts
+++ b/packages/server/src/config/config-manager.ts
@@ -870,6 +870,29 @@ export class ConfigManager {
     await this.saveConfig();
   }
 
+  /**
+   * Atomically switch the active profile and its operating memory.
+   *
+   * All profile-switch callers (ProfileManager, RadioPowerController, …) must
+   * use this entry so snapshot → setActive → load stays ordered and complete.
+   */
+  async switchActiveProfile(id: string): Promise<{ previousProfileId: string | null; profileId: string }> {
+    if (!this.config.profiles.find((profile) => profile.id === id)) {
+      throw new Error(`Profile ${id} does not exist`);
+    }
+
+    const previousProfileId = this.getActiveProfileId();
+    if (previousProfileId && previousProfileId !== id) {
+      await this.snapshotOperatingMemoryForProfile(previousProfileId);
+    }
+    await this.setActiveProfileId(id);
+    if (previousProfileId !== id) {
+      await this.loadOperatingMemoryForProfile(id);
+    }
+
+    return { previousProfileId, profileId: id };
+  }
+
   // ===== 配置派生方法（从 activeProfile 派生，签名不变） =====
 
   /**

--- a/packages/server/src/config/config-manager.ts
+++ b/packages/server/src/config/config-manager.ts
@@ -24,7 +24,11 @@ import { createLogger } from '../utils/logger.js';
 import { normalizeHamlibConfig, normalizeSerialConnectionConfig } from '../radio/hamlibConfigUtils.js';
 import { DEFAULT_NTP_SERVERS } from '../services/ntpServers.js';
 import { JsonFileStore, PersistenceCoordinator } from '../utils/persistence/index.js';
-import { RuntimeStateManager, type RuntimeState } from './RuntimeStateManager.js';
+import {
+  RuntimeStateManager,
+  type ProfileOperatingMemory,
+  type RuntimeState,
+} from './RuntimeStateManager.js';
 
 const logger = createLogger('ConfigManager');
 
@@ -835,6 +839,7 @@ export class ConfigManager {
 
     this.config.profiles.splice(index, 1);
     await this.saveConfig();
+    await this.deleteProfileOperatingMemory(id);
   }
 
   /**
@@ -1174,7 +1179,9 @@ export class ConfigManager {
     band: string;
     description?: string;
   }): Promise<void> {
-    await this.setRuntimeValue('lastSelectedFrequency', { ...frequencyConfig });
+    const next = { ...frequencyConfig };
+    await this.setRuntimeValue('lastSelectedFrequency', next);
+    await this.mirrorOperatingFieldToActiveProfile({ lastSelectedFrequency: next });
     logger.debug(`Last selected frequency saved: ${frequencyConfig.description || frequencyConfig.frequency}Hz`);
   }
 
@@ -1201,7 +1208,9 @@ export class ConfigManager {
     ctcssToneTenthsHz?: number;
     dcsCode?: number;
   }): Promise<void> {
-    await this.setRuntimeValue('lastVoiceFrequency', { ...frequencyConfig });
+    const next = { ...frequencyConfig };
+    await this.setRuntimeValue('lastVoiceFrequency', next);
+    await this.mirrorOperatingFieldToActiveProfile({ lastVoiceFrequency: next });
     logger.debug(`Last voice frequency saved: ${frequencyConfig.description || frequencyConfig.frequency}Hz`);
   }
 
@@ -1210,6 +1219,7 @@ export class ConfigManager {
    */
   async clearLastSelectedFrequency(): Promise<void> {
     await this.setRuntimeValue('lastSelectedFrequency', null);
+    await this.mirrorOperatingFieldToActiveProfile({ lastSelectedFrequency: null });
   }
 
   /**
@@ -1217,6 +1227,7 @@ export class ConfigManager {
    */
   async clearLastVoiceFrequency(): Promise<void> {
     await this.setRuntimeValue('lastVoiceFrequency', null);
+    await this.mirrorOperatingFieldToActiveProfile({ lastVoiceFrequency: null });
   }
 
   /**
@@ -1237,7 +1248,9 @@ export class ConfigManager {
     band: string;
     description?: string;
   }): Promise<void> {
-    await this.setRuntimeValue('lastCWFrequency', { ...frequencyConfig });
+    const next = { ...frequencyConfig };
+    await this.setRuntimeValue('lastCWFrequency', next);
+    await this.mirrorOperatingFieldToActiveProfile({ lastCWFrequency: next });
     logger.debug(`Last CW frequency saved: ${frequencyConfig.description || frequencyConfig.frequency}Hz`);
   }
 
@@ -1246,6 +1259,94 @@ export class ConfigManager {
    */
   async clearLastCWFrequency(): Promise<void> {
     await this.setRuntimeValue('lastCWFrequency', null);
+    await this.mirrorOperatingFieldToActiveProfile({ lastCWFrequency: null });
+  }
+
+  getProfileOperatingMemory(profileId: string): ProfileOperatingMemory | null {
+    const memory = this.getRuntimeValue('profileOperatingMemory')?.[profileId];
+    return memory ? { ...memory } : null;
+  }
+
+  /**
+   * Snapshot current global last* values into a profile bucket (profile switch leave path).
+   */
+  async snapshotOperatingMemoryForProfile(profileId: string): Promise<void> {
+    await this.patchProfileOperatingMemory(profileId, {
+      lastSelectedFrequency: this.getLastSelectedFrequency(),
+      lastVoiceFrequency: this.getLastVoiceFrequency(),
+      lastCWFrequency: this.getLastCWFrequency(),
+      lastEngineMode: this.getLastEngineMode(),
+      lastDigitalModeName: this.getLastDigitalModeName(),
+    });
+  }
+
+  /**
+   * Load a profile bucket into global last* values. Missing memory clears globals so
+   * bootstrap does not restore another radio's band.
+   */
+  async loadOperatingMemoryForProfile(profileId: string): Promise<void> {
+    const memory = this.getRuntimeValue('profileOperatingMemory')?.[profileId];
+    if (!memory) {
+      await this.setRuntimeValue('lastSelectedFrequency', null);
+      await this.setRuntimeValue('lastVoiceFrequency', null);
+      await this.setRuntimeValue('lastCWFrequency', null);
+      await this.setRuntimeValue('lastEngineMode', 'digital');
+      await this.setRuntimeValue('lastDigitalModeName', 'FT8');
+      logger.info('No operating memory for profile; cleared global last-frequency state', { profileId });
+      return;
+    }
+
+    await this.setRuntimeValue('lastSelectedFrequency', memory.lastSelectedFrequency ?? null);
+    await this.setRuntimeValue('lastVoiceFrequency', memory.lastVoiceFrequency ?? null);
+    await this.setRuntimeValue('lastCWFrequency', memory.lastCWFrequency ?? null);
+    if (memory.lastEngineMode) {
+      await this.setRuntimeValue('lastEngineMode', memory.lastEngineMode);
+    } else {
+      await this.setRuntimeValue('lastEngineMode', 'digital');
+    }
+    if (memory.lastDigitalModeName) {
+      await this.setRuntimeValue('lastDigitalModeName', memory.lastDigitalModeName);
+    } else {
+      await this.setRuntimeValue('lastDigitalModeName', 'FT8');
+    }
+    logger.info('Loaded operating memory for profile', {
+      profileId,
+      engineMode: memory.lastEngineMode ?? 'digital',
+      digitalMHz: memory.lastSelectedFrequency
+        ? (memory.lastSelectedFrequency.frequency / 1_000_000).toFixed(3)
+        : null,
+    });
+  }
+
+  async deleteProfileOperatingMemory(profileId: string): Promise<void> {
+    const map = { ...(this.getRuntimeValue('profileOperatingMemory') ?? {}) };
+    if (!(profileId in map)) {
+      return;
+    }
+    delete map[profileId];
+    await this.setRuntimeValue('profileOperatingMemory', Object.keys(map).length > 0 ? map : null);
+  }
+
+  private async patchProfileOperatingMemory(
+    profileId: string,
+    patch: Partial<ProfileOperatingMemory>,
+  ): Promise<void> {
+    const map = { ...(this.getRuntimeValue('profileOperatingMemory') ?? {}) };
+    map[profileId] = {
+      ...map[profileId],
+      ...patch,
+    };
+    await this.setRuntimeValue('profileOperatingMemory', map);
+  }
+
+  private async mirrorOperatingFieldToActiveProfile(
+    patch: Partial<ProfileOperatingMemory>,
+  ): Promise<void> {
+    const profileId = this.getActiveProfileId();
+    if (!profileId) {
+      return;
+    }
+    await this.patchProfileOperatingMemory(profileId, patch);
   }
 
   /**
@@ -1494,6 +1595,7 @@ export class ConfigManager {
 
   async setLastEngineMode(mode: 'digital' | 'voice' | 'cw'): Promise<void> {
     await this.setRuntimeValue('lastEngineMode', mode);
+    await this.mirrorOperatingFieldToActiveProfile({ lastEngineMode: mode });
   }
 
   getLastDigitalModeName(): string {
@@ -1502,6 +1604,7 @@ export class ConfigManager {
 
   async setLastDigitalModeName(modeName: string): Promise<void> {
     await this.setRuntimeValue('lastDigitalModeName', modeName);
+    await this.mirrorOperatingFieldToActiveProfile({ lastDigitalModeName: modeName });
   }
 
   // ===== Voice mode config =====

--- a/packages/server/src/radio/RadioPowerController.ts
+++ b/packages/server/src/radio/RadioPowerController.ts
@@ -226,15 +226,19 @@ export class RadioPowerController extends EventEmitter<RadioPowerControllerEvent
       radioManager.markIntentionalDisconnect('profile switch for power operation');
       await radioManager.disconnect('profile switch for power operation').catch(() => undefined);
     }
-    await configManager.setActiveProfileId(profileId);
+
+    // Same atomic snapshot / setActive / load path as ProfileManager.activateProfile.
+    const { previousProfileId } = await configManager.switchActiveProfile(profileId);
+    const engine = DigitalRadioEngine.getInstance();
+    engine.getAudioStreamManager().reloadAudioConfig();
+
     const profile = configManager.getProfile(profileId);
     if (profile) {
-      const engine = DigitalRadioEngine.getInstance();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (engine as any).emit('profileChanged', {
         profileId,
         profile,
-        previousProfileId: currentActiveId,
+        previousProfileId,
         wasRunning: false,
       });
     }

--- a/packages/server/src/radio/__tests__/RadioPowerController.test.ts
+++ b/packages/server/src/radio/__tests__/RadioPowerController.test.ts
@@ -1,5 +1,20 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import type { RadioProfile } from '@tx5dr/contracts';
+
+const { mockReloadAudioConfig, mockEngineEmit } = vi.hoisted(() => ({
+  mockReloadAudioConfig: vi.fn(),
+  mockEngineEmit: vi.fn(),
+}));
+
+vi.mock('../../DigitalRadioEngine.js', () => ({
+  DigitalRadioEngine: {
+    getInstance: () => ({
+      getAudioStreamManager: () => ({ reloadAudioConfig: mockReloadAudioConfig }),
+      emit: mockEngineEmit,
+    }),
+  },
+}));
+
 import { RadioPowerController } from '../RadioPowerController.js';
 import { PhysicalRadioManager } from '../PhysicalRadioManager.js';
 import { ConfigManager } from '../../config/config-manager.js';
@@ -26,7 +41,7 @@ function resetControllerSingleton(): void {
   (RadioPowerController as unknown as { instance: RadioPowerController | null }).instance = null;
 }
 
-function createProfile(): RadioProfile {
+function createProfile(overrides?: Partial<RadioProfile>): RadioProfile {
   return {
     id: 'profile-ft710',
     name: 'FT-710',
@@ -38,16 +53,17 @@ function createProfile(): RadioProfile {
     audioLockedToRadio: false,
     createdAt: 1,
     updatedAt: 1,
+    ...overrides,
   };
 }
 
-function installConfig(profile = createProfile()): void {
+function installConfig(profiles: RadioProfile[], activeProfileId?: string): void {
   const cfg = ConfigManager.getInstance() as unknown as {
     config: { profiles: RadioProfile[]; activeProfileId: string };
   };
   cfg.config = {
-    profiles: [profile],
-    activeProfileId: profile.id,
+    profiles,
+    activeProfileId: activeProfileId ?? profiles[0]!.id,
   };
 }
 
@@ -56,9 +72,11 @@ function createController(options?: {
   connected?: boolean;
   running?: boolean;
   wakeAndConnect?: ReturnType<typeof vi.fn>;
+  profiles?: RadioProfile[];
+  activeProfileId?: string;
 }) {
   resetControllerSingleton();
-  installConfig();
+  installConfig(options?.profiles ?? [createProfile()], options?.activeProfileId);
 
   const lifecycle: MockLifecycle = {
     getIsRunning: vi.fn().mockReturnValue(options?.running ?? false),
@@ -98,6 +116,8 @@ function unsupportedPowerError(): RadioError {
 describe('RadioPowerController', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    mockReloadAudioConfig.mockReset();
+    mockEngineEmit.mockReset();
     resetControllerSingleton();
   });
 
@@ -107,7 +127,7 @@ describe('RadioPowerController', () => {
   });
 
   it('does not expose operate for FT-710 power support', async () => {
-    installConfig();
+    installConfig([createProfile()]);
     vi.spyOn(PhysicalRadioManager, 'listSupportedRigs').mockResolvedValue([
       { rigModel: 1049, mfgName: 'Yaesu', modelName: 'FT-710' },
     ] as never);
@@ -118,6 +138,45 @@ describe('RadioPowerController', () => {
     expect(support.canPowerOn).toBe(true);
     expect(support.canPowerOff).toBe(true);
     expect(support.supportedStates).toEqual(['off']);
+  });
+
+  it('switches active profile through the shared snapshot/setActive/load path before power-on', async () => {
+    const order: string[] = [];
+    const profileA = createProfile({ id: 'profile-a', name: 'Radio A' });
+    const profileB = createProfile({ id: 'profile-b', name: 'Radio B' });
+    mockReloadAudioConfig.mockImplementation(() => {
+      order.push('reloadAudio');
+    });
+
+    const configManager = ConfigManager.getInstance();
+    const switchSpy = vi.spyOn(configManager, 'switchActiveProfile').mockImplementation(async (id) => {
+      order.push(`switch:${id}`);
+      return { previousProfileId: 'profile-a', profileId: id };
+    });
+    vi.spyOn(configManager, 'getProfile').mockImplementation((id) => (
+      id === 'profile-b' ? profileB : profileA
+    ));
+
+    const { controller, radioManager } = createController({
+      profiles: [profileA, profileB],
+      activeProfileId: 'profile-a',
+      connected: false,
+      running: false,
+      wakeAndConnect: vi.fn().mockImplementation(async () => {
+        order.push('wake');
+      }),
+    });
+
+    await expect(controller.handleRequest({
+      profileId: 'profile-b',
+      state: 'on',
+      autoEngine: false,
+    })).resolves.toBe('awake');
+
+    expect(switchSpy).toHaveBeenCalledWith('profile-b');
+    expect(mockReloadAudioConfig).toHaveBeenCalledTimes(1);
+    expect(radioManager.wakeAndConnect).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['switch:profile-b', 'reloadAudio', 'wake']);
   });
 
   it('does not stop the engine or disconnect when operate is unsupported', async () => {

--- a/packages/web/src/components/cw/CWFrequencyControl.tsx
+++ b/packages/web/src/components/cw/CWFrequencyControl.tsx
@@ -3,7 +3,7 @@ import { Card, CardBody } from '@heroui/react';
 import { api, ApiError, getBandFromFrequency } from '@tx5dr/core';
 import { useTranslation } from 'react-i18next';
 import { useAbility, useAuth, useCan } from '../../store/authStore';
-import { useConnection, useOperators, useRadioConnectionState, useRadioState, useSplitState } from '../../store/radioStore';
+import { useConnection, useOperators, useProfiles, useRadioConnectionState, useRadioState, useSplitState } from '../../store/radioStore';
 import { createLogger } from '../../utils/logger';
 import { canExecuteRadioFrequency, canWriteRadioFrequency } from '../../utils/radioControl';
 import { resetOperatorsForOperatingStateChange } from '../../utils/operatorReset';
@@ -61,6 +61,7 @@ export const CWFrequencyControl: React.FC = () => {
   const { t } = useTranslation('voice');
   const connection = useConnection();
   const { operators } = useOperators();
+  const { activeProfileId } = useProfiles();
   const radioConnection = useRadioConnectionState();
   const radio = useRadioState();
   const { state: authState } = useAuth();
@@ -203,7 +204,7 @@ export const CWFrequencyControl: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [canUseAuthenticatedRest, liveFrequency]);
+  }, [canUseAuthenticatedRest, liveFrequency, activeProfileId]);
 
   useEffect(() => {
     const radioService = connection.state.radioService;

--- a/packages/web/src/components/radio/control/RadioControl.tsx
+++ b/packages/web/src/components/radio/control/RadioControl.tsx
@@ -605,7 +605,7 @@ export const RadioControl: React.FC<RadioControlProps> = ({ onOpenRadioSettings,
   const radioMode = useRadioModeState();
   const { pttStatus, tuneToneStatus, voicePttLock } = usePTTState();
   const { state: radioState, dispatch: radioDispatch } = useRadioState();
-  const { activeProfile } = useProfiles();
+  const { activeProfile, activeProfileId } = useProfiles();
   const { latestError } = useRadioErrors();
   const { state: authState } = useAuth();
   const isAdmin = useHasMinRole(UserRole.ADMIN);
@@ -1192,7 +1192,7 @@ export const RadioControl: React.FC<RadioControlProps> = ({ onOpenRadioSettings,
       }, 500);
       return () => window.clearTimeout(timeoutId);
     }
-  }, [availableFrequencies, radioMode.currentMode, connection.state.isConnected, canUseAuthenticatedRest, canWriteFrequency]);
+  }, [availableFrequencies, radioMode.currentMode, connection.state.isConnected, canUseAuthenticatedRest, canWriteFrequency, activeProfileId]);
 
 
 

--- a/packages/web/src/components/voice/VoiceFrequencyControl.tsx
+++ b/packages/web/src/components/voice/VoiceFrequencyControl.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroui/react';
 import { addToast } from '@heroui/toast';
 import { api, ApiError } from '@tx5dr/core';
-import { useCapabilityDescriptor, useCapabilityState, useConnection, useOperators, useRadioConnectionState, useRadioState, useSplitState } from '../../store/radioStore';
+import { useCapabilityDescriptor, useCapabilityState, useConnection, useOperators, useProfiles, useRadioConnectionState, useRadioState, useSplitState } from '../../store/radioStore';
 import { useAuth, useHasMinRole, useCan, useAbility } from '../../store/authStore';
 import { UserRole, type PresetFrequency } from '@tx5dr/contracts';
 import { showErrorToast } from '../../utils/errorToast';
@@ -55,6 +55,7 @@ export const VoiceFrequencyControl: React.FC = () => {
   const { t } = useTranslation('voice');
   const connection = useConnection();
   const { operators } = useOperators();
+  const { activeProfileId } = useProfiles();
   const radioConnection = useRadioConnectionState();
   const radio = useRadioState();
   const radioModeDescriptor = useCapabilityDescriptor('radio_mode');
@@ -305,7 +306,7 @@ export const VoiceFrequencyControl: React.FC = () => {
     } finally {
       setIsLoadingPresets(false);
     }
-  }, [canUseAuthenticatedRest, connection.state.isConnected, formatBandLabel]);
+  }, [canUseAuthenticatedRest, connection.state.isConnected, formatBandLabel, activeProfileId]);
 
   // Load voice frequency presets + restore last frequency
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Persist last digital/voice/CW frequency (and engine mode) per profile.
- Add `ConfigManager.switchActiveProfile()` so ProfileManager and RadioPowerController share the same snapshot → setActive → load flow, including audio reload.

Addresses #57 review: power-operation profile switches no longer bypass operating-memory swap.

## Test plan
- [ ] Switch between two profiles with different bands; each restores its last frequency
- [ ] Power-on a non-active profile and confirm its remembered band is loaded before CAT bootstrap
- [ ] Run ConfigManager / ProfileManager operating-memory tests

Split from #57.