### PR TITLE
voice: warn instead of disabling mode buttons on mode-write failure

### DIFF
--- a/packages/server/src/routes/radio.ts
+++ b/packages/server/src/routes/radio.ts
@@ -924,7 +924,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
     return reply.send({
       success: true,
       frequency,
-      radioMode: effectiveRadioMode,
+      radioMode: applyResult.modeError ? lastFrequency?.radioMode : effectiveRadioMode,
       repeaterShift: repeaterDuplexToApply?.repeaterShift,
       repeaterOffsetHz: repeaterDuplexToApply?.repeaterOffsetHz,
       toneMode: toneSquelchToApply?.toneMode,

--- a/packages/web/src/components/voice/VoiceFrequencyControl.tsx
+++ b/packages/web/src/components/voice/VoiceFrequencyControl.tsx
@@ -8,6 +8,7 @@ import {
   Listbox,
   ListboxItem,
   ListboxSection,
+  Tooltip,
 } from '@heroui/react';
 import { addToast } from '@heroui/toast';
 import { api, ApiError } from '@tx5dr/core';
@@ -83,7 +84,18 @@ export const VoiceFrequencyControl: React.FC<VoiceFrequencyControlProps> = ({ pr
   const canWriteTargetFrequency = useCallback((frequency: number) => (
     canWriteFrequency && canExecuteRadioFrequency(ability, frequency)
   ), [ability, canWriteFrequency]);
-  const canWriteRadioMode = canSetFrequency && isCoreCapabilityAvailable(radioConnection.coreCapabilities, 'writeRadioMode');
+  const writeRadioModeAvailable = isCoreCapabilityAvailable(radioConnection.coreCapabilities, 'writeRadioMode');
+  // The radio_mode capability poll calls conn.getMode() directly, so a poll failure marks
+  // the capability unavailable (value=null) but does NOT touch the core readRadioMode
+  // capability. Use the capability's availability/value as the accurate "can read mode"
+  // signal instead of the core capability.
+  const readRadioModeAvailable = radioModeCapabilityState?.supported !== false
+    && radioModeCapabilityState?.availability !== 'unavailable';
+  const actualRadioMode = radioModeCapabilityState?.value ?? null;
+  // When the radio rejects a mode write (e.g. mode not supported on the current band),
+  // the backend marks writeRadioMode unsupported. We surface this as a warning state
+  // (yellow border) instead of disabling the buttons, so the user can retry.
+  const modeWriteWarning = !writeRadioModeAvailable;
 
   const [presets, setPresets] = useState<FrequencyPreset[]>([]);
   const [isLoadingPresets, setIsLoadingPresets] = useState(false);
@@ -244,6 +256,18 @@ export const VoiceFrequencyControl: React.FC<VoiceFrequencyControlProps> = ({ pr
     () => deriveVoiceRadioModeOptions(radioModeDescriptor, radioModeCapabilityState),
     [radioModeDescriptor, radioModeCapabilityState],
   );
+
+  // Which mode is highlighted:
+  // - writeRadioMode available: follow the (optimistic, event-synced) local selection.
+  // - writeRadioMode unavailable + can still read mode: revert to the radio's actual mode.
+  // - writeRadioMode unavailable + cannot read mode: deselect everything.
+  const selectedRadioMode = writeRadioModeAvailable
+    ? currentRadioMode
+    : (readRadioModeAvailable && actualRadioMode ? actualRadioMode : null);
+
+  const modeWarningTooltip = readRadioModeAvailable
+    ? t('radioMode.warningReverted')
+    : t('radioMode.warningUnknown');
   const formatFrequencyLabel = useCallback((frequency: number) => `${formatFrequencyMHz(frequency)} MHz`, []);
   const formatBandLabel = useCallback((band?: string | null) => {
     if (!band || band.toLowerCase() === CUSTOM_BAND) {
@@ -572,6 +596,7 @@ export const VoiceFrequencyControl: React.FC<VoiceFrequencyControlProps> = ({ pr
     // Immediately update UI + register pending intent so any stale server echo
     // (incl. in-flight debounced digit edits) is suppressed until preset confirms.
     setCurrentFrequency(preset.frequency);
+    const previousRadioMode = currentRadioMode;
     if (preset.radioMode) setCurrentRadioMode(preset.radioMode);
     pendingFreqRef.current = { intendedFrequency: preset.frequency, sentAt: Date.now() };
     if (freqDebounceTimerRef.current) {
@@ -603,6 +628,11 @@ export const VoiceFrequencyControl: React.FC<VoiceFrequencyControlProps> = ({ pr
         if (pendingFreqRef.current) {
           pendingFreqRef.current = { intendedFrequency: preset.frequency, sentAt: Date.now() };
         }
+        if (response.radioMode) {
+          setCurrentRadioMode(response.radioMode);
+        } else {
+          setCurrentRadioMode(previousRadioMode);
+        }
         resetOperatorsAfterOperatingStateChange();
         addToast({
           title: t('frequency.switchSuccess'),
@@ -620,13 +650,13 @@ export const VoiceFrequencyControl: React.FC<VoiceFrequencyControlProps> = ({ pr
   };
 
   // Handle radio mode change
-  const handleRadioModeChange = (mode: string) => {
-    if (!canWriteRadioMode) return;
+  const handleRadioModeChange = async (mode: string) => {
+    if (!canSetFrequency) return;
     setCurrentRadioMode(mode);
-    if (presetMode === 'VOICE') {
+    if (presetMode === 'VOICE' && !modeWriteWarning) {
       connection.state.radioService?.setVoiceRadioMode(mode);
     } else {
-      void setRadioFrequencyWithIntent({
+      await setRadioFrequencyWithIntent({
         frequency: currentFrequency,
         mode: presetMode,
         band: currentPresetSelection.band,
@@ -836,20 +866,29 @@ export const VoiceFrequencyControl: React.FC<VoiceFrequencyControlProps> = ({ pr
 
         {/* Radio mode buttons */}
         <div className="flex-shrink-0 flex justify-center">
-          <ButtonGroup size="sm" variant="flat">
-            {radioModeOptions.map((mode) => (
-              <Button
-                key={mode}
-                color={currentRadioMode === mode ? 'primary' : 'default'}
-                variant={currentRadioMode === mode ? 'solid' : 'flat'}
-                onPress={() => handleRadioModeChange(mode)}
-                isDisabled={!canWriteRadioMode}
-                className="min-w-12"
-              >
-                {mode}
-              </Button>
-            ))}
-          </ButtonGroup>
+          <Tooltip content={modeWarningTooltip} isDisabled={!modeWriteWarning} placement="top">
+            <ButtonGroup
+              size="sm"
+              variant="flat"
+              className={modeWriteWarning ? 'border-medium border-warning rounded-[calc(theme(borderRadius.small)_+_theme(borderWidth.medium))]' : undefined}
+            >
+              {radioModeOptions.map((mode) => {
+                const isSelected = selectedRadioMode === mode;
+                return (
+                  <Button
+                    key={mode}
+                    color={isSelected ? 'primary' : 'default'}
+                    variant={isSelected ? 'solid' : 'flat'}
+                    onPress={async () => await handleRadioModeChange(mode)}
+                    isDisabled={!canSetFrequency}
+                    className="min-w-12"
+                  >
+                    {mode}
+                  </Button>
+                );
+              })}
+            </ButtonGroup>
+          </Tooltip>
         </div>
 
         {/* Preset frequency list - fills remaining space */}

--- a/packages/web/src/i18n/locales/en/voice.json
+++ b/packages/web/src/i18n/locales/en/voice.json
@@ -33,7 +33,9 @@
     "lsb": "LSB",
     "fm": "FM",
     "am": "AM",
-    "wfm": "WFM"
+    "wfm": "WFM",
+    "warningReverted": "Mode switch failed. The selection has reverted to the radio's current mode. You can retry by selecting again.",
+    "warningUnknown": "Mode switch failed and the current mode could not be read. You can retry by selecting again."
   },
   "ptt": {
     "title": "Voice PTT",

--- a/packages/web/src/i18n/locales/zh/voice.json
+++ b/packages/web/src/i18n/locales/zh/voice.json
@@ -33,7 +33,9 @@
     "lsb": "LSB",
     "fm": "FM",
     "am": "AM",
-    "wfm": "WFM"
+    "wfm": "WFM",
+    "warningReverted": "模式切换失败，已回退至电台当前模式。可重新点选重试。",
+    "warningUnknown": "模式切换失败，且无法读取电台当前模式。可重新点选重试。"
   },
   "ptt": {
     "title": "语音发射",


### PR DESCRIPTION
When a voice mode switch fails (e.g. the radio rejects the mode on the current band), the backend marks writeRadioMode unsupported, which used to gray out the entire mode button group until the radio reconnects or switching frequency/mode presets. Replace that disabled state with a yellow warning border so the buttons stay interactive and the user can retry:

- writeRadioMode unavailable: yellow border around the button group with a tooltip explaining the failure; selection reverts to the radio's actual mode (from the radio_mode capability value / system status broadcast).
- writeRadioMode + readRadioMode both unavailable: deselect all buttons since the actual mode is unknown; keep the yellow border.
- writeRadioMode available: normal state, border cleared.

Retrying while in the warning state re-routes through applyOperatingState (current frequency + mode) instead of setVoiceRadioMode, bypassing the setMode short-circuit so a successful write can recover the capability and clear the border.

Backend: POST /radio/frequency now returns the pre-request radioMode (and a frequency-only message) when the mode write fails, so the caller can revert the selection from the response.