### PR TITLE
HamlibConnection: Fix ctcss tones unit to be 0.1Hz instead of Hz

### DIFF
--- a/packages/server/src/radio/connections/HamlibConnection.ts
+++ b/packages/server/src/radio/connections/HamlibConnection.ts
@@ -2787,7 +2787,9 @@ export class HamlibConnection
           'getAvailableCtcssTones.getAvailableCtcssTones',
           this.rig!.getAvailableCtcssTones(),
         ))
-          .filter((tone) => Number.isFinite(tone) && tone > 0);
+          .filter((tone) => Number.isFinite(tone) && tone > 0)
+          // Hamlib returns Hz; convert to 0.1Hz to honor IRadioConnection contract
+          .map((tone) => Math.round(tone * 10));
         return Array.from(new Set(tones)).sort((a, b) => a - b);
       } catch (error) {
         throw this.convertOptionalOperationError(error, 'getAvailableCtcssTones');


### PR DESCRIPTION
In IRadioConnection, ctcss tones are expected to be in 0.1Hz units. The Hamlib binding package returns available ctcss tones in Hz units, so we need to convert them to 0.1Hz units before returning them.