### PR TITLE
fix: keep frequency precision when converting to/from Hz and MHz

### DIFF
--- a/packages/server/src/DigitalRadioEngine.ts
+++ b/packages/server/src/DigitalRadioEngine.ts
@@ -75,6 +75,7 @@ import { ResourceManager } from './utils/ResourceManager.js';
 import { initializePSKReporterService } from './services/PSKReporterService.js';
 import { createLogger } from './utils/logger.js';
 import { bootstrapCoordinator } from './services/BootstrapCoordinator.js';
+import { formatFrequencyMHz } from './utils/frequencyMHz.js';
 
 const logger = createLogger('DigitalRadioEngine');
 
@@ -2045,7 +2046,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
   ): Promise<OperatingStateSyncResult> {
     const configManager = ConfigManager.getInstance();
     const description = preset.description
-      || `${(preset.frequency / 1000000).toFixed(3)} MHz${preset.band ? ` ${preset.band}` : ''}`;
+      || `${formatFrequencyMHz(preset.frequency)} MHz${preset.band ? ` ${preset.band}` : ''}`;
     const radioConnected = this.radioManager.isConnected();
     const activeRadioConfig = configManager.getRadioConfig();
     const radioModeResolution = resolveFrequencyRadioMode({
@@ -2185,7 +2186,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
           frequency: currentFrequency,
           mode: targetMode.name,
           band,
-          description: `${(currentFrequency / 1_000_000).toFixed(3)} MHz`,
+          description: `${formatFrequencyMHz(currentFrequency)} MHz`,
           radioConnected: true,
           confirmation: result.frequencyConfirmed === false ? 'mismatch' : 'confirmed',
           ...(result.observedFrequency !== undefined ? { observedFrequency: result.observedFrequency } : {}),
@@ -2198,7 +2199,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
             frequency: currentFrequency,
             mode: targetMode.name,
             band,
-            description: `${(currentFrequency / 1_000_000).toFixed(3)} MHz`,
+            description: `${formatFrequencyMHz(currentFrequency)} MHz`,
           });
         }
         return result.frequencyConfirmed === false || result.modeError
@@ -2260,7 +2261,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
         timeout: 5000,
         key: 'repeaterDuplexUnsupported',
         params: {
-          frequency: (frequency / 1_000_000).toFixed(3),
+          frequency: formatFrequencyMHz(frequency),
           reason: result.message || '',
         },
       });
@@ -2287,7 +2288,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
         timeout: 5000,
         key: 'toneSquelchUnsupported',
         params: {
-          frequency: (frequency / 1_000_000).toFixed(3),
+          frequency: formatFrequencyMHz(frequency),
           reason: result.message || '',
         },
       });
@@ -2560,7 +2561,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
         tolerateModeFailure: true,
       }, expectedConnectionGeneration);
       const band = saved?.band || this.resolveBandLabel(targetFrequency);
-      const description = saved?.description || `${(targetFrequency / 1_000_000).toFixed(3)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
+      const description = saved?.description || `${formatFrequencyMHz(targetFrequency)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
       this.emitProgramFrequencyState({
         frequency: targetFrequency,
         mode: mode.name,
@@ -2668,7 +2669,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       }, expectedConnectionGeneration);
 
       if (lastVoice && !applyResult.frequencyApplied) {
-        logger.warn(`Failed to restore last voice frequency: ${(targetFrequency / 1000000).toFixed(3)} MHz`);
+        logger.warn(`Failed to restore last voice frequency: ${formatFrequencyMHz(lastVoice.frequency)} MHz`);
         return { status: 'failed', detail: 'frequency write was not confirmed' };
       }
 
@@ -2688,7 +2689,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       }, targetFrequency, supportsFmOptions && (lastVoice?.toneMode === 'ctcss' || lastVoice?.toneMode === 'dcs'));
 
       const band = lastVoice?.band || this.resolveBandLabel(targetFrequency);
-      const description = lastVoice?.description || `${(targetFrequency / 1000000).toFixed(3)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
+      const description = lastVoice?.description || `${formatFrequencyMHz(targetFrequency)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
       this.emitProgramFrequencyState({
         frequency: targetFrequency,
         mode: 'VOICE',
@@ -2747,7 +2748,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       }
       targetFrequency = currentFreq;
       targetRadioMode = 'CW';
-      logger.info(`No saved CW frequency, switching radio to CW mode on current frequency: ${(currentFreq / 1000000).toFixed(3)} MHz`);
+      logger.info(`No saved CW frequency, switching radio to CW mode on current frequency: ${formatFrequencyMHz(currentFreq)} MHz`);
     }
 
     try {
@@ -2760,7 +2761,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       }, expectedConnectionGeneration);
 
       if (lastCW?.frequency && !applyResult.frequencyApplied) {
-        logger.warn(`Failed to restore CW frequency: ${(targetFrequency / 1000000).toFixed(3)} MHz`);
+        logger.warn(`Failed to restore CW frequency: ${formatFrequencyMHz(targetFrequency)} MHz`);
         return { status: 'failed', detail: 'frequency write was not confirmed' };
       }
 
@@ -2769,7 +2770,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       }
 
       const band = this.resolveBandLabel(targetFrequency);
