### PR TITLE
fix(qso): 修复 RST 有概率记录为 0 (#70)

### DIFF
--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
@@ -271,4 +271,51 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
     expect(snapshot.context?.reportReceived).toBe(2);
     expect(snapshot.context?.reportSent).toBe(-16);
   });
+
+  it('overwrites a cached reportReceived of 0 when answering a fresh SIGNAL_REPORT', async () => {
+    // Reproduces issue #70: cached/UI sentinel 0 must not replace the air report (-15).
+    const operator = createOperator({ myCallsign: 'BG5FRH', myGrid: 'PL09' });
+    const runtime = new StandardQSOPluginRuntime(operator);
+
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      targetGrid: 'NO26',
+      reportSent: -2,
+      reportReceived: 0,
+    });
+    runtime.clearQSOContext();
+    runtime.setState('TX6');
+
+    await runtime.decide([
+      createParsedMessage('BG5FRH RW9HSB -15', { snr: -2, slotId: 'slot-issue-70' }),
+    ]);
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.currentState).toBe('TX3');
+    expect(snapshot.context?.targetCallsign).toBe('RW9HSB');
+    expect(snapshot.context?.reportReceived).toBe(-15);
+    expect(snapshot.context?.reportSent).toBe(-2);
+    expect(snapshot.slots?.TX3).toBe('RW9HSB BG5FRH R-02');
+  });
+
+  it('overwrites a stale reportReceived of 0 when TX2 receives a ROGER_REPORT', async () => {
+    const operator = createOperator({ myCallsign: 'BG5FRH', myGrid: 'PL09' });
+    const runtime = new StandardQSOPluginRuntime(operator);
+
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      reportSent: -2,
+      reportReceived: 0,
+    });
+    runtime.setState('TX2');
+
+    await runtime.decide([
+      createParsedMessage('BG5FRH RW9HSB R-15', { snr: -3, slotId: 'slot-roger-overwrite' }),
+    ]);
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.currentState).toBe('TX4');
+    expect(snapshot.context?.reportReceived).toBe(-15);
+    expect(snapshot.context?.reportSent).toBe(-3);
+  });
 });

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
@@ -318,4 +318,47 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
     expect(snapshot.context?.reportReceived).toBe(-15);
     expect(snapshot.context?.reportSent).toBe(-3);
   });
+
+  it('clears stale cached reports when answering a CALL after restoreContext', async () => {
+    const operator = createOperator({ myCallsign: 'BG5FRH', myGrid: 'PL09' });
+    const runtime = new StandardQSOPluginRuntime(operator);
+
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      targetGrid: 'NO26',
+      reportSent: -8,
+      reportReceived: 0,
+    });
+    runtime.clearQSOContext();
+    runtime.setState('TX6');
+
+    await runtime.decide([
+      createParsedMessage('BG5FRH RW9HSB NO26', { snr: -5, slotId: 'slot-call-clear' }),
+    ]);
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.currentState).toBe('TX2');
+    expect(snapshot.context?.targetCallsign).toBe('RW9HSB');
+    expect(snapshot.context?.targetGrid).toBe('NO26');
+    expect(snapshot.context?.reportSent).toBe(-5);
+    expect(snapshot.context?.reportReceived).toBeUndefined();
+  });
+
+  it('clears reports when patchContext receives null', () => {
+    const runtime = new StandardQSOPluginRuntime(createOperator());
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      reportSent: -12,
+      reportReceived: -8,
+    });
+    runtime.patchContext({
+      reportSent: null,
+      reportReceived: null,
+    });
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.context?.targetCallsign).toBe('RW9HSB');
+    expect(snapshot.context?.reportSent).toBeUndefined();
+    expect(snapshot.context?.reportReceived).toBeUndefined();
+  });
 });

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
@@ -259,12 +259,13 @@ async function trySwitchToDirectedProtocol(
 
         if (msg.type === FT8MessageType.SIGNAL_REPORT) {
             strategy.logger.debug(`${prefix}: switching to direct signal report ${callsign} (SNR: ${directCall.snr})`);
-            if (!strategy.restoreContext(callsign)) {
-                strategy.context.reportReceived = (msg as FT8MessageSignalReport).report;
-                strategy.context.reportSent = directCall.snr;
-                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                    strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
-                }
+            // Always apply the fresh report from the air message after restore.
+            // Cached context may still hold a UI/default sentinel of 0.
+            strategy.restoreContext(callsign);
+            strategy.context.reportReceived = (msg as FT8MessageSignalReport).report;
+            strategy.context.reportSent = directCall.snr;
+            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
             }
             strategy.updateSlots();
             return { changeState: 'TX3' };
@@ -453,14 +454,12 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             // 切换到新呼号
                             strategy.context.targetCallsign = newCallsign;
 
-                            // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
-                            if (!strategy.restoreContext(newCallsign)) {
-                                strategy.context.reportReceived = reportMsg.report;
-                                strategy.context.reportSent = newCall.snr;
-                                // 记录实际通联频率
-                                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                                    strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
-                                }
+                            // Restore grid/frequency cache, but always take the fresh report from this message.
+                            strategy.restoreContext(newCallsign);
+                            strategy.context.reportReceived = reportMsg.report;
+                            strategy.context.reportSent = newCall.snr;
+                            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                                strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
                             }
 
                             strategy.updateSlots();