-      const description = `${(targetFrequency / 1000000).toFixed(3)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
+      const description = `${formatFrequencyMHz(targetFrequency)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
       this.emitProgramFrequencyState({
         frequency: targetFrequency,
         mode: 'CW',

--- a/packages/server/src/config/config-manager.ts
+++ b/packages/server/src/config/config-manager.ts
@@ -44,6 +44,7 @@ import {
   type ProfileVolumeGainSlot,
   type RuntimeState,
 } from './RuntimeStateManager.js';
+import { formatFrequencyMHz } from '../utils/frequencyMHz.js';
 
 const logger = createLogger('ConfigManager');
 
@@ -1728,7 +1729,7 @@ export class ConfigManager {
       profileId,
       engineMode: memory.lastEngineMode ?? 'digital',
       digitalMHz: memory.lastSelectedFrequency
-        ? (memory.lastSelectedFrequency.frequency / 1_000_000).toFixed(3)
+        ? formatFrequencyMHz(memory.lastSelectedFrequency.frequency)
         : null,
     });
   }

--- a/packages/server/src/radio/PhysicalRadioManager.ts
+++ b/packages/server/src/radio/PhysicalRadioManager.ts
@@ -58,6 +58,7 @@ import { RadioState, type RadioInput } from '../state-machines/types.js';
 import { ConfigManager } from '../config/config-manager.js';
 import { buildFrequencyOperatingStateRequest } from './frequencyRadioMode.js';
 import { isCapabilityTemporarilyDisabled } from './capabilities/definitions.js';
+import { formatFrequencyMHz } from '../utils/frequencyMHz.js';
 
 const logger = createLogger('PhysicalRadioManager');
 const NORMAL_FREQUENCY_POLL_MS = 2000;
@@ -1245,7 +1246,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
           source: 'program',
         });
       }