@@ -534,12 +533,9 @@ const states: { [key in SlotsIndex]: StandardState } = {
             if (msgRogerReport) {
                 const msg = msgRogerReport.message as FT8MessageRogerReport;
                 strategy.logger.debug('TX2: received ROGER_REPORT, moving to TX4');
-                // 【修复】ROGER_REPORT也包含对方给我们的信号报告（msg.report）
-                // 如果之前没有设置reportReceived，从ROGER_REPORT中获取
-                if (strategy.context.reportReceived === undefined || strategy.context.reportReceived === null) {
-                    strategy.context.reportReceived = msg.report;
-                }
-                // 【修复】允许更新reportSent为当前SNR（移除过于保守的条件限制）
+                // Always take the report from the air message. A prior UI/default
+                // sentinel of 0 must not block updating to the real value.
+                strategy.context.reportReceived = msg.report;
                 strategy.context.reportSent = msgRogerReport.snr;
                 // 记录或更新实际通联频率 (基础频率 + 对方信号的频率偏移)
                 // 只有当基础频率有效时（大于1MHz）才计算actualFrequency
@@ -566,11 +562,7 @@ const states: { [key in SlotsIndex]: StandardState } = {
             if (msgSignalReport) {
                 const msg = msgSignalReport.message as FT8MessageSignalReport;
                 strategy.logger.debug('TX2: fallback - received SIGNAL_REPORT instead of ROGER_REPORT, treating as confirmation, moving to TX4');
-                // 【修复】提取对方告诉我们的信号报告值（msg.report）
-                if (strategy.context.reportReceived === undefined || strategy.context.reportReceived === null) {
-                    strategy.context.reportReceived = msg.report;
-                }
-                // 【修复】允许更新reportSent（移除过于保守的条件限制）
+                strategy.context.reportReceived = msg.report;
                 strategy.context.reportSent = msgSignalReport.snr;
                 // 记录或更新实际通联频率
                 if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
@@ -682,12 +674,7 @@ const states: { [key in SlotsIndex]: StandardState } = {
                 const msg = msgSignalReport.message as FT8MessageSignalReport;
                 strategy.logger.debug(`TX3: fallback - received repeated SIGNAL_REPORT (SNR: ${msgSignalReport.snr}dB), updating report`);
 
-                // 更新接收的信号报告（如果之前没有设置）
-                if (strategy.context.reportReceived === undefined ||
-                    strategy.context.reportReceived === null) {
-                    strategy.context.reportReceived = msg.report;
-                }
-
+                strategy.context.reportReceived = msg.report;
                 // 更新我方准备发送的报告（使用最新的SNR）
                 strategy.context.reportSent = msgSignalReport.snr;
 
@@ -1287,10 +1274,8 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
                 } else if (msg.type === FT8MessageType.ROGER_REPORT) {
                     // 对方发了 ROGER_REPORT，回复 RR73
                     const rogerMsg = msg as FT8MessageRogerReport;
-                    // 从 ROGER_REPORT 中提取对方给我们的信号报告
-                    if (this.context.reportReceived === undefined || this.context.reportReceived === null) {
-                        this.context.reportReceived = rogerMsg.report;
-                    }
+                    // Always take the report from the air message.
+                    this.context.reportReceived = rogerMsg.report;
                     // 记录实际通联频率
                     if (this.context.config.frequency && this.context.config.frequency > 1000000) {
                         this.context.actualFrequency = this.context.config.frequency + parsedMessage.df;

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
@@ -246,12 +246,16 @@ async function trySwitchToDirectedProtocol(
 
         if (msg.type === FT8MessageType.CALL) {
             strategy.logger.debug(`${prefix}: switching to direct call ${callsign} (SNR: ${directCall.snr})`);
-            if (!strategy.restoreContext(callsign)) {
-                strategy.context.reportSent = directCall.snr;
-                strategy.context.targetGrid = (msg as FT8MessageCall).grid;
-                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                    strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
-                }
+            const callMsg = msg as FT8MessageCall;
+            // Restore grid/frequency cache, but always refresh SNR and clear stale received reports.
+            strategy.restoreContext(callsign);
+            if (callMsg.grid) {
+                strategy.context.targetGrid = callMsg.grid;
+            }
+            strategy.context.reportSent = directCall.snr;
+            strategy.context.reportReceived = undefined;
+            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
             }
             strategy.updateSlots();
             return { changeState: 'TX2' };
@@ -408,14 +412,15 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             // 切换到新呼号
                             strategy.context.targetCallsign = newCallsign;
 
-                            // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
-                            if (!strategy.restoreContext(newCallsign)) {
-                                strategy.context.reportSent = newCall.snr;
+                            // Restore grid/frequency cache, but always refresh SNR and clear stale received reports.
+                            strategy.restoreContext(newCallsign);
+                            if (callMsg.grid) {
                                 strategy.context.targetGrid = callMsg.grid;
-                                // 记录实际通联频率
-                                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                                    strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
-                                }
+                            }
+                            strategy.context.reportSent = newCall.snr;
+                            strategy.context.reportReceived = undefined;
+                            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                                strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
                             }
 
                             strategy.updateSlots();
@@ -984,15 +989,15 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             strategy.logger.debug(`TX6: replying to CQ from ${callsign} (not worked, SNR: ${cqCall.snr}dB, by signal strength)`);
                             strategy.context.targetCallsign = callsign;
 
-                            // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
-                            if (!strategy.restoreContext(callsign)) {
+                            // Restore grid/frequency cache, but always refresh SNR and clear stale received reports.
+                            strategy.restoreContext(callsign);
+                            if (msg.grid) {
                                 strategy.context.targetGrid = msg.grid;
-                                strategy.context.reportSent = cqCall.snr;
-                                // 记录实际通联频率 (基础频率 + CQ信号的频率偏移)
-                                // 只有当基础频率有效时（大于1MHz）才计算actualFrequency
-                                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                                    strategy.context.actualFrequency = strategy.context.config.frequency + cqCall.df;
-                                }
+                            }
+                            strategy.context.reportSent = cqCall.snr;
+                            strategy.context.reportReceived = undefined;
+                            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                                strategy.context.actualFrequency = strategy.context.config.frequency + cqCall.df;
                             }
 
                             strategy.updateSlots();
@@ -1338,10 +1343,22 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
 
     patchContext(patch: Partial<StrategyRuntimeContext>): void {
         this.syncOperatorConfig();
-        this._context = {
+        const next: QSOContext = {
             ...this._context,
-            ...patch,
         };
+        if (patch.targetCallsign !== undefined) next.targetCallsign = patch.targetCallsign;
+        if (patch.targetGrid !== undefined) next.targetGrid = patch.targetGrid;
+        if (patch.actualFrequency !== undefined) {
+            next.actualFrequency = patch.actualFrequency ?? undefined;
+        }
+        // JSON/WebSocket cannot omit-vs-clear cleanly; null means "clear this report".
+        if (patch.reportSent !== undefined) {
+            next.reportSent = patch.reportSent === null ? undefined : patch.reportSent;
+        }
+        if (patch.reportReceived !== undefined) {
+            next.reportReceived = patch.reportReceived === null ? undefined : patch.reportReceived;
+        }
+        this._context = next;
 
         const needsSlotUpdate =
             patch.targetCallsign !== undefined ||

--- a/packages/contracts/src/schema/websocket.schema.ts
+++ b/packages/contracts/src/schema/websocket.schema.ts
@@ -387,6 +387,9 @@ export const StrategyRuntimeContextSchema = z.object({
 });
 export type StrategyRuntimeContext = z.infer<typeof StrategyRuntimeContextSchema>;
 
+/** Null clears an unsettable runtime report field over JSON/WebSocket. */
+export const OperatorContextReportFieldSchema = z.number().nullish();
+
 export const StrategyRuntimeSnapshotSchema = z.object({
   currentState: z.string(),
   slots: z.object({
@@ -717,8 +720,8 @@ export const WSSetOperatorContextMessageSchema = WSBaseMessageSchema.extend({
       targetCallsign: z.string().optional(),
       targetGrid: z.string().optional(),
       frequency: z.number().optional(),
-      reportSent: z.number().optional(),
-      reportReceived: z.number().optional(),
+      reportSent: OperatorContextReportFieldSchema,
+      reportReceived: OperatorContextReportFieldSchema,
     }),
   }),
 });

--- a/packages/plugin-api/src/runtime.ts
+++ b/packages/plugin-api/src/runtime.ts
@@ -21,10 +21,16 @@ export interface StrategyRuntimeContext {
   targetCallsign?: string;
   /** Grid locator reported by the target station, if known. */
   targetGrid?: string;
-  /** Signal report sent to the target station. */
-  reportSent?: number;
-  /** Signal report received from the target station. */
-  reportReceived?: number;
+  /**
+   * Signal report sent to the target station.
+   * Use `null` in {@link StrategyRuntime.patchContext} to clear a previously set value.
+   */
+  reportSent?: number | null;
+  /**
+   * Signal report received from the target station.
+   * Use `null` in {@link StrategyRuntime.patchContext} to clear a previously set value.
+   */
+  reportReceived?: number | null;
   /** Actual RF/audio frequency being used for the active QSO. */
   actualFrequency?: number;
 }

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -65,6 +65,22 @@ function normalizeOperatorContext(context: any): any {
   };
 }
 
+/** True when a logged RST/SNR field is absent. Note: "0" is a valid FT8 report. */
+function isMissingSignalReport(value: string | undefined | null): boolean {
+  return value === undefined || value === null || value === '';
+}
+
+function preferSignalReport(
+  ...candidates: Array<string | undefined | null>
+): string | undefined {
+  for (const candidate of candidates) {
+    if (!isMissingSignalReport(candidate)) {
+      return candidate ?? undefined;
+    }
+  }
+  return undefined;
+}
+
 interface SameTransmissionGuardState {
   canonicalMessage: string;
   count: number;
@@ -636,11 +652,19 @@ export class RadioOperatorManager {
         targetGrid = this.callsignTracker.getGrid(targetCall) ?? '';
       }
 
+      const rawReportSent = runtimeState?.context?.reportSent;
+      const rawReportReceived = runtimeState?.context?.reportReceived;
       const targetContext = {
         targetCall,
         targetGrid,
-        reportSent: Number(runtimeState?.context?.reportSent ?? 0),
-        reportReceived: Number(runtimeState?.context?.reportReceived ?? 0),
+        // Keep unset reports as undefined. Coercing to 0 pollutes QSO logs
+        // because FT8 SNR of 0 is valid and UI echoes can write the sentinel back.
+        reportSent: typeof rawReportSent === 'number' && Number.isFinite(rawReportSent)
+          ? rawReportSent
+          : undefined,
+        reportReceived: typeof rawReportReceived === 'number' && Number.isFinite(rawReportReceived)
+          ? rawReportReceived
+          : undefined,
       };
       
       operators.push({
@@ -1830,24 +1854,6 @@ export class RadioOperatorManager {
     const grid = qsoRecord.grid
       || this.callsignTracker?.getGrid(targetCallsign);
 
-    // Recover signal reports from CallsignContextTracker if missing
-    let reportSent = qsoRecord.reportSent;
-    let reportReceived = qsoRecord.reportReceived;
-    if (this.callsignTracker && myCallsign) {
-      if (!reportSent) {
-        const sent = this.callsignTracker.getReport(myCallsign, targetCallsign);
-        if (sent !== undefined) {
-          reportSent = sent.toString();
-        }
-      }
-      if (!reportReceived) {
-        const received = this.callsignTracker.getReport(targetCallsign, myCallsign);
-        if (received !== undefined) {
-          reportReceived = received.toString();
-        }
-      }
-    }
-
     const messageHistory = this.rebuildQSOMessageHistory(historySlotPacks, {
       operatorId,
       myCallsign,
@@ -1856,13 +1862,41 @@ export class RadioOperatorManager {
       endMs: historyEndMs,
     });
 
+    // Prefer reports decoded from the air messages; context may still hold a
+    // UI/default sentinel of "0" that would otherwise be logged as-is.
+    const fromHistory = this.extractReportsFromMessageHistory(
+      messageHistory,
+      myCallsign,
+      targetCallsign,
+    );
+
+    let reportSent = preferSignalReport(fromHistory.reportSent, qsoRecord.reportSent);
+    let reportReceived = preferSignalReport(fromHistory.reportReceived, qsoRecord.reportReceived);
+
+    // Recover remaining gaps from CallsignContextTracker.
+    // Do not use truthiness checks: "0" is a valid FT8 report.
+    if (this.callsignTracker && myCallsign) {
+      if (isMissingSignalReport(reportSent)) {
+        const sent = this.callsignTracker.getReport(myCallsign, targetCallsign);
+        if (sent !== undefined) {
+          reportSent = sent.toString();
+        }
+      }
+      if (isMissingSignalReport(reportReceived)) {
+        const received = this.callsignTracker.getReport(targetCallsign, myCallsign);
+        if (received !== undefined) {
+          reportReceived = received.toString();
+        }
+      }
+    }
+
     const completedRecord = {
       ...qsoRecord,
       callsign: targetCallsign,
       myCallsign: myCallsign || qsoRecord.myCallsign,
       grid,
-      reportSent: reportSent || qsoRecord.reportSent,
-      reportReceived: reportReceived || qsoRecord.reportReceived,
+      reportSent: preferSignalReport(reportSent, qsoRecord.reportSent),
+      reportReceived: preferSignalReport(reportReceived, qsoRecord.reportReceived),
       messageHistory,
     };
     return {
@@ -1932,6 +1966,46 @@ export class RadioOperatorManager {
     }
 
     return messages;
+  }
+
+  /**
+   * Extract directed SNR reports exchanged between myCallsign and targetCallsign.
+   * Later messages win so the final report in the QSO is preferred.
+   */
+  private extractReportsFromMessageHistory(
+    messages: string[],
+    myCallsign: string,
+    targetCallsign: string,
+  ): { reportSent?: string; reportReceived?: string } {
+    let reportSent: string | undefined;
+    let reportReceived: string | undefined;
+    const me = myCallsign.toUpperCase();
+    const them = targetCallsign.toUpperCase();
+
+    for (const message of messages) {
+      try {
+        const parsed = FT8MessageParser.parseMessage(message);
+        if (parsed.type !== 'signal_report' && parsed.type !== 'roger_report') {
+          continue;
+        }
+        if (typeof parsed.report !== 'number' || !Number.isFinite(parsed.report)) {
+          continue;
+        }
+        const sender = parsed.senderCallsign?.toUpperCase();
+        const target = parsed.targetCallsign?.toUpperCase();
+        // Keep WSJT-X style two-digit reports (e.g. "-09") instead of bare "-9".
+        const report = FT8MessageParser.generateSignalReport(parsed.report);
+        if (sender === me && target === them) {
+          reportSent = report;
+        } else if (sender === them && target === me) {
+          reportReceived = report;
+        }
+      } catch (error) {
+        logger.warn(`Failed to parse frame while extracting QSO reports: "${message}"`, error);
+      }
+    }
+
+    return { reportSent, reportReceived };
   }
 
   private isFrameRelatedToQSO(
@@ -2013,8 +2087,9 @@ export class RadioOperatorManager {
       startTime: Math.min(existing.startTime, incoming.startTime),
       endTime: Math.max(existingEndTime, incomingEndTime),
       grid: incoming.grid || existing.grid,
-      reportSent: incoming.reportSent || existing.reportSent,
-      reportReceived: incoming.reportReceived || existing.reportReceived,
+      // "0" is a valid FT8 report; do not treat it as missing via ||.
+      reportSent: preferSignalReport(incoming.reportSent, existing.reportSent),
+      reportReceived: preferSignalReport(incoming.reportReceived, existing.reportReceived),
       messageHistory,
       lotwQslSent: existing.lotwQslSent,
       lotwQslReceived: existing.lotwQslReceived,

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -65,9 +65,11 @@ function normalizeOperatorContext(context: any): any {
   };
 }
 
-/** True when a logged RST/SNR field is absent. Note: "0" is a valid FT8 report. */
+/** True when a logged RST/SNR field is absent.
+ * Note: "+00" is a valid FT8 report of 0 dB from generateSignalReport.
+ * Bare "0" is treated as the legacy UI/runtime clear sentinel. */
 function isMissingSignalReport(value: string | undefined | null): boolean {
-  return value === undefined || value === null || value === '';
+  return value === undefined || value === null || value === '' || value === '0';
 }
 
 function preferSignalReport(

--- a/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
+++ b/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
@@ -4,6 +4,19 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+// PluginManager pulls host hamlib; unit tests do not need the native binding.
+vi.mock('hamlib', () => ({
+  HamLib: class HamLib {},
+  Rotator: class Rotator {
+    static getSupportedRotators() { return []; }
+    static getHamlibVersion() { return 'mock-hamlib'; }
+  },
+  PASSBAND: {
+    NORMAL: 0,
+    NOCHANGE: -1,
+  },
+}));
+
 import type { DigitalRadioEngineEvents, FrameMessage, QSORecord, RadioOperatorConfig, SlotInfo, SlotPack } from '@tx5dr/contracts';
 import { FT8MessageType, MODES } from '@tx5dr/contracts';
 
@@ -640,7 +653,14 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       activeSlotPacks: [
         buildSlotPack(`ft8-${base}`, base, [
           {
-            message: 'BG5DRB N0CALL -12',
+            message: 'BG5DRB N0CALL -09',
+            snr: -12,
+            dt: 0,
+            freq: 1300,
+            confidence: 1,
+          },
+          {
+            message: 'N0CALL BG5DRB -12',
             snr: -999,
             dt: 0,
             freq: 1300,
@@ -679,7 +699,10 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     expect(provider.addQSO).toHaveBeenCalledTimes(1);
     expect(updatedSpy).not.toHaveBeenCalled();
     expect(addedSpy).toHaveBeenCalledTimes(1);
-    expect(provider.addQSO.mock.calls[0]?.[0]?.messageHistory).toEqual(['BG5DRB N0CALL -12']);
+    expect(provider.addQSO.mock.calls[0]?.[0]?.messageHistory).toEqual([
+      'BG5DRB N0CALL -09',
+      'N0CALL BG5DRB -12',
+    ]);
     expect(provider.addQSO.mock.calls[0]?.[0]?.comment).toBe('FT8  Sent: -12  Rcvd: -09');
     expect(autoSync).toHaveBeenCalledTimes(1);
     expect(notifyQSOComplete).toHaveBeenCalledTimes(1);
@@ -688,7 +711,10 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       expect.objectContaining({
         id: 'temp-2',
         callsign: 'N0CALL',
-        messageHistory: ['BG5DRB N0CALL -12'],
+        messageHistory: [
+          'BG5DRB N0CALL -09',
+          'N0CALL BG5DRB -12',
+        ],
         comment: 'FT8  Sent: -12  Rcvd: -09',
       }),
     );
@@ -770,6 +796,143 @@ describe('RadioOperatorManager automatic QSO logging', () => {
         comment: 'FT8  Sent: -12  Rcvd: -09',
       }),
     );
+  });
+
+  it('recovers reportReceived from air history when the logged value is a sentinel 0', async () => {
+    // Issue #70: context may carry reportReceived "0" while the exchange contained -15.
+    const base = Date.parse('2026-07-23T07:43:00.000Z');
+    const provider = {
+      addQSO: vi.fn().mockResolvedValue(undefined),
+      updateQSO: vi.fn(),
+      getQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 0 }),
+    };
+
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5FRH',
+      activeSlotPacks: [
+        buildSlotPack(`ft8-${base}`, base, [
+          {
+            message: 'BG5FRH RW9HSB -15',
+            snr: -2,
+            dt: 0.1,
+            freq: 2557,
+            confidence: 1,
+          },
+        ]),
+        buildSlotPack(`ft8-${base + MODES.FT8.slotMs}`, base + MODES.FT8.slotMs, [
+          {
+            message: 'RW9HSB BG5FRH R-02',
+            snr: -999,
+            dt: 0,
+            freq: 2386,
+            confidence: 1,
+            operatorId: 'op1',
+          },
+        ]),
+        buildSlotPack(`ft8-${base + MODES.FT8.slotMs * 2}`, base + MODES.FT8.slotMs * 2, [
+          {
+            message: 'BG5FRH RW9HSB RR73',
+            snr: -3,
+            dt: 0.2,
+            freq: 2559,
+            confidence: 1,
+          },
+        ]),
+      ],
+      storedRecords: [],
+    });
+    attachQSOHookSpy(manager);
+
+    await invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoRecord: {
+        id: 'temp-issue-70',
+        callsign: 'RW9HSB',
+        grid: 'NO26',
+        frequency: 21_076_000,
+        mode: 'FT8',
+        startTime: base,
+        endTime: base + MODES.FT8.slotMs * 2,
+        reportSent: '-2',
+        reportReceived: '0',
+        messageHistory: [],
+        myCallsign: 'BG5FRH',
+        myGrid: 'PL09',
+      },
+    });
+
+    expect(provider.addQSO).toHaveBeenCalledTimes(1);
+    expect(provider.addQSO.mock.calls[0]?.[0]).toMatchObject({
+      callsign: 'RW9HSB',
+      reportSent: '-02',
+      reportReceived: '-15',
+      comment: 'FT8  Sent: -02  Rcvd: -15',
+    });
+  });
+
+  it('preserves a legitimate FT8 report of 0 when merging QSO records', async () => {
+    const base = Date.parse('2026-07-23T08:00:00.000Z');
+    const provider = {
+      addQSO: vi.fn(),
+      updateQSO: vi.fn().mockResolvedValue(undefined),
+      getQSO: vi.fn().mockResolvedValue({
+        id: 'existing-zero',
+        callsign: 'N0CALL',
+        frequency: 14_074_000,
+        mode: 'FT8',
+        startTime: base - 30_000,
+        endTime: base + MODES.FT8.slotMs,
+        reportSent: '0',
+        reportReceived: '-09',
+        messageHistory: [],
+      }),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue({
+        id: 'existing-zero',
+        callsign: 'N0CALL',
+        frequency: 14_074_000,
+        mode: 'FT8',
+        startTime: base - 30_000,
+        endTime: base - 15_000,
+        reportSent: '-10',
+        reportReceived: '-08',
+        messageHistory: [],
+      }),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 1 }),
+    };
+
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5DRB',
+      activeSlotPacks: [],
+      storedRecords: [],
+    });
+    attachQSOHookSpy(manager);
+
+    await invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoRecord: {
+        id: 'temp-zero',
+        callsign: 'N0CALL',
+        frequency: 14_074_000,
+        mode: 'FT8',
+        startTime: base,
+        endTime: base + MODES.FT8.slotMs,
+        reportSent: '0',
+        reportReceived: '-09',
+        messageHistory: [],
+        myCallsign: 'BG5DRB',
+      },
+    });
+
+    expect(provider.updateQSO).toHaveBeenCalledTimes(1);
+    expect(provider.updateQSO.mock.calls[0]?.[1]).toMatchObject({
+      reportSent: '0',
+      reportReceived: '-09',
+      comment: 'FT8  Sent: 0  Rcvd: -09',
+    });
   });
 
   it('replaces the queued transmission when a late decode advances standard-qso during the current TX slot', async () => {

--- a/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
+++ b/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
@@ -64,7 +64,10 @@ function createManager(options: {
   encodeQueue?: { push: ReturnType<typeof vi.fn> };
   getRadioFrequency?: () => Promise<number | null>;
   getKnownRadioFrequency?: () => number | null;
-  callsignTracker?: { getGrid: (callsign: string) => string | undefined };
+  callsignTracker?: {
+    getGrid: (callsign: string) => string | undefined;
+    getReport?: (senderCallsign: string, targetCallsign: string) => number | undefined;
+  };
   getFakeFrequencyEnabled?: () => boolean;
 }) {
   const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
@@ -873,7 +876,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     });
   });
 
-  it('preserves a legitimate FT8 report of 0 when merging QSO records', async () => {
+  it('preserves a legitimate FT8 report of +00 when merging QSO records', async () => {
     const base = Date.parse('2026-07-23T08:00:00.000Z');
     const provider = {
       addQSO: vi.fn(),
@@ -885,7 +888,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
         mode: 'FT8',
         startTime: base - 30_000,
         endTime: base + MODES.FT8.slotMs,
-        reportSent: '0',
+        reportSent: '+00',
         reportReceived: '-09',
         messageHistory: [],
       }),
@@ -920,7 +923,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
         mode: 'FT8',
         startTime: base,
         endTime: base + MODES.FT8.slotMs,
-        reportSent: '0',
+        reportSent: '+00',
         reportReceived: '-09',
         messageHistory: [],
         myCallsign: 'BG5DRB',
@@ -929,9 +932,60 @@ describe('RadioOperatorManager automatic QSO logging', () => {
 
     expect(provider.updateQSO).toHaveBeenCalledTimes(1);
     expect(provider.updateQSO.mock.calls[0]?.[1]).toMatchObject({
-      reportSent: '0',
+      reportSent: '+00',
       reportReceived: '-09',
-      comment: 'FT8  Sent: 0  Rcvd: -09',
+      comment: 'FT8  Sent: +00  Rcvd: -09',
+    });
+  });
+
+  it('treats bare sentinel "0" as missing when no air history is available', async () => {
+    const base = Date.parse('2026-07-23T09:00:00.000Z');
+    const provider = {
+      addQSO: vi.fn().mockResolvedValue(undefined),
+      updateQSO: vi.fn(),
+      getQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 0 }),
+    };
+    const callsignTracker = {
+      getGrid: vi.fn(() => undefined),
+      getReport: vi.fn((sender: string, target: string) => {
+        if (sender === 'RW9HSB' && target === 'BG5FRH') return -15;
+        if (sender === 'BG5FRH' && target === 'RW9HSB') return -2;
+        return undefined;
+      }),
+    };
+
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5FRH',
+      activeSlotPacks: [],
+      storedRecords: [],
+      callsignTracker,
+    });
+    attachQSOHookSpy(manager);
+
+    await invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoRecord: {
+        id: 'temp-sentinel',
+        callsign: 'RW9HSB',
+        frequency: 21_076_000,
+        mode: 'FT8',
+        startTime: base,
+        endTime: base + MODES.FT8.slotMs,
+        reportSent: '0',
+        reportReceived: '0',
+        messageHistory: [],
+        myCallsign: 'BG5FRH',
+      },
+    });
+
+    expect(provider.addQSO).toHaveBeenCalledTimes(1);
+    expect(provider.addQSO.mock.calls[0]?.[0]).toMatchObject({
+      reportSent: '-2',
+      reportReceived: '-15',
+      comment: 'FT8  Sent: -2  Rcvd: -15',
     });
   });
 

--- a/packages/server/src/websocket/WSServer.ts
+++ b/packages/server/src/websocket/WSServer.ts
@@ -2295,15 +2295,15 @@ export class WSServer extends WSMessageHandler {
   private broadcastQSOToast(operatorId: string, qso: any, key: ServerMessageKey.QSO_LOGGED | ServerMessageKey.QSO_UPDATED): void {
     try {
       const mhz = (qso.frequency / 1_000_000).toFixed(3);
-      const reportSent = qso.reportSent || '--';
-      const reportReceived = qso.reportReceived || '--';
+      const reportSent = qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '--';
+      const reportReceived = qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '--';
       const summaryParts = [qso.callsign];
       if (qso.grid) {
         summaryParts.push(qso.grid);
       }
       summaryParts.push(`${mhz} MHz`);
       summaryParts.push(qso.mode);
-      if (qso.reportSent || qso.reportReceived) {
+      if ((qso.reportSent != null && qso.reportSent !== '') || (qso.reportReceived != null && qso.reportReceived !== '')) {
         summaryParts.push(`${reportSent}/${reportReceived}`);
       }
 

--- a/packages/web/src/components/app/GlobalShortcutBridge.tsx
+++ b/packages/web/src/components/app/GlobalShortcutBridge.tsx
@@ -149,8 +149,8 @@ export function GlobalShortcutBridge() {
       radioService.setOperatorContext(activeOperator.id, {
         targetCallsign: '',
         targetGrid: '',
-        reportSent: 0,
-        reportReceived: 0,
+        reportSent: null,
+        reportReceived: null,
       });
       radioService.setOperatorRuntimeState(activeOperator.id, 'TX6');
       dispatchOperatorSlotShortcutFeedback(activeOperator.id, 'TX6');

--- a/packages/web/src/components/logbook/LogbookViewer.tsx
+++ b/packages/web/src/components/logbook/LogbookViewer.tsx
@@ -973,9 +973,9 @@ const LogbookViewer: React.FC<LogbookViewerProps> = ({ operatorId, logBookId, op
           </Chip>
         );
       case "reportSent":
-        return qso.reportSent || '-';
+        return qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '-';
       case "reportReceived":
-        return qso.reportReceived || '-';
+        return qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '-';
       case "qslStatus": {
         const isLotwConfirmed = qso.lotwQslReceived === 'Y' || qso.lotwQslReceived === 'V';
         const isQrzConfirmed = qso.qrzQslReceived === 'Y';

--- a/packages/web/src/components/logbook/QSOFormModal.tsx
+++ b/packages/web/src/components/logbook/QSOFormModal.tsx
@@ -174,12 +174,12 @@ const QSOFormModal: React.FC<QSOFormModalProps> = ({
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <Input
                 label={t('editQso.reportSent')}
-                value={formData.reportSent || ''}
+                value={formData.reportSent ?? ''}
                 onChange={e => onChange({ ...formData, reportSent: e.target.value || undefined })}
               />
               <Input
                 label={t('editQso.reportReceived')}
-                value={formData.reportReceived || ''}
+                value={formData.reportReceived ?? ''}
                 onChange={e => onChange({ ...formData, reportReceived: e.target.value || undefined })}
               />
             </div>

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -132,9 +132,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
     };
   });
 
-  // 报告字段的原始字符串（支持 ""、"-" 等中间态）
+  // 报告字段的原始字符串（支持 ""、"-" 等中间态；未设置时显示空而非哨兵 0）
   const [reportSentRaw, setReportSentRaw] = React.useState(() =>
-    (operatorStatus.context.reportSent ?? 0).toString()
+    operatorStatus.context.reportSent === undefined || operatorStatus.context.reportSent === null
+      ? ''
+      : operatorStatus.context.reportSent.toString()
   );
 
   // 频率字段的原始字符串（支持编辑中间态，失焦时 clamp）
@@ -367,7 +369,9 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
 
         // 同步原始字符串显示（仅非聚焦/冷却时）
         if (!focusedFields.has('reportSent') && !cooldownFields.has('reportSent')) {
-          const newVal = (newContext.reportSent ?? 0).toString();
+          const newVal = newContext.reportSent === undefined || newContext.reportSent === null
+            ? ''
+            : newContext.reportSent.toString();
           if (reportSentRaw !== newVal) {
             setReportSentRaw(newVal);
           }
@@ -472,16 +476,18 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       targetCallsign: ctx.targetCall,
       targetGrid: ctx.targetGrid,
       frequency: ctx.frequency,
-      // Only send reportSent when explicitly set. Never echo a UI default of 0 for
+      // Only send reportSent when explicitly set. Never echo a UI default for
       // reportReceived — that field is driven by FT8 exchanges on the server.
       ...(typeof ctx.reportSent === 'number' && Number.isFinite(ctx.reportSent)
         ? { reportSent: ctx.reportSent }
-        : {}),
+        : ctx.reportSent === null
+          ? { reportSent: null }
+          : {}),
     });
   }, [setOperatorContext]);
 
   // 处理上下文更新（用户每次击键）
-  const handleContextUpdate = (field: string, value: string | number) => {
+  const handleContextUpdate = (field: string, value: string | number | null) => {
     const newContext = { ...localContext, [field]: value };
     setLocalContext(newContext);
 
@@ -544,7 +550,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
         // 同步原始字符串显示
         if (field === 'reportSent') {
           setReportSentRaw(
-            typeof bufferedValue === 'number' ? bufferedValue.toString() : '0',
+            typeof bufferedValue === 'number' ? bufferedValue.toString() : '',
           );
         } else if (field === 'frequency') {
           setFrequencyRaw(bufferedValue.toString());
@@ -1314,8 +1320,8 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
                     setOperatorContext({
                       targetCallsign: '',
                       targetGrid: '',
-                      reportSent: 0,
-                      reportReceived: 0,
+                      reportSent: null,
+                      reportReceived: null,
                     });
 
                     // 第2步：切换到 TX6 槽位
@@ -1374,11 +1380,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
             }}
             onFocus={() => handleInputFocus('reportSent')}
             onBlur={() => {
-              // 失焦时修正中间态
+              // 失焦时修正中间态：空输入表示清除，不再写入哨兵 0
               const num = parseInt(reportSentRaw);
               if (isNaN(num)) {
-                setReportSentRaw('0');
-                handleContextUpdate('reportSent', 0);
+                setReportSentRaw('');
+                handleContextUpdate('reportSent', null);
               }
               handleInputBlur('reportSent');
             }}

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -125,8 +125,10 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       targetCall: operatorStatus.context.targetCall || '',
       targetGrid: operatorStatus.context.targetGrid || '',
       frequency: operatorStatus.context.frequency, // 频率可选，用于无电台模式设置完整的无线电频率（Hz）
-      reportSent: operatorStatus.context.reportSent ?? 0,
-      reportReceived: operatorStatus.context.reportReceived ?? 0,
+      // Keep unset reports as undefined. FT8 SNR of 0 is valid; defaulting to 0
+      // caused QSO logs to record a sentinel "0" (issue #70).
+      reportSent: operatorStatus.context.reportSent,
+      reportReceived: operatorStatus.context.reportReceived,
     };
   });
 