-      logger.debug(`Frequency set: ${(freq / 1000000).toFixed(3)} MHz`);
+      logger.debug(`Frequency set: ${formatFrequencyMHz(freq)} MHz`);
       return true;
     } catch (error) {
       if (isExplicitOptionalRadioCapabilityError(error)) {
@@ -1751,7 +1752,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
 
     try {
       const currentFreq = await this.connection.getFrequency();
-      logger.info(`Connection test passed, current frequency: ${(currentFreq / 1000000).toFixed(3)} MHz`);
+      logger.info(`Connection test passed, current frequency: ${formatFrequencyMHz(currentFreq)} MHz`);
     } catch (error) {
       logger.error(`Connection test failed: ${(error as Error).message}`);
       this.handleConnectionError(error as Error);
@@ -2906,7 +2907,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       if (this.shouldIgnoreFrequencyObservation(frequency, this.frequencyWriteEpoch, 'connection-event')) {
         return;
       }
-      logger.debug(`Frequency changed: ${(frequency / 1000000).toFixed(3)} MHz`);
+      logger.debug(`Frequency changed: ${formatFrequencyMHz(frequency)} MHz`);
       this.updateKnownFrequency(frequency);
       this.emitRadioFrequencyChanged(frequency, {
         confirmation: 'confirmed',
@@ -3155,7 +3156,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
     try {
       const currentFrequency = await this.getFrequency();
       if (currentFrequency > 0) {
-        logger.debug(`Captured initial frequency during bootstrap: ${(currentFrequency / 1000000).toFixed(3)} MHz`);
+        logger.debug(`Captured initial frequency during bootstrap: ${formatFrequencyMHz(currentFrequency)} MHz`);
         this.updateKnownFrequency(currentFrequency);
         this.emitRadioFrequencyChanged(currentFrequency, {
           confirmation: 'confirmed',
@@ -3592,9 +3593,9 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
         logger.debug(
           `Frequency changed: ${
             previousKnownFrequency
-              ? (previousKnownFrequency / 1000000).toFixed(3)
+              ? formatFrequencyMHz(previousKnownFrequency)
               : 'N/A'
-          } MHz -> ${(currentFrequency / 1000000).toFixed(3)} MHz`
+          } MHz -> ${formatFrequencyMHz(currentFrequency)} MHz`
         );
 
         if (previousKnownFrequency !== null) {
@@ -3611,7 +3612,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
         this.queuePostFrequencyCapabilityRefresh('frequencyMonitor');
       } else if (previousKnownFrequency === null && currentFrequency > 0) {
         // 首次获取频率
-        logger.debug(`Initial frequency: ${(currentFrequency / 1000000).toFixed(3)} MHz`);
+        logger.debug(`Initial frequency: ${formatFrequencyMHz(currentFrequency)} MHz`);
         this.updateKnownFrequency(currentFrequency);
       }
     } catch (error) {

--- a/packages/server/src/radio/connections/HamlibConnection.ts
+++ b/packages/server/src/radio/connections/HamlibConnection.ts
@@ -15,6 +15,7 @@ import { SpectrumController } from 'hamlib/spectrum';
 import type { ManagedSpectrumConfig, SpectrumLine, SpectrumSupportSummary } from 'hamlib/spectrum';
 import serialport from 'serialport';
 import type { LevelMeterReading, MeterCapabilities, SerialConfig, TxAudioInputSource } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz.js';
 import {
   type MeterDecodeStrategy,
   resolveHamlibMeterDecodeStrategy,
@@ -3463,7 +3464,7 @@ export class HamlibConnection
 
       this.lastSuccessfulOperation = Date.now();
       this.currentFrequencyHz = frequency;
-      logger.debug(`Frequency set: ${(frequency / 1000000).toFixed(3)} MHz`);
+      logger.debug(`Frequency set: ${formatFrequencyMHz(frequency)} MHz`);
     } catch (error) {
       throw this.convertError(error, 'setFrequency');
     }
@@ -3796,7 +3797,7 @@ export class HamlibConnection
         try {
           await this.writeSplitFrequencyForVfo(txFrequency, txVfo);
           this.lastSuccessfulOperation = Date.now();
-          logger.debug(`Split TX frequency set: ${(txFrequency / 1000000).toFixed(3)} MHz`);
+          logger.debug(`Split TX frequency set: ${formatFrequencyMHz(txFrequency)} MHz`);
           return;
         } catch (error) {
           lastError = error;
@@ -3823,7 +3824,7 @@ export class HamlibConnection
       ]);
 
       this.lastSuccessfulOperation = Date.now();
-      logger.debug(`Split TX freq/mode set: ${(txFrequency / 1000000).toFixed(3)} MHz ${txMode} ${txWidth}Hz`);
+      logger.debug(`Split TX freq/mode set: ${formatFrequencyMHz(txFrequency)} MHz ${txMode} ${txWidth}Hz`);
     } catch (error) {
       throw this.convertError(error, 'setSplitFreqMode');
     }

--- a/packages/server/src/radio/connections/IcomWlanConnection.ts
+++ b/packages/server/src/radio/connections/IcomWlanConnection.ts
@@ -45,6 +45,7 @@ import {
 } from './IRadioConnection.js';
 import type { TxAudioInputSource } from '@tx5dr/contracts';
 import { ICOM_CONNECTOR_SOURCE_MAP } from '../txAudioInput/TxAudioInputProvider.js';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz.js';
 
 const logger = createLogger('IcomWlanConnection');
 
@@ -397,7 +398,7 @@ export class IcomWlanConnection
 
     try {
       await this.rig!.setFrequency(frequency);
-      logger.debug(`Frequency set: ${(frequency / 1000000).toFixed(3)} MHz`);
+      logger.debug(`Frequency set: ${formatFrequencyMHz(frequency)} MHz`);
     } catch (error) {
       throw this.convertError(error, 'setFrequency');
     }
@@ -896,7 +897,7 @@ export class IcomWlanConnection
       try {
         const freq = await this.rig!.readOperatingFrequency({ timeout: 5000 });
         if (freq !== null) {
-          logger.debug(`Connection test passed, current frequency: ${(freq / 1000000).toFixed(3)} MHz`);
+          logger.debug(`Connection test passed, current frequency: ${formatFrequencyMHz(freq)} MHz`);
         } else {
           throw new Error('Test connection failed: unable to get frequency');
         }

--- a/packages/server/src/routes/radio.ts
+++ b/packages/server/src/routes/radio.ts
@@ -42,6 +42,8 @@ export {
   resolveFrequencyRadioMode,
 } from '../radio/frequencyRadioMode.js';
 
+import { formatFrequencyMHz } from '../utils/frequencyMHz.js';
+
 type SerialPortInfo = Awaited<ReturnType<typeof SerialPort.list>>[number];
 
 function buildDarwinCalloutPortFromDialin(port: SerialPortInfo): SerialPortInfo | null {
@@ -447,7 +449,7 @@ function emitRepeaterDuplexWarning(
     timeout: 5000,
     key: 'repeaterDuplexUnsupported',
     params: {
-      frequency: (frequency / 1_000_000).toFixed(3),
+      frequency: formatFrequencyMHz(frequency),
       reason: result.message || '',
     },
   });
@@ -519,7 +521,7 @@ function emitToneSquelchWarning(
     timeout: 5000,
     key: 'toneSquelchUnsupported',
     params: {
-      frequency: (frequency / 1_000_000).toFixed(3),
+      frequency: formatFrequencyMHz(frequency),
       reason: result.message || '',
     },
   });
@@ -818,7 +820,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
     // 检查电台是否已连接
     if (!radioConnected) {
       // 电台未连接时，只记录频率但不实际设置
-      logger.debug(`Radio not connected, recording frequency: ${(frequency / 1000000).toFixed(3)} MHz${effectiveRadioMode ? ` (${effectiveRadioMode})` : ''}`);
+      logger.debug(`Radio not connected, recording frequency: ${formatFrequencyMHz(frequency)} MHz${effectiveRadioMode ? ` (${effectiveRadioMode})` : ''}`);
 
       // 只有在频率真正改变时才广播
       if (isFrequencyChanged) {
@@ -828,7 +830,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
           logicalState: {
             mode: effectiveMode,
             band: band || '',
-            description: description || `${(frequency / 1000000).toFixed(3)} MHz`,
+            description: description || `${formatFrequencyMHz(frequency)} MHz`,
             ...(effectiveRadioMode ? { radioMode: effectiveRadioMode } : {}),
           },
         });
@@ -915,7 +917,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
         logicalState: {
           mode: effectiveMode,
           band: band || '',
-          description: description || `${(frequency / 1000000).toFixed(3)} MHz`,
+          description: description || `${formatFrequencyMHz(frequency)} MHz`,
           ...(effectiveRadioMode ? { radioMode: effectiveRadioMode } : {}),
         },
       });

--- a/packages/server/src/spectrum/SpectrumSessionCoordinator.ts
+++ b/packages/server/src/spectrum/SpectrumSessionCoordinator.ts
@@ -7,6 +7,7 @@ import type {
   SpectrumSessionState,
   SpectrumSessionSourceMode,
 } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../utils/frequencyMHz.js';
 import type { DigitalRadioEngine } from '../DigitalRadioEngine.js';
 import { FrequencyManager } from '../radio/FrequencyManager.js';
 import { ConfigManager } from '../config/config-manager.js';
@@ -38,7 +39,7 @@ const OPENWEBRX_DETAIL_OFFSET_HZ = 1500;
 const VOICE_FREQUENCY_GESTURE_STEP_HZ = 1000;
 
 function formatPresetMarkerLabel(frequencyHz: number): string {
-  return `${(frequencyHz / 1_000_000).toFixed(3)} MHz`;
+  return `${formatFrequencyMHz(frequencyHz)} MHz`;
 }
 
 interface SpectrumSessionCoordinatorEvents {

--- a/packages/server/src/subsystems/RadioBridge.ts
+++ b/packages/server/src/subsystems/RadioBridge.ts
@@ -21,6 +21,7 @@ import type { EngineLifecycle } from './EngineLifecycle.js';
 import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { createLogger } from '../utils/logger.js';
 import { buildRadioStatusPayload } from '../radio/buildRadioStatusPayload.js';
+import { formatFrequencyMHz } from '../utils/frequencyMHz.js';
 
 const logger = createLogger('RadioBridge');
 
@@ -173,7 +174,7 @@ export class RadioBridge {
       const revision = typeof metadata.revision === 'number'
         ? metadata.revision
         : this.latestFrequencyRevision + 1;
-      logger.debug(`Radio frequency changed: ${(frequency / 1000000).toFixed(3)} MHz`);
+      logger.debug(`Radio frequency changed: ${formatFrequencyMHz(frequency)} MHz`);
 
       this.frequencyEventTail = this.frequencyEventTail
         .catch(() => undefined)
@@ -320,7 +321,7 @@ export class RadioBridge {
         mode: logicalState?.mode ?? preset.mode,
         band: logicalState?.band ?? preset.band,
         radioMode: logicalState?.radioMode ?? preset.radioMode,
-        description: logicalState?.description ?? (preset.description || `${(preset.frequency / 1000000).toFixed(3)} MHz`),
+        description: logicalState?.description ?? (preset.description || `${formatFrequencyMHz(preset.frequency)} MHz`),
         repeaterShift: supportsFmOptions ? preset.repeaterShift : undefined,
         repeaterOffsetHz: supportsFmOptions ? preset.repeaterOffsetHz : undefined,
         toneMode: supportsFmOptions ? preset.toneMode : undefined,
@@ -343,7 +344,7 @@ export class RadioBridge {
       mode: logicalState?.mode ?? (isVoiceMode ? 'VOICE' : isCWMode ? 'CW' : digitalModeName),
       band: logicalState?.band ?? band,
       radioMode: logicalState?.radioMode ?? (isVoiceMode ? lastVoiceFrequency?.radioMode : isCWMode ? (lastCWFrequency?.radioMode || 'CW') : undefined),
-      description: logicalState?.description ?? `${(frequency / 1000000).toFixed(3)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`,
+      description: logicalState?.description ?? `${formatFrequencyMHz(frequency)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`,
       repeaterShift: supportsFmOptions ? lastVoiceFrequency?.repeaterShift : undefined,
       repeaterOffsetHz: supportsFmOptions ? lastVoiceFrequency?.repeaterOffsetHz : undefined,
       toneMode: supportsFmOptions ? lastVoiceFrequency?.toneMode : undefined,

--- a/packages/server/src/utils/__tests__/frequencyMHz.test.ts
+++ b/packages/server/src/utils/__tests__/frequencyMHz.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { formatFrequencyMHz } from '../frequencyMHz.js';
+
+describe('frequency formatting', () => {
+  describe('formatFrequencyMHz', () => {
+    it('pads to three decimals when fewer', () => {
+      expect(formatFrequencyMHz(145_000_000)).toBe('145.000');
+      expect(formatFrequencyMHz(7_000_000)).toBe('7.000');
+      expect(formatFrequencyMHz(146_520_000)).toBe('146.520');
+      expect(formatFrequencyMHz(1_000_000)).toBe('1.000');
+    });
+
+    it('keeps exactly three decimals at 1 kHz granularity', () => {
+      expect(formatFrequencyMHz(145_895_000)).toBe('145.895');
+      expect(formatFrequencyMHz(14_074_000)).toBe('14.074');
+    });
+
+    it('preserves all significant digits beyond three', () => {
+      // 145.89525 MHz — would be truncated to 145.895 by toFixed(3)
+      expect(formatFrequencyMHz(145_895_250)).toBe('145.89525');
+      // 50.125625 MHz
+      expect(formatFrequencyMHz(50_125_625)).toBe('50.125625');
+      // 10.000005 MHz (5 Hz)
+      expect(formatFrequencyMHz(10_000_005)).toBe('10.000005');
+    });
+
+    it('handles sub-MHz frequencies', () => {
+      expect(formatFrequencyMHz(1_000)).toBe('0.001');
+      expect(formatFrequencyMHz(1_500_000)).toBe('1.500');
+    });
+
+    it('handles zero and non-finite', () => {
+      expect(formatFrequencyMHz(0)).toBe('0.000');
+      expect(formatFrequencyMHz(NaN)).toBe('');
+      expect(formatFrequencyMHz(Infinity)).toBe('');
+    });
+  });
+});

--- a/packages/server/src/utils/frequencyMHz.ts
+++ b/packages/server/src/utils/frequencyMHz.ts
@@ -1,0 +1,1 @@
+../../../web/src/utils/frequencyMHz.ts

--- a/packages/server/src/websocket/WSServer.ts
+++ b/packages/server/src/websocket/WSServer.ts
@@ -39,6 +39,7 @@ import { projectSpectrumFrame } from '../spectrum/spectrumProjection.js';
 import { buildRadioStatusPayload } from '../radio/buildRadioStatusPayload.js';
 import { OperatorScopedSlotPackProjectionService } from './OperatorScopedSlotPackProjectionService.js';
 import { canReadFullProfiles, redactHamlibConfigForRead, redactProfileForRead, redactProfilesForRead } from '../security/profileRedaction.js';
+import { formatFrequencyMHz } from '../utils/frequencyMHz.js';
 
 const logger = createLogger('WSServer');
 const DECODE_WORKER_UNAVAILABLE_USER_MESSAGE_KEY = 'errors:code.DECODE_WORKER_UNAVAILABLE.userMessage';
@@ -2235,8 +2236,8 @@ export class WSServer extends WSMessageHandler {
       ? (savedFrequency.band || this.resolveBandLabel(frequency))
       : this.resolveBandLabel(frequency);
     const description = savedFrequency?.frequency === frequency
-      ? (savedFrequency.description || `${(frequency / 1000000).toFixed(3)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`)
-      : `${(frequency / 1000000).toFixed(3)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
+      ? (savedFrequency.description || `${formatFrequencyMHz(frequency)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`)
+      : `${formatFrequencyMHz(frequency)} MHz${band !== 'Unknown' ? ` ${band}` : ''}`;
     const frequencyMetadata = radioManager.getFrequencyStateMetadata?.();
     const radioConnected = radioManager.isConnected();
     const confirmation = radioConnected
@@ -2865,7 +2866,7 @@ export class WSServer extends WSMessageHandler {
 
   private broadcastQSOToast(operatorId: string, qso: any, key: ServerMessageKey.QSO_LOGGED | ServerMessageKey.QSO_UPDATED): void {
     try {
-      const mhz = (qso.frequency / 1_000_000).toFixed(3);
+      const mhz = formatFrequencyMHz(qso.frequency);
       const reportSent = qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '--';
       const reportReceived = qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '--';
       const summaryParts = [qso.callsign];

--- a/packages/web/src/components/auth/TokenManagement.tsx
+++ b/packages/web/src/components/auth/TokenManagement.tsx
@@ -38,6 +38,7 @@ import {
 } from '@tx5dr/contracts';
 import type { TokenInfo, CreateTokenRequest, NetworkInfo, PermissionGrant, PresetFrequency, UpdateTokenRequest } from '@tx5dr/contracts';
 import { useOperators } from '../../store/radioStore';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 
 const ROLE_COLORS: Record<string, 'default' | 'primary' | 'warning'> = {
   viewer: 'default',
@@ -48,7 +49,7 @@ const CUSTOM_BAND = 'custom';
 const CUSTOM_RANGE_BAND = 'custom';
 const FREQUENCY_RANGE_BAND_OPTIONS = Object.entries(FREQUENCY_PERMISSION_BAND_RANGES).map(([key, range]) => ({
   key,
-  label: `${key} ${(range.minFrequency / 1_000_000).toFixed(3)}-${(range.maxFrequency / 1_000_000).toFixed(3)} MHz`,
+  label: `${key} ${formatFrequencyMHz(range.minFrequency)}-${formatFrequencyMHz(range.maxFrequency)} MHz`,
   range,
 }));
 
@@ -1113,7 +1114,7 @@ export function TokenManagement() {
                                   >
                                     {frequencyPresets.map((preset) => (
                                       <Checkbox key={String(preset.frequency)} value={String(preset.frequency)}>
-                                        <span className="text-xs">{preset.description || `${(preset.frequency / 1e6).toFixed(3)} MHz`} — {formatBandLabel(preset.band)} {preset.mode}</span>
+                                        <span className="text-xs">{preset.description || `${formatFrequencyMHz(preset.frequency)} MHz`} — {formatBandLabel(preset.band)} {preset.mode}</span>
                                       </Checkbox>
                                     ))}
                                   </CheckboxGroup>

--- a/packages/web/src/components/cw/CWQSOLogCard.tsx
+++ b/packages/web/src/components/cw/CWQSOLogCard.tsx
@@ -22,6 +22,7 @@ import { api, getDisplayMode } from '@tx5dr/core';
 import { useWSEvent } from '../../hooks/useWSEvent';
 import { useCWKeyer } from '../../hooks/useCWKeyer';
 import type { QSORecord } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 import { openLogbookWindow } from '../../utils/windowManager';
 import { setCWQSOHisCallsign, setCWQSOTrst, setCWQSORrst, useCWQSODraft } from '../../store/cwQsoDraftStore';
 
@@ -485,7 +486,7 @@ export const CWQSOLogCard: React.FC<CWQSOLogCardProps> = ({
 
         {/* Auto-filled info */}
         <div className="flex gap-4 text-xs text-default-400">
-          <span>{t('radio:cw.qso.frequency')}: <span className="font-mono">{((displayedFrequency || 0) / 1000000).toFixed(3)} MHz</span></span>
+          <span>{t('radio:cw.qso.frequency')}: <span className="font-mono">{formatFrequencyMHz(displayedFrequency || 0)} MHz</span></span>
           <span>{t('radio:cw.qso.mode')}: <span className="font-mono">{displayedMode}</span></span>
         </div>
 

--- a/packages/web/src/components/cw/CWRecentQSOList.tsx
+++ b/packages/web/src/components/cw/CWRecentQSOList.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { createLogger } from '../../utils/logger';
 import { api, getDisplayMode } from '@tx5dr/core';
 import type { DigitalRadioEngineEvents, QSORecord } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 
 const logger = createLogger('CWRecentQSOList');
 
@@ -120,7 +121,7 @@ export const CWRecentQSOList: React.FC<CWRecentQSOListProps> = ({
   };
 
   const formatFreq = (freqHz: number): string => {
-    return (freqHz / 1000000).toFixed(3);
+    return formatFrequencyMHz(freqHz);
   };
 
   const getDateKey = (timestamp: number): string => {

--- a/packages/web/src/components/image-radio/SstvComposer.tsx
+++ b/packages/web/src/components/image-radio/SstvComposer.tsx
@@ -25,6 +25,7 @@ import {
   textLayerHandles,
   type CanvasPoint,
 } from './sstvTextLayerGeometry';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 
 type TextLayer = ImageTemplateTextLayer;
 type LayerInteraction =
@@ -145,7 +146,7 @@ export function SstvComposer() {
 
   const values = useMemo(() => ({
     MYCALL: operator?.context.myCall ?? '', MYGRID: operator?.context.myGrid ?? '', HISCALL: hisCall,
-    RSV: rsv, UTC: new Date().toISOString().slice(11, 16), FREQ: radio.currentRadioFrequency ? `${(radio.currentRadioFrequency / 1e6).toFixed(3)}` : '', NOTE: note,
+    RSV: rsv, UTC: new Date().toISOString().slice(11, 16), FREQ: radio.currentRadioFrequency ? formatFrequencyMHz(radio.currentRadioFrequency) : '', NOTE: note,
   }), [hisCall, note, operator?.context.myCall, operator?.context.myGrid, radio.currentRadioFrequency, rsv]);
 
   const resolveText = useCallback((text: string) => text.replace(/\{([A-Z]+)\}/g, (_match, key: keyof typeof values) => values[key] ?? ''), [values]);

--- a/packages/web/src/components/logbook/RecentQSOGlobeCard.tsx
+++ b/packages/web/src/components/logbook/RecentQSOGlobeCard.tsx
@@ -22,6 +22,7 @@ import {
   type WorkedGridLabel,
   type WorkedGridLine,
 } from '../../utils/logbookGlobe';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 
 const logger = createLogger('RecentQSOGlobeCard');
 
@@ -795,7 +796,7 @@ const RecentQSOGlobeCard: React.FC<RecentQSOGlobeCardProps> = ({
         arcDashAnimateTime="dashAnimateTime"
         arcLabel={(arc) => {
           const globeArc = arc as GlobeArc;
-          return `${globeArc.callsign} · ${globeArc.grid}<br/>${globeArc.mode} · ${(globeArc.frequency / 1_000_000).toFixed(3)} MHz<br/>${formatUtcTime(globeArc.startTime)} UTC`;
+          return `${globeArc.callsign} · ${globeArc.grid}<br/>${globeArc.mode} · ${formatFrequencyMHz(globeArc.frequency)} MHz<br/>${formatUtcTime(globeArc.startTime)} UTC`;
         }}
         ringsData={visibleRings}
         ringLat="lat"

--- a/packages/web/src/components/radio/digital/FramesTable.tsx
+++ b/packages/web/src/components/radio/digital/FramesTable.tsx
@@ -9,6 +9,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { useDisplayNotificationSettings } from '../../../hooks/useDisplayNotificationSettings';
 import { type FrameTableCycleBackgrounds, getHighlightTypeLabels, HighlightType } from '../../../utils/displayNotificationSettings';
 import { useTranslation } from 'react-i18next';
+import { formatFrequencyMHz } from '../../../utils/frequencyMHz';
 import { getBadgeColors, hexToRgba } from '../../../utils/colorUtils';
 import { FlagDisplay } from '../../common/FlagDisplay';
 import { ScrollToBottomButton } from '../../common/ScrollToBottomButton';
@@ -276,7 +277,7 @@ const formatGroupHeaderLabel = (
   const context = group.frequencyContext;
   if (context) {
     const frequencyLabel = typeof context.frequency === 'number' && Number.isFinite(context.frequency)
-      ? `${(context.frequency / 1_000_000).toFixed(3)} MHz`
+      ? `${formatFrequencyMHz(context.frequency)} MHz`
       : context.description;
     const parts = [frequencyLabel, context.band, context.mode, timeLabel].filter(Boolean);
     return parts.length > 0

--- a/packages/web/src/components/radio/profile/OpenWebRXProfileSelectModal.tsx
+++ b/packages/web/src/components/radio/profile/OpenWebRXProfileSelectModal.tsx
@@ -16,6 +16,7 @@ import type {
   OpenWebRXProfileSelectRequest,
   OpenWebRXProfileVerifyResult,
 } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../../utils/frequencyMHz';
 import { useWSEvent } from '../../../hooks/useWSEvent';
 import { useConnection } from '../../../store/radioStore';
 import { useCan } from '../../../store/authStore';
@@ -137,7 +138,7 @@ export function OpenWebRXProfileSelectModal() {
   // Only show for users with frequency control permission
   if (!canSetFrequency) return null;
 
-  const targetFreqMHz = request ? (request.targetFrequency / 1_000_000).toFixed(3) : '';
+  const targetFreqMHz = request ? formatFrequencyMHz(request.targetFrequency) : '';
 
   return (
     <Modal
@@ -196,7 +197,7 @@ export function OpenWebRXProfileSelectModal() {
                 <Alert color="danger" variant="flat">
                   {verifyResult.centerFreq != null && verifyResult.sampRate != null
                     ? t('settings:openwebrx.profileSelect.verifyFailed', {
-                        centerFreq: (verifyResult.centerFreq / 1_000_000).toFixed(3),
+                        centerFreq: formatFrequencyMHz(verifyResult.centerFreq),
                         bandwidth: (verifyResult.sampRate / 2 / 1_000_000).toFixed(3),
                       })
                     : verifyResult.error ?? t('settings:openwebrx.profileSelect.verifyFailed', {

--- a/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
+++ b/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
@@ -51,6 +51,7 @@ import {
   STRATEGY_FREQUENCY_PICK_EVENT,
   type StrategyFrequencyPickRequest,
 } from '../../../utils/strategyFrequencyPick';
+import { formatFrequencyMHz } from '../../../utils/frequencyMHz';
 
 const logger = createLogger('SpectrumDisplay');
 const SPECTRUM_NO_FRAME_STALE_MS = 10_000;
@@ -435,7 +436,7 @@ export function buildRadioSdrFrequencyRequest({
 }): SetRadioFrequencyParams | null {
   const snappedFrequency = snapFrequencyToStep(frequency, stepHz);
   const roundedFrequency = Math.round(snappedFrequency);
-  const description = `${(snappedFrequency / 1_000_000).toFixed(3)} MHz`;
+  const description = `${formatFrequencyMHz(snappedFrequency)} MHz`;
 
   if (engineMode === 'voice' || engineMode === 'image') {
     return {
@@ -1730,7 +1731,7 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
       const response = await setRadioFrequencyWithIntent({
         frequency: roundedFrequency,
         band: getBandFromFrequency(roundedFrequency),
-        description: `${(roundedFrequency / 1_000_000).toFixed(3)} MHz`,
+        description: `${formatFrequencyMHz(roundedFrequency)} MHz`,
       });
       if (response.success) {
         resetOperatorsAfterOperatingStateChange();

--- a/packages/web/src/components/radio/spectrum/WebGLWaterfall.tsx
+++ b/packages/web/src/components/radio/spectrum/WebGLWaterfall.tsx
@@ -4,6 +4,7 @@ import { Popover, PopoverTrigger, PopoverContent, Button } from '@heroui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { useTranslation } from 'react-i18next';
+import { formatFrequencyMHz } from '../../../utils/frequencyMHz';
 import { createLogger } from '../../../utils/logger';
 import {
   cropSpectrumToRange,
@@ -5006,7 +5007,7 @@ export const WebGLWaterfall: React.FC<WebGLWaterfallProps> = ({
                 <div className="px-2 py-1">
                   <div className="text-sm font-semibold">{marker.description}</div>
                   <div className="text-xs text-default-400">
-                    {`${(marker.frequency / 1_000_000).toFixed(3)} MHz`}
+                    {`${formatFrequencyMHz(marker.frequency)} MHz`}
                   </div>
                 </div>
               </PopoverContent>

--- a/packages/web/src/components/settings/OpenWebRXSettings.tsx
+++ b/packages/web/src/components/settings/OpenWebRXSettings.tsx
@@ -26,6 +26,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { api } from '@tx5dr/core';
 import type { OpenWebRXStationConfig, OpenWebRXListenStatus, OpenWebRXProfile } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 import { useAudioMonitorPlayback } from '../../hooks/useAudioMonitorPlayback';
 import { createLogger } from '../../utils/logger';
 import {
@@ -462,7 +463,7 @@ export function OpenWebRXSettings() {
                           placeholder="14074000"
                           value={listenFrequency}
                           onValueChange={setListenFrequency}
-                          description={listenFrequency ? `${(parseInt(listenFrequency) / 1000000).toFixed(3)} MHz` : ''}
+                          description={listenFrequency ? `${formatFrequencyMHz(parseInt(listenFrequency))} MHz` : ''}
                           className="flex-1"
                           size="sm"
                         />
@@ -530,7 +531,7 @@ export function OpenWebRXSettings() {
                       placeholder="14074000"
                       value={listenFrequency}
                       onValueChange={setListenFrequency}
-                      description={listenFrequency ? `${(parseInt(listenFrequency) / 1000000).toFixed(3)} MHz` : ''}
+                      description={listenFrequency ? `${formatFrequencyMHz(parseInt(listenFrequency))} MHz` : ''}
                       className="flex-1"
                       size="sm"
                     />
@@ -560,7 +561,7 @@ export function OpenWebRXSettings() {
                   <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-default-400">
                     {listenStatus?.centerFreq && (
                       <span>
-                        {t('openwebrx.centerFreq')}: {(listenStatus.centerFreq / 1000000).toFixed(3)} MHz
+                        {t('openwebrx.centerFreq')}: {formatFrequencyMHz(listenStatus.centerFreq)} MHz
                         {listenStatus.sampleRate && ` (BW: ${(listenStatus.sampleRate / 1000).toFixed(0)} kHz)`}
                       </span>
                     )}

--- a/packages/web/src/components/voice/VoiceQSOLogCard.tsx
+++ b/packages/web/src/components/voice/VoiceQSOLogCard.tsx
@@ -21,6 +21,7 @@ import { createLogger } from '../../utils/logger';
 import { api, getDisplayMode } from '@tx5dr/core';
 import { useWSEvent } from '../../hooks/useWSEvent';
 import type { QSORecord } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 import { openLogbookWindow } from '../../utils/windowManager';
 import { QrzCallsignLink } from '../common/QrzCallsignLink';
 
@@ -473,7 +474,7 @@ export const VoiceQSOLogCard: React.FC<VoiceQSOLogCardProps> = ({
 
         {/* Auto-filled info */}
         <div className="flex gap-4 text-xs text-default-400">
-          <span>{t('qso.frequency')}: <span className="font-mono">{((displayedFrequency || 0) / 1000000).toFixed(3)} MHz</span></span>
+          <span>{t('qso.frequency')}: <span className="font-mono">{formatFrequencyMHz(displayedFrequency || 0)} MHz</span></span>
           <span>{t('qso.mode')}: <span className="font-mono">{displayedMode}</span></span>
         </div>
 

--- a/packages/web/src/components/voice/VoiceRecentQSOList.tsx
+++ b/packages/web/src/components/voice/VoiceRecentQSOList.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { createLogger } from '../../utils/logger';
 import { api, getDisplayMode } from '@tx5dr/core';
 import type { DigitalRadioEngineEvents, QSORecord } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 import { QrzCallsignLink } from '../common/QrzCallsignLink';
 
 const logger = createLogger('VoiceRecentQSOList');
@@ -121,7 +122,7 @@ export const VoiceRecentQSOList: React.FC<VoiceRecentQSOListProps> = ({
   };
 
   const formatFreq = (freqHz: number): string => {
-    return (freqHz / 1000000).toFixed(3);
+    return formatFrequencyMHz(freqHz);
   };
 
   const getDateKey = (timestamp: number): string => {

--- a/packages/web/src/notifications/notificationDriver.ts
+++ b/packages/web/src/notifications/notificationDriver.ts
@@ -1,4 +1,5 @@
 import type { QSORecord } from '@tx5dr/contracts';
+import { formatFrequencyMHz } from '../utils/frequencyMHz';
 import { createLogger } from '../utils/logger';
 
 const logger = createLogger('NotificationDriver');
@@ -254,7 +255,7 @@ export function buildQsoNotificationSummary(qso: Pick<QSORecord, 'callsign' | 'g
   }
 
   if (typeof qso.frequency === 'number' && qso.frequency > 0) {
-    summaryParts.push(`${(qso.frequency / 1_000_000).toFixed(3)} MHz`);
+    summaryParts.push(`${formatFrequencyMHz(qso.frequency)} MHz`);
   }
 
   if (qso.mode) {

--- a/packages/web/src/store/radio/provider.tsx
+++ b/packages/web/src/store/radio/provider.tsx
@@ -47,6 +47,7 @@ import { createSpectrumNegotiator } from './spectrumNegotiation';
 import type { FrameDisplayMessage, FrameGroup } from '../../components/radio/digital/FramesTable';
 import type { RadioState } from './types';
 import { resolveOperatorTargetCallsigns } from '../../utils/operatorTargets';
+import { formatFrequencyMHz } from '../../utils/frequencyMHz';
 
 const logger = createLogger('RadioStore');
 const MAX_VALID_DATE_MS = 8_640_000_000_000_000;
@@ -73,7 +74,7 @@ function buildFrequencyContext(
     ...(currentMode ? { mode: currentMode } : {}),
     ...(currentRadioMode ? { radioMode: currentRadioMode } : {}),
     ...(band && band !== 'Unknown' ? { band } : {}),
-    description: `${(currentRadioFrequency / 1_000_000).toFixed(3)} MHz`,
+    description: `${formatFrequencyMHz(currentRadioFrequency)} MHz`,
   };
 }
 


### PR DESCRIPTION
When converting frequencies between Hz and MHz, the precision was being lost during rounding. This commit ensures that the precision is maintained by keep at least 3 decimal digits when converting to MHz, so that frequencies like 439.4625 MHz will be accurately represented rather than being truncated to 439.462 MHz.