@@ -171,7 +173,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
   const [cooldownSlotFields, setCooldownSlotFields] = React.useState<Set<OperatorRuntimeSlot>>(new Set());
 
   // 冷却期缓冲区：存储冷却期间服务端推送的最新值
-  const cooldownBufferRef = React.useRef<Record<string, string | number>>({});
+  const cooldownBufferRef = React.useRef<Record<string, string | number | undefined>>({});
   const cooldownSlotBufferRef = React.useRef<RuntimeSlotContents>({});
 
   // localContext ref，供回调函数读取最新值
@@ -333,13 +335,13 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
     if (operatorStatus.context && operatorStatus.context.myCall) {
       const serverCtx = operatorStatus.context;
       const fields = ['myCall', 'myGrid', 'targetCall', 'targetGrid', 'frequency', 'reportSent'] as const;
-      const serverMap: Record<string, string | number> = {
+      const serverMap: Record<string, string | number | undefined> = {
         myCall: serverCtx.myCall || '',
         myGrid: serverCtx.myGrid || '',
         targetCall: serverCtx.targetCall || '',
         targetGrid: serverCtx.targetGrid || '',
         frequency: serverCtx.frequency ?? 0,
-        reportSent: serverCtx.reportSent ?? 0,
+        reportSent: serverCtx.reportSent,
       };
 
       // 冷却中的字段：更新缓冲区
@@ -356,7 +358,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
             // 聚焦或冷却中 → 保留本地值
             continue;
           }
-          (newContext as Record<string, string | number>)[field] = serverMap[field];
+          (newContext as Record<string, string | number | undefined>)[field] = serverMap[field];
         }
 
         const hasChanged = fields.some(f =>
@@ -470,8 +472,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       targetCallsign: ctx.targetCall,
       targetGrid: ctx.targetGrid,
       frequency: ctx.frequency,
-      reportSent: ctx.reportSent,
-      reportReceived: ctx.reportReceived,
+      // Only send reportSent when explicitly set. Never echo a UI default of 0 for
+      // reportReceived — that field is driven by FT8 exchanges on the server.
+      ...(typeof ctx.reportSent === 'number' && Number.isFinite(ctx.reportSent)
+        ? { reportSent: ctx.reportSent }
+        : {}),
     });
   }, [setOperatorContext]);
 
@@ -538,7 +543,9 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
         });
         // 同步原始字符串显示
         if (field === 'reportSent') {
-          setReportSentRaw(bufferedValue.toString());
+          setReportSentRaw(
+            typeof bufferedValue === 'number' ? bufferedValue.toString() : '0',
+          );
         } else if (field === 'frequency') {
           setFrequencyRaw(bufferedValue.toString());
         }

--- a/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
+++ b/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
@@ -1247,8 +1247,14 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
       targetCallsign: operator.context.targetCall,
       targetGrid: operator.context.targetGrid,
       frequency: Math.round(frequency),
-      reportSent: operator.context.reportSent,
-      reportReceived: operator.context.reportReceived,
+      // Only forward finite reports; omit unset so a frequency drag cannot
+      // re-inject a missing/sentinel report into the runtime.
+      ...(typeof operator.context.reportSent === 'number' && Number.isFinite(operator.context.reportSent)
+        ? { reportSent: operator.context.reportSent }
+        : {}),
+      ...(typeof operator.context.reportReceived === 'number' && Number.isFinite(operator.context.reportReceived)
+        ? { reportReceived: operator.context.reportReceived }
+        : {}),
     });
   }, [connection.state.radioService, operators]);
 

--- a/packages/web/src/notifications/notificationDriver.ts
+++ b/packages/web/src/notifications/notificationDriver.ts
@@ -261,8 +261,8 @@ export function buildQsoNotificationSummary(qso: Pick<QSORecord, 'callsign' | 'g
     summaryParts.push(qso.mode);
   }
 
-  if (qso.reportSent || qso.reportReceived) {
-    summaryParts.push(`${qso.reportSent || '--'}/${qso.reportReceived || '--'}`);
+  if (qso.reportSent != null && qso.reportSent !== '' || qso.reportReceived != null && qso.reportReceived !== '') {
+    summaryParts.push(`${qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '--'}/${qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '--'}`);
   }
 
   return summaryParts.join(' • ');

--- a/packages/web/src/utils/__tests__/operatorReset.test.ts
+++ b/packages/web/src/utils/__tests__/operatorReset.test.ts
@@ -16,8 +16,8 @@ function createOperator(overrides: Partial<OperatorStatus> = {}): OperatorStatus
       targetCall: '',
       targetGrid: '',
       frequency: 1500,
-      reportSent: 0,
-      reportReceived: 0,
+      reportSent: undefined,
+      reportReceived: undefined,
     },
     strategy: {
       name: 'standard-qso',
@@ -65,8 +65,8 @@ describe('resetOperatorsForOperatingStateChange', () => {
     expect(radioService.setOperatorContext).toHaveBeenCalledWith('op-1', {
       targetCallsign: '',
       targetGrid: '',
-      reportSent: 0,
-      reportReceived: 0,
+      reportSent: null,
+      reportReceived: null,
     });
     expect(radioService.setOperatorRuntimeState).toHaveBeenCalledWith('op-1', 'TX6');
     expect(radioService.stopOperator).toHaveBeenCalledWith('op-1');
@@ -101,5 +101,33 @@ describe('resetOperatorsForOperatingStateChange', () => {
     expect(radioService.removeOperatorFromTransmission).not.toHaveBeenCalled();
     expect(radioService.setOperatorContext).not.toHaveBeenCalled();
     expect(radioService.setOperatorRuntimeState).not.toHaveBeenCalled();
+  });
+
+  it('clears a legitimate 0 dB report when resetting for an operating-state change', () => {
+    const radioService = createRadioService();
+    const operator = createOperator({
+      context: {
+        myCall: 'BG5DRB',
+        myGrid: 'PM01',
+        targetCall: '',
+        targetGrid: '',
+        frequency: 1500,
+        reportSent: 0,
+        reportReceived: undefined,
+      },
+    });
+
+    const result = resetOperatorsForOperatingStateChange({
+      operators: [operator],
+      radioService,
+    });
+
+    expect(result.operatorsChanged).toBe(1);
+    expect(radioService.setOperatorContext).toHaveBeenCalledWith('op-1', {
+      targetCallsign: '',
+      targetGrid: '',
+      reportSent: null,
+      reportReceived: null,
+    });
   });
 });

--- a/packages/web/src/utils/operatorReset.ts
+++ b/packages/web/src/utils/operatorReset.ts
@@ -16,7 +16,7 @@ const hasText = (value: unknown): boolean => (
 );
 
 const hasNonDefaultReport = (value: unknown): boolean => (
-  typeof value === 'number' && Number.isFinite(value) && value !== 0
+  typeof value === 'number' && Number.isFinite(value)
 );
 
 const getOperatorSlot = (operator: OperatorStatus): string | undefined => (
@@ -54,8 +54,8 @@ export const resetOperatorsForOperatingStateChange = ({
   const clearContext: WSSetOperatorContextMessage['data']['context'] = {
     targetCallsign: '',
     targetGrid: '',
-    reportSent: 0,
-    reportReceived: 0,
+    reportSent: null,
+    reportReceived: null,
   };
 
   for (const operator of operators) {


### PR DESCRIPTION
## Summary
- 修复 [#70](https://github.com/boybook/tx-5dr/issues/70)：自动 QSO 日志中 `reportReceived` 有概率被写成哨兵 `0`（空口实为 `-15` 等真实报告）
- 状态机在 SIGNAL/ROGER/CALL/CQ 路径上始终用空口报文刷新报告，不再被 `restoreContext` 缓存或 UI 默认值挡住
- 落盘时优先从 message history / CallsignContextTracker 回填；裸 `"0"` 视为旧哨兵，合法 0 dB 使用 `"+00"`；重置/清空经 WebSocket 用 `null` 表示未设置

## Test plan
- [ ] 复现 #70 场景：对方发 `CALLSIGN MYCALL -15`，本台回 `R-xx`，收 `RR73`；确认日志「对方收我」为 `-15` 而非 `0`
- [ ] 重置操作员到 CQ 后，确认上下文报告被清空（非写死 `0`），再开始新通联报告正确
- [ ] 合法 0 dB 通联（空口 `+00`）落盘与合并后仍保留 `+00`
- [ ] 单元测试：`yarn workspace @tx5dr/builtin-plugins test src/standard-qso/StandardQSOPluginRuntime.test.ts`
- [ ] 单元测试：`yarn workspace @tx5dr/server test src/operator/__tests__/RadioOperatorManager.test.ts`
- [ ] 单元测试：`yarn workspace @tx5dr/web test src/utils/__tests__/operatorReset.test.ts`


Made with [Cursor](https://cursor.com)