### PR TITLE
refactor: transactional transmission lifecycle and persistent radio sessions

### DIFF
--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -1,1955 +1,634 @@
-# TX-5DR 插件系统开发指南
+# TX-5DR Plugin API v2 开发指南
 
-> 面向读者：希望为 TX-5DR 编写插件或对插件系统进行二次开发的开发者
+本文面向 TX-5DR 插件作者，说明公开 API 的正确用法。类型定义以
+`@tx5dr/plugin-api` 为准；不要从 `@tx5dr/contracts` 或 server 内部目录导入实现。
 
----
+## 1. 快速开始
 
-## 目录
+### 1.1 创建项目
 
-1. [产品概述](#1-产品概述)
-2. [核心概念](#2-核心概念)
-3. [插件结构规范](#3-插件结构规范)
-4. [完整 API 参考](#4-完整-api-参考)
-   - 4.1 [PluginDefinition](#41-plugindefinition)
-   - 4.2 [PluginContext](#42-plugincontext)
-   - 4.3 [OperatorControl](#43-operatorcontrol)
-   - 4.4 [Hook 分类与语义](#44-hook-分类与语义)
-   - 4.5 [设置系统](#45-设置系统)
-   - 4.6 [QuickActions 与 QuickSettings](#46-quickactions-与-quicksettings)
-   - 4.7 [Panels](#47-panels)
-   - 4.8 [持久化存储](#48-持久化存储)
-   - 4.9 [自定义 UI（iframe 页面与面板）](#49-自定义-uiiframe-页面与面板)
-   - 4.10 [文件存储](#410-文件存储)
-   - 4.11 [日志同步 Provider](#411-日志同步-provider)
-   - 4.12 [宿主设置访问](#412-宿主设置访问)
-   - 4.13 [插件市场](#413-插件市场)
-5. [编写你的第一个插件](#5-编写你的第一个插件)
-   - 5.1 [最简工具插件（JS）](#51-最简工具插件js)
-   - 5.2 [TypeScript 完整项目](#52-typescript-完整项目)
-   - 5.3 [策略插件示例](#53-策略插件示例)
-6. [内置插件参考](#6-内置插件参考)
-7. [插件系统架构](#7-插件系统架构)
-8. [REST API 与 WebSocket 事件](#8-rest-api-与-websocket-事件)
-9. [前端 UI 集成](#9-前端-ui-集成)
-10. [新增内置插件指南](#10-新增内置插件指南)
-11. [代码文件导航](#11-代码文件导航)
+推荐使用脚手架：
 
----
-
-## 1. 产品概述
-
-TX-5DR 的插件系统允许开发者通过编写单个 JavaScript（或 TypeScript）文件来扩展、替换或增强数字电台的自动化通联逻辑，无需修改核心代码。
-
-### 设计目标
-
-| 目标 | 体现 |
-|------|------|
-| **低门槛** | 单个 `.js` 文件即可运行，通过 JSDoc 获得 IDE 补全 |
-| **高上限** | 完整 TypeScript 项目，可实现任意复杂的通联策略 |
-| **高自由** | 策略插件可完全替换内置 QSO 决策逻辑 |
-| **清晰直观** | 声明式 settings/quickActions/panels，UI 自动生成 |
-| **IDE 友好** | `@tx5dr/plugin-api` 提供统一的公共开发接口与自动补全 |
-
-### 什么时候需要插件？
-
-- **偏好筛选**：只回复特定前缀或 DXCC 的电台
-- **自动唤醒**：监听到目标电台时自动开始发射
-- **定时任务**：每隔 N 分钟切换波段（Band Hopping）
-- **竞赛模式**：完全替换 QSO 流程以适配特定竞赛规则
-- **数据展示**：实时统计并在面板中展示通联数据
-- **外部集成**：查询 DX Cluster、上传日志到外部服务
-
----
-
-## 2. 核心概念
-
-### 插件类型
-
-#### 策略插件（`type: 'strategy'`）
-
-- **每个操作员只能选择一个活跃策略**（互斥）
-- 通过 `createStrategyRuntime(ctx)` 显式创建 `StrategyRuntime`
-- 活跃策略运行时直接决定 QSO 状态机、槽位内容、上下文和发射文本
-- 内置的 `standard-qso` 就是一个策略插件
-
-#### 工具插件（`type: 'utility'`）
-
-- **可以多个同时激活**（叠加）
-- 通过 Pipeline Hooks 过滤/评分候选目标
-- 通过 Broadcast Hooks 监听事件并做旁路处理
-- 不干预核心决策流程，只辅助增强
-
-### 操作员维度
-
-每个操作员（Operator）都有**独立的插件实例**。一个应用可以同时运行多个操作员（不同呼号/频率），每个操作员独立持有自己的 operator-scope 配置。
-
-- `PluginManager` 会为每个操作员创建一套插件实例
-- 对于策略插件，运行时对象也会按操作员维度创建
-- 但真正参与自动化决策和发射流程的，始终只有当前选中的那一个活跃策略
-
-### 实例作用域
-
-- **`instanceScope: 'operator'`**（默认）：为每个操作员分别创建一个实例
-- **`instanceScope: 'global'`**：整个应用只创建一个共享实例（仅 utility 支持）
-
-`global` 实例的设计目标，是承载"全局资源 + 按呼号分发"的插件，例如日志同步 Provider。此类插件通常需要：
-
-- 共享一份证书、登录态或远端客户端
-- 面向多个操作员/多个呼号工作
-- 通过 `ctx.logbook.forCallsign(callsign)` 显式访问目标日志本
-
-`global` 实例当前只支持 `utility` 插件，并受到以下约束：
-
-- 不能声明 operator-scope `settings`
-- 不能声明 `quickSettings`
-- 不能声明 operator 面板 `panels`
-- 不能实现依赖单个操作员运行时语义的 hooks（如 `onDecode`、`onQSOComplete`、`onAutoCallCandidate` 等）
-
-### 设置作用域
-
-- **`global` scope**：所有操作员共享，在"插件设置"全局面板中显示（如 API Key、黑名单）
-- **`operator` scope**：每个操作员独立，在操作员配置面板中显示（如 autoReplyToCQ）
-
----
-
-## 3. 插件结构规范
-
-### 用户插件目录
-
-用户插件始终放置在应用数据目录下的 `plugins/` 子目录中：
-
-```
-{dataDir}/plugins/
-└── my-plugin/
-    ├── plugin.js        # 主入口（ESM），或 index.js
-    ├── locales/         # 可选：插件自带的 i18n 翻译
-    │   ├── zh.json
-    │   └── en.json
-    └── README.md        # 可选：说明文档
+```bash
+npx create-tx5dr-plugin my-plugin
+npx create-tx5dr-plugin my-strategy --type strategy
+npx create-tx5dr-plugin my-panel --template ui-react
 ```
 
-> **常见目录位置**：
-> - Electron / macOS：`~/Library/Application Support/TX-5DR/plugins`
-> - Electron / Windows：`%LOCALAPPDATA%\TX-5DR\plugins`
-> - Linux（桌面 / 开发环境）：`~/.local/share/TX-5DR/plugins`
-> - Linux server 包：`/var/lib/tx5dr/plugins`
-> - Docker 容器内：`/app/data/plugins`
+也可以在现有 ESM 项目中安装 API：
 
-### 内置插件目录
-
-内置插件与用户插件遵循**相同的目录结构**，位于独立包 `packages/builtin-plugins/src/`：
-
-```
-packages/builtin-plugins/src/
-├── standard-qso/           # 策略插件：标准 QSO 流程
-├── snr-filter/             # 工具插件：SNR 过滤
-├── no-reply-memory-filter/ # 工具插件：无回复记忆过滤
-├── callsign-filter/        # 工具插件：呼号过滤
-├── worked-station-bias/    # 工具插件：已通联偏置评分
-├── watched-callsign-autocall/  # 工具插件：守候呼号自动起呼
-├── watched-novelty-autocall/   # 工具插件：守候新类型自动起呼
-├── autocall-idle-frequency/    # 工具插件：自动起呼择频
-├── lotw-sync/              # 工具插件：LoTW 日志同步
-├── qrz-sync/               # 工具插件：QRZ 日志同步
-├── wavelog-sync/           # 工具插件：WaveLog 日志同步
-└── qso-udp-broadcast/      # 工具插件：QSO UDP 广播
+```bash
+npm install --save-dev @tx5dr/plugin-api@^2
 ```
 
-内置插件的翻译通过 `import ... with { type: 'json' }` 编译进 bundle，无运行时 I/O。
+编译结果放在一个独立插件目录中。Host 按以下顺序查找入口：
+`plugin.js`、`plugin.mjs`、`index.js`、`index.mjs`。
 
-每个插件目录下的结构示例：
-
-```
-standard-qso/
-├── index.ts                # 导出 PluginDefinition + locales + 命名常量
-├── StandardQSOPluginRuntime.ts  # 策略运行时（仅策略插件）
-└── locales/
-    ├── zh.json
-    └── en.json
-```
-
-带自定义 UI 的插件：
-
-```
-lotw-sync/
-├── index.ts
-├── provider.ts             # LogbookSyncProvider 实现
+```text
+my-plugin/
+├── plugin.js
 ├── locales/
 │   ├── zh.json
 │   └── en.json
-└── ui/                     # iframe 页面静态资源
-    ├── settings.html
-    ├── settings.css
-    ├── settings.js
-    └── download-wizard.html
+└── ui/                 # 可选：iframe 页面静态资源
 ```
 
-### 插件入口规范
+### 1.2 最小 utility 插件
 
-插件入口文件必须是 **ESM 格式**，默认导出一个 `PluginDefinition` 对象：
+```ts
+import { definePlugin } from '@tx5dr/plugin-api';
 
-```js
-// plugin.js
-export default {
-  name: 'my-plugin',
+export default definePlugin({
+  apiVersion: 2,
+  name: 'decode-observer',
   version: '1.0.0',
   type: 'utility',
-  // ...
-};
+  permissions: [],
+
+  hooks: {
+    onDecode(messages, ctx) {
+      ctx.log.debug('Decoded messages', { count: messages.length });
+    },
+  },
+});
 ```
 
-系统会按以下顺序查找入口文件：`plugin.js` → `plugin.mjs` → `index.js` → `index.mjs`
+始终使用 `definePlugin()`。它会保留 `permissions` 的字面量类型，使 TypeScript
+只提供已经声明的 capability；不要把定义或回调手动扩宽成宽泛的
+`PluginDefinition` 或 `PluginContext`。
 
-### i18n 翻译规范
+所有新插件都应写 `apiVersion: 2`。strategy 插件，以及请求
+`operator:transmit-control`、`radio:control`、`radio:tuner-control`、
+`radio:power`、`logbook:write` 或 `logbook:sync` 的 utility 插件必须使用 v2，
+否则 Host 会以 `PLUGIN_API_INCOMPATIBLE` 拒绝加载。
 
-插件的 `settings[key].label` 字段是 i18n key，前端会从插件自带的翻译命名空间（`plugin:{pluginName}`）中查找对应文本。
+## 2. 插件类型与实例作用域
 
-```json
-// locales/zh.json
-{
-  "minSNR": "最低信噪比 (dB)",
-  "myToggle": "启用某功能"
-}
-```
+### 2.1 插件类型
 
-```js
-// plugin.js
-settings: {
-  minSNR: { type: 'number', default: -15, label: 'minSNR', scope: 'global' }
-}
-```
+| 类型 | 用途 | 发射相关规则 |
+|---|---|---|
+| `strategy` | 每个操作员选择一个 QSO 自动化策略 | 通过 `StrategyRuntime.decide()` 返回声明式发射决策 |
+| `utility` | 过滤、评分、监控、同步、UI 和外部集成 | 默认不能发射；需要高层操作员命令时声明 `operator:transmit-control` |
 
-若翻译文件中找不到 key，直接显示 label 原文作为 fallback。
+`type: 'strategy'` 与 `apiVersion: 2` 已经是 strategy 的声明式发射授权。
+strategy 不需要 `operator:transmit-control`，也不会获得
+`ctx.operatorCommands`。
 
----
+### 2.2 实例作用域
 
-## 4. 完整 API 参考
+- `instanceScope: 'operator'`：默认值，每个操作员一个实例。
+- `instanceScope: 'global'`：整个 Host 一个实例，仅支持 utility。
 
-> **获取类型支持**：`npm install --save-dev @tx5dr/plugin-api`
->
-> 对于独立插件项目，`@tx5dr/plugin-api` 是唯一的公共开发入口。
-> 请优先从这里导入插件定义、上下文、消息类型与常用枚举，而不要直接依赖 `@tx5dr/contracts`。
+global utility 适合站级同步服务和共享资源。它不能声明 operator-scope setting、
+`quickSettings`、操作员面板或操作员相关 hook；需要访问特定日志本时使用
+`ctx.logbook.forCallsign(callsign)`。`operator:transmit-control` 只允许 operator scope。
 
-### 4.1 PluginDefinition
+## 3. PluginDefinition
 
-插件的顶层定义对象，即 `export default` 的内容。
+插件入口默认导出 `definePlugin({...})`。常用字段如下：
 
-```typescript
-interface PluginDefinition {
-  /** 插件唯一标识符，全局不可重复 */
-  name: string;
+| 字段 | 说明 |
+|---|---|
+| `apiVersion` | 新插件使用 `2` |
+| `name` | 稳定且唯一的插件 ID；发布后不要更改 |
+| `version` | 插件版本 |
+| `type` | `strategy` 或 `utility` |
+| `instanceScope` | `operator`（默认）或 `global` |
+| `description` | 插件管理页中的简短说明或翻译 key |
+| `permissions` | 所需 capability 的最小集合 |
+| `settings` | Host 生成表单并持久化的设置定义 |
+| `quickActions` | 一次性操作按钮，触发 `hooks.onUserAction` |
+| `quickSettings` | 暴露到快捷区的 operator-scope setting |
+| `panels` | Host 渲染的声明式或 iframe 面板 |
+| `storage` | 声明 `global` / `operator` 持久存储 scope |
+| `ui` | 自定义 iframe 页面 |
+| `onLoad` | 实例加载后的初始化 |
+| `onUnload` | 实例卸载前的清理 |
+| `hooks` | Host 事件和 pipeline hook |
+| `createStrategyRuntime` | strategy 必填，utility 禁止提供 |
 
-  /** 语义化版本号，如 "1.0.0" */
-  version: string;
+Host 会校验并冻结加载后的定义。不要在运行期修改 definition、permissions、hooks
+或 UI descriptor。
 
-  /** 插件类型：策略（互斥）或工具（叠加） */
-  type: 'strategy' | 'utility';
+## 4. Context 与 capability
 
-  /**
-   * 插件实例作用域
-   * - 'operator'：每个操作员一个实例（默认）
-   * - 'global'：整个应用共享一个实例（仅 utility 支持）
-   */
-  instanceScope?: 'operator' | 'global';
+### 4.1 基础 context
 
-  /** 可选：人类可读的描述 */
-  description?: string;
+每次正常 invocation 的 `ctx` 都包含：
 
-  /** 可选：作者名 */
-  author?: string;
+| 属性 | 用途 |
+|---|---|
+| `config` / `updateConfig()` | 读取或更新当前插件设置 |
+| `store` | 插件私有的 `global` / `operator` KV 存储 |
+| `log` | 结构化日志 |
+| `timers` | Host 管理的命名 timer |
+| `operator` | 当前操作员的只读快照和查询 |
+| `radio` | 频率、波段、模式、连接状态的只读快照 |
+| `band` | 当前解码环境和自动目标辅助查询 |
+| `ui` | panel 数据和 iframe 通信 |
+| `files` | 插件私有文件存储 |
 
-  /** 可选：所需权限声明 */
-  permissions?: (
-    | 'network'
-    | 'host:hamlib'
-    | 'radio:read' | 'radio:control' | 'radio:power'
-    | 'settings:ft8' | 'settings:decode-windows' | 'settings:realtime'
-    | 'settings:frequency-presets' | 'settings:station'
-    | 'settings:psk-reporter' | 'settings:ntp'
-  )[];
+### 4.2 permission 映射
 
-  /**
-   * 声明式设置项
-   * 键名为 setting key，前端自动渲染对应的 UI 控件
-   */
-  settings?: Record<string, PluginSettingDescriptor>;
+未声明 permission 时，对应属性在 TypeScript 类型和运行时对象中都不存在。
 
-  /**
-   * 快捷操作按钮
-   * 出现在操作员面板的自动化下拉区域，点击触发 hooks.onUserAction
-   */
-  quickActions?: PluginQuickAction[];
+| permission | 获得的 context capability |
+|---|---|
+| `operator:transmit-control` | `operatorCommands` |
+| `radio:read` | `radioCapabilities`、只读 `radioPower` |
+| `radio:control` | `radioCommands` |
+| `radio:tuner-control` | `radioTunerCommands` |
+| `radio:power` | `radioPowerCommands` |
+| `logbook:read` | 只读 `logbook` |
+| `logbook:write` | 可 durable 写入的 `logbook` |
+| `logbook:sync` | `logbookSync` Provider 注册入口 |
+| `settings:ft8` | `settings.ft8` |
+| `settings:decode-windows` | `settings.decodeWindows` |
+| `settings:realtime` | `settings.realtime` |
+| `settings:frequency-presets` | `settings.frequencyPresets` |
+| `settings:station` | `settings.station` |
+| `settings:psk-reporter` | `settings.pskReporter` |
+| `settings:ntp` | `settings.ntp` |
+| `network` | `network`（含 UDP）和受控 `fetch` |
+| `plugin:event-bus` | `eventBus` |
+| `host:hamlib` | `hostDependencies.hamlib` |
 
-  /**
-   * 快捷设置
-   * 引用 operator-scope setting，在自动化面板中渲染为紧凑控件
-   */
-  quickSettings?: PluginQuickSetting[];
+这些 capability 是 Host 仲裁后的公开端口。它们不暴露 raw PTT、音频播放器、
+Mixer、Encoder、physical lease 或全局紧急停止。
 
-  /**
-   * 数据展示面板
-   * 出现在操作员面板下方，通过 ctx.ui.send() 推送数据
-   */
-  panels?: PluginPanelDescriptor[];
+### 4.3 utility 的操作员命令
 
-  /** 声明需要哪些存储作用域 */
-  storage?: { scopes: ('global' | 'operator')[] };
+需要影响操作员自动化的 utility 必须：
 
-  /**
-   * 自定义 UI 页面声明
-   */
-  ui?: {
-    /** 静态资源目录（相对于插件根目录，默认 'ui'） */
-    dir?: string;
-    /** 注册的页面列表 */
-    pages?: PluginUIPageDescriptor[];
-  };
+1. 声明 `operator:transmit-control`；
+2. 使用 operator scope；
+3. 实现 `isTransmitControlEnabled(ctx)` 或 `isAutoCallEnabled(ctx)`；
+4. 只通过 `ctx.operatorCommands.submit(...)` 提交高层命令。
 
-  /**
-   * 策略运行时工厂
-   * type='strategy' 时必填；type='utility' 时不得提供
-   */
-  createStrategyRuntime?(ctx: PluginContext): StrategyRuntime;
+可提交的命令形状：
 
-  /** 插件实例加载时调用 */
-  onLoad?(ctx: PluginContext): void | Promise<void>;
-
-  /** 插件实例卸载时调用，定时器自动清理 */
-  onUnload?(ctx: PluginContext): void | Promise<void>;
-
-  /** Hook 实现 */
-  hooks?: PluginHooks;
-}
-```
-
-权限说明：
-
-| 权限 | 授予能力 |
-|------|---------|
-| `network` | `ctx.fetch()` HTTP 请求 |
-| `host:hamlib` | `ctx.hostDependencies.hamlib` 宿主 Hamlib Rotator 依赖 |
-| `radio:read` | `ctx.radio.capabilities.getSnapshot()` / `getState()` / `refresh()` |
-| `radio:control` | `ctx.radio.capabilities.write()` |
-| `radio:power` | `ctx.radio.power.*` |
-| `settings:ft8` | `ctx.settings.ft8` |
-| `settings:decode-windows` | `ctx.settings.decodeWindows` |
-| `settings:realtime` | `ctx.settings.realtime` |
-| `settings:frequency-presets` | `ctx.settings.frequencyPresets` |
-| `settings:station` | `ctx.settings.station` |
-| `settings:psk-reporter` | `ctx.settings.pskReporter` |
-| `settings:ntp` | `ctx.settings.ntp` |
-
-### 4.2 PluginContext
-
-运行时注入的上下文对象，是插件与系统交互的唯一入口。
-
-```typescript
-interface PluginContext {
-  /** 当前生效的设置值（global + operator 合并，只读） */
-  readonly config: Readonly<Record<string, unknown>>;
-
-  /**
-   * 更新本插件实例的设置（自更新）
-   * 浅合并后持久化，触发 onConfigChange，推送前端
-   */
-  updateConfig(patch: Record<string, unknown>): Promise<void>;
-
-  /** 持久化 KV 存储 */
-  readonly store: {
-    readonly global: KVStore;    // 所有操作员共享
-    readonly operator: KVStore;  // 当前实例独占
-  };
-
-  /** 日志接口（输出到系统日志 + 前端日志面板） */
-  readonly log: PluginLogger;
-
-  /** 命名定时器管理 */
-  readonly timers: PluginTimers;
-
-  /** 操作员控制 */
-  readonly operator: OperatorControl;
-
-  /** 物理电台控制 */
-  readonly radio: RadioControl;
-
-  /** 日志本访问（查询/写入/通知） */
-  readonly logbook: LogbookAccess;
-
-  /** 波段/解码数据访问 */
-  readonly band: BandAccess;
-
-  /** 向前端面板推送数据 + 自定义 iframe 页面通信 */
-  readonly ui: UIBridge;
-
-  /** 二进制文件持久化存储 */
-  readonly files: PluginFileStore;
-
-  /** 日志同步 Provider 注册入口 */
-  readonly logbookSync: LogbookSyncRegistrar;
-
-  /**
-   * 宿主设置访问（权限门控）
-   * 每个命名空间需要对应的 settings:* 权限
-   */
-  readonly settings: HostSettingsControl;
-
-  /**
-   * 插件间通信 Event Bus（权限门控）
-   * 仅声明 permissions: ['plugin:event-bus'] 后可用，否则为 undefined
-   */
-  readonly eventBus?: PluginEventBus;
-
-  /**
-   * 宿主进程持有的运行时依赖。每个依赖都需要独立权限并且可能为 undefined。
-   */
-  readonly hostDependencies: HostDependencies;
-
-  /**
-   * 受控 HTTP fetch
-   * 仅声明 permissions: ['network'] 后可用，否则为 undefined
-   */
-  readonly fetch?: (url: string, init?: RequestInit) => Promise<Response>;
-}
-```
-
-#### PluginEventBus
-
-`ctx.eventBus` 为插件提供同一宿主进程内的轻量级插件间通信能力。该能力需要 manifest 声明 `permissions: ['plugin:event-bus']`；未声明权限时 `ctx.eventBus` 为 `undefined`。
-
-接口定义：
-
-```typescript
-interface PluginEventBus {
-  /** 向指定 topic 的所有当前订阅者发送消息（fire-and-forget） */
-  publish(topic: string, payload?: unknown): void;
-  /** 订阅指定 topic，返回取消订阅函数 */
-  subscribe(
-    topic: string,
-    handler: (message: PluginEventBusMessage) => void | Promise<void>,
-  ): () => void;
-}
-
-interface PluginEventBusMessage {
-  topic: string;       // 消息发布到的 topic
-  payload: unknown;    // 发布者设置的任意数据
-  timestamp: number;   // 宿主分发消息时的 epoch 毫秒时间戳
-  publisher: {
-    pluginName: string;                       // 发布插件的名称
-    instanceScope: 'operator' | 'global';     // 发布者是全局实例还是操作员实例
-    operatorId?: string;                      // 操作员实例时为其 ID
-  };
-}
-```
-
-##### 行为说明
-
-- topic 为**精确匹配**的字符串，不支持 wildcard / pattern
-- `publish()` 不等待订阅方完成（fire-and-forget）
-- 同一 handler 函数实例不会被重复添加；不同闭包（即使逻辑相同）视为不同订阅
-- 订阅回调抛错（同步或异步）不会让发布方抛错；宿主会记录运行时日志
-- 插件卸载、重载、关闭时，宿主会自动清理该实例的所有订阅
-- 手动取消单个订阅：调用 `subscribe()` 返回的函数
-
-##### Topic 命名约定
-
-使用**点分隔、插件名前缀**的命名方式，避免不同插件间的 topic 冲突：
-
-```
-<插件名>.<领域>.<事件>
+```ts
+type PluginOperatorCommand =
+  | { type: 'start-automation' }
+  | { type: 'stop-automation' }
+  | { type: 'request-call'; callsign: string; lastMessage?: LastMessageInfo }
+  | {
+      type: 'reply-to-decode';
+      callsign: string;
+      lastMessage: LastMessageInfo;
+      modifiers?: number;
+    }
+  | { type: 'set-transmit-cycles'; cycles: number | number[] }
+  | { type: 'remove-contribution' }
+  | { type: 'clear-decodes'; window?: number }
+  | { type: 'set-free-text'; text: string }
+  | { type: 'send-free-text'; text?: string }
+  | { type: 'set-temporary-location'; location: string }
+  | {
+      type: 'highlight-callsign';
+      callsign: string;
+      background?: string | null;
+      foreground?: string | null;
+      lastOnly?: boolean;
+    };
 ```
 
 示例：
 
-| Topic | 含义 |
-|-------|------|
-| `psk-reporter.spot.sent` | 一条 spot 已上传到 PSK Reporter |
-| `callsign-filter.match.found` | 呼号匹配了过滤规则 |
-| `logbook-sync.upload.complete` | 日志同步上传完成 |
-
-避免使用 `update`、`message` 等过于通用的名称。
-
-##### 基本用法
-
-```typescript
-// 发布方插件
-ctx.eventBus?.publish('callsign-filter.match.found', {
-  callsign: 'JA1ABC',
-  band: '20m',
-});
-
-// 订阅方插件
-const unsubscribe = ctx.eventBus?.subscribe('callsign-filter.match.found', (message) => {
-  const { callsign, band } = message.payload as { callsign: string; band: string };
-  ctx.log.info('received match', { callsign, band });
-});
-```
-
-##### 跨操作员通信
-
-操作员作用域的插件可以通过 Event Bus 与同一宿主上的其他操作员通信。`publisher` 元数据让订阅者识别消息来源：
-
-```typescript
-ctx.eventBus?.subscribe('qso-monitor.qso-complete', (message) => {
-  const { callsign, band } = message.payload as { callsign: string; band: string };
-  ctx.log.info('other operator completed QSO', {
-    operator: message.publisher.operatorId,
-    callsign,
-    band,
-  });
-});
-```
-
-##### 测试
-
-使用 `@tx5dr/plugin-api/testing` 中的 `createMockEventBus()` 进行单元测试：
-
-```typescript
-import { describe, it, expect, vi } from 'vitest';
-import { createMockEventBus } from '@tx5dr/plugin-api/testing';
-
-it('发布 spot 数据', () => {
-  // 可选：自定义发布者元数据
-  const bus = createMockEventBus({ owner: { pluginName: 'spot-monitor' } });
-  const handler = vi.fn();
-
-  bus.subscribe('spot-monitor.new-spot', handler);
-  bus.publish('spot-monitor.new-spot', { callsign: 'W1AW', frequency: 14074000 });
-
-  expect(handler).toHaveBeenCalledTimes(1);
-  expect(handler).toHaveBeenCalledWith(expect.objectContaining({
-    topic: 'spot-monitor.new-spot',
-    payload: { callsign: 'W1AW', frequency: 14074000 },
-    publisher: expect.objectContaining({ pluginName: 'spot-monitor' }),
-  }));
-});
-
-it('跟踪已发布消息', () => {
-  const bus = createMockEventBus();
-
-  bus.publish('topic-a', { value: 1 });
-  bus.publish('topic-b', { value: 2 });
-
-  // _published 记录所有已发布消息
-  expect(bus._published).toHaveLength(2);
-  expect(bus._published[0].topic).toBe('topic-a');
-});
-
-it('取消订阅后不再接收消息', () => {
-  const bus = createMockEventBus();
-  const handler = vi.fn();
-
-  const unsub = bus.subscribe('topic', handler);
-  bus.publish('topic', 'first');
-  unsub();
-  bus.publish('topic', 'second');
-
-  expect(handler).toHaveBeenCalledTimes(1);
-});
-```
-
-Mock 对象说明：
-
-| 属性/方法 | 说明 |
-|-----------|------|
-| `_published` | 所有已发布消息的数组，用于断言 |
-| `_subscriptions` | 内部 topic → handler 映射，用于高级检查 |
-| `publish()` | 记录消息到 `_published` 并同步分发给订阅者 |
-| `subscribe()` | 返回取消订阅函数 |
-
-
-#### HostDependencies
-
-`ctx.hostDependencies` 暴露由 TX-5DR 宿主进程加载和持有的 native/runtime 依赖。每个依赖都需要独立权限；未声明权限时对应字段为 `undefined`。插件目录位于宿主包树之外，直接 `import('hamlib')` 在生产安装、Electron 打包、开发软链接等场景下都可能解析失败；因此需要通过宿主上下文拿到同一个依赖实例。
-
-`ctx.hostDependencies.hamlib` 需要 manifest 声明 `permissions: ['host:hamlib']`。该权限允许插件直接打开 Hamlib Rotator 的串口或网络连接，应只授予可信插件；`radio:read` / `radio:control` / `radio:power` 不会自动授予该能力。
-
-当前暴露：
-
-```typescript
-const hamlib = ctx.hostDependencies.hamlib;
-if (!hamlib) throw new Error('host:hamlib permission is required');
-
-const { Rotator } = hamlib;
-const rotators = Rotator.getSupportedRotators();
-const rotator = new Rotator(rotators[0].rotModel, '127.0.0.1:4533');
-
-await rotator.open();
-await rotator.setPosition(135, 0);
-const position = await rotator.getPosition();
-await rotator.stop();
-await rotator.close();
-```
-
-`ctx.hostDependencies.hamlib` 是宿主的 allow-listed `hamlib` / node-hamlib Rotator 表面，只包含 `Rotator` 与 `PASSBAND`。Rotator API 包含：`getSupportedRotators()`、`open()`、`setPosition()`、`getPosition()`、`move()`、`stop()`、`park()`、`reset()`、`setConf()`、`getConfigSchema()`、`getRotatorCaps()` 等。
-
-#### KVStore
-
-```typescript
-interface KVStore {
-  get<T = unknown>(key: string, defaultValue?: T): T;
-  set(key: string, value: unknown): void;
-  delete(key: string): void;
-  getAll(): Record<string, unknown>;
-  /** 强制 flush 待写入数据到磁盘 */
-  flush(): Promise<void>;
-}
-```
-
-写入操作有 300ms debounce；插件实例卸载或插件子系统关闭时会强制 flush。
-
-#### PluginLogger
-
-```typescript
-interface PluginLogger {
-  debug(message: string, data?: Record<string, unknown>): void;
-  info(message: string, data?: Record<string, unknown>): void;
-  warn(message: string, data?: Record<string, unknown>): void;
-  error(message: string, error?: unknown): void;
-}
-```
-
-日志同时输出到：系统日志文件、前端设置页中的"插件日志"面板。
-
-#### PluginTimers
-
-```typescript
-interface PluginTimers {
-  set(id: string, intervalMs: number): void;
-  clear(id: string): void;
-  clearAll(): void;
-}
-```
-
-定时器触发时调用 `hooks.onTimer(timerId, ctx)`。`clearAll()` 在 `onUnload` 时自动调用。
-
-#### RadioControl
-
-```typescript
-interface RadioControl {
-  readonly frequency: number;
-  readonly band: string;
-  readonly isConnected: boolean;
-  readonly capabilities: RadioCapabilitiesControl;
-  readonly power: RadioPowerControl;
-  setFrequency(freq: number): Promise<void>;
-}
-
-interface RadioCapabilitiesControl {
-  getSnapshot(): CapabilityList;                         // 需 radio:read
-  getState(id: string): CapabilityState | null;          // 需 radio:read
-  refresh(): Promise<CapabilityList>;                    // 需 radio:read
-  write(payload: WriteCapabilityPayload): Promise<void>; // 需 radio:control
-}
-
-interface RadioPowerControl {
-  getSupport(profileId?: string): Promise<RadioPowerSupportInfo>; // 需 radio:read
-  getState(profileId?: string): RadioPowerStateEvent | null;      // 需 radio:read
-  set(state, options?: { profileId?: string; autoEngine?: boolean }): Promise<RadioPowerResponse>; // 需 radio:power
-}
-```
-
-`ctx.radio` 只在服务端插件上下文中可用。`power.set()` 的 `profileId` 缺省为当前 active profile，`autoEngine` 缺省为 `true`。
-
-#### Callsign / DXCC helpers
-
-```typescript
-import { getCallsignInfo, listDXCCEntities, resolveDXCCEntity } from '@tx5dr/plugin-api';
-```
-
-- `resolveDXCCEntity(callsign)` 根据呼号解析 DXCC 实体，返回 `entity.entityCode/name/flag` 等信息
-- `getCallsignInfo(callsign)` 返回更适合显示的呼号国家/地区信息
-- `listDXCCEntities()` 返回当前内置 DXCC 实体列表，适合生成设置项多选选项
-
-#### LogbookAccess
-
-```typescript
-interface LogbookAccess {
-  // 只读查询
-  hasWorked(callsign: string): Promise<boolean>;
-  hasWorkedDXCC(dxccEntity: string): Promise<boolean>;
-  hasWorkedGrid(grid: string): Promise<boolean>;
-
-  // 高级查询
-  queryQSOs(filter: QSOQueryFilter): Promise<QSORecord[]>;
-  countQSOs(filter?: QSOQueryFilter): Promise<number>;
-
-  // 呼号绑定访问器（global 实例用）
-  forCallsign(callsign: string): CallsignLogbookAccess;
-
-  // 写入
-  addQSO(record: QSORecord): Promise<void>;
-  updateQSO(qsoId: string, updates: Partial<QSORecord>): Promise<void>;
-
-  // 通知
-  notifyUpdated(): Promise<void>;
-}
-
-interface CallsignLogbookAccess {
-  readonly callsign: string;
-  getLogBookId(): Promise<string | null>;
-  queryQSOs(filter: QSOQueryFilter): Promise<QSORecord[]>;
-  countQSOs(filter?: QSOQueryFilter): Promise<number>;
-  addQSO(record: QSORecord): Promise<void>;
-  updateQSO(qsoId: string, updates: Partial<QSORecord>): Promise<void>;
-  getStatistics(): Promise<LogBookStatistics | null>;
-  notifyUpdated(operatorId?: string): Promise<void>;
-}
-```
-
-```typescript
-interface QSOQueryFilter {
-  callsign?: string;
-  timeRange?: { start: number; end: number };
-  frequencyRange?: { min: number; max: number };
-  mode?: string;
-  band?: string;
-  qslStatus?: 'confirmed' | 'uploaded' | 'none';
-  limit?: number;
-  offset?: number;
-  orderDirection?: 'asc' | 'desc';
-}
-```
-
-#### BandAccess
-
-```typescript
-interface BandAccess {
-  getActiveCallers(): ParsedFT8Message[];
-  getLatestSlotPack(): SlotPack | null;
-  findIdleTransmitFrequency(options?: IdleTransmitFrequencyOptions): number | null;
-  evaluateAutoTargetEligibility(message: ParsedFT8Message): {
-    eligible: boolean;
-    reason: string;
-    modifier?: string;
-  };
-}
-```
-
-#### UIBridge
-
-```typescript
-interface UIBridge {
-  /** 推送结构化面板数据 */
-  send(panelId: string, data: unknown): void;
-
-  /** 更新面板运行期 meta（标题、可见性等） */
-  setPanelMeta(panelId: string, meta: PanelMeta): void;
-
-  /** 替换一个运行期 UI Contribution group */
-  setPanelContributions(groupId: string, panels: PluginPanelDescriptor[]): void;
-
-  /** 清空一个运行期 UI Contribution group */
-  clearPanelContributions(groupId: string): void;
-
-  /** 注册 iframe 页面消息处理器（每实例一个） */
-  registerPageHandler(handler: PluginUIHandler): void;
-
-  /** 推送到指定 page session */
-  pushToSession(pageSessionId: string, action: string, data?: unknown): void;
-
-  /** 列出当前实例下某 pageId 的活跃 session */
-  listActivePageSessions(pageId: string): PluginUIPageSessionInfo[];
-
-  /** 推送到 iframe 页面（仅当该 pageId 恰好有一个 session 时可用） */
-  pushToPage(pageId: string, action: string, data?: unknown): void;
-}
-
-interface PanelMeta {
-  title?: string | null;
-  titleValues?: Record<string, unknown>;
-  visible?: boolean;
-}
-
-interface PluginUIHandler {
-  onMessage(
-    pageId: string,
-    action: string,
-    data: unknown,
-    requestContext: PluginUIRequestContext,
-  ): Promise<unknown>;
-}
-```
-
-`requestContext` 由宿主基于页面 session 注入，包含：
-
-- `pageSessionId` — 页面 session ID
-- `user` — 当前用户信息（tokenId, role, operatorIds, permissionGrants）
-- `instanceTarget` — 插件实例目标（global 或 operatorId）
-- `resource` — 绑定的资源（如 callsign）
-- `page` — 页面上下文（含 `push()` 快捷方法）
-- `files` — 页面 scope 的文件存储
-
-### 4.3 OperatorControl
-
-```typescript
-interface OperatorControl {
-  readonly id: string;
-  readonly isTransmitting: boolean;
-  readonly callsign: string;
-  readonly grid: string;
-  readonly frequency: number;
-  readonly mode: ModeDescriptor;
-  readonly transmitCycles: number[];
-  /** 当前自动化运行时快照 */
-  readonly automation: StrategyRuntimeSnapshot | null;
-
-  startTransmitting(): void;
-  stopTransmitting(): void;
-  call(callsign: string, lastMessage?: { message: FrameMessage; slotInfo: SlotInfo }): void;
-  setTransmitCycles(cycles: number | number[]): void;
-  hasWorkedCallsign(callsign: string): Promise<boolean>;
-  isTargetBeingWorkedByOthers(targetCallsign: string): boolean;
-  recordQSO(record: QSORecord): void;
-  notifySlotsUpdated(slots: OperatorSlots): void;
-  notifyStateChanged(state: string): void;
-}
-```
-
-### 4.4 Hook 分类与语义
-
-#### Pipeline Hooks（活跃插件链式处理）
-
-链式执行，前一个插件的输出是下一个插件的输入。
-
-| Hook | 参数 | 返回 | 安全网 |
-|------|------|------|--------|
-| `onFilterCandidates` | `candidates: ParsedFT8Message[], ctx` | 过滤后的列表 | 若返回空数组且输入非空，跳过此插件 |
-| `onScoreCandidates` | `candidates: ScoredCandidate[], ctx` | 评分后的列表 | 无 |
-| `onAutoCallCandidate` | `slotInfo, messages, ctx` | `AutoCallProposal \| null` | 多插件按优先级仲裁 |
-| `onConfigureAutoCallExecution` | `request, plan, ctx` | 更新后的 plan | 链式修改执行计划 |
-
-#### Strategy Runtime（仅活跃策略插件）
-
-每个操作员只有一个活跃策略插件。策略插件必须显式创建 `StrategyRuntime`：
-
-| 方法 | 触发时机 | 说明 |
-|------|---------|------|
-| `decide(messages, meta?)` | 每个时隙开始 | 核心决策，返回 `StrategyDecision` |
-| `getTransmitText()` | 编码时机 | 返回要发射的文本，null 表示不发射 |
-| `requestCall(callsign, lastMessage?)` | 用户手动点击呼叫 | 处理用户主动呼叫 |
-| `patchContext(patch)` | 用户修改上下文 | 更新 target/report 等策略上下文 |
-| `setState(state)` | 用户手动切换 TX 状态 | 直接切换策略运行时状态 |
-| `setSlotContent({ slot, content })` | 用户编辑槽位文本 | 直接更新指定槽位文本 |
-| `getSnapshot()` | 服务端同步状态给客户端 | 返回当前状态/槽位/上下文快照 |
-| `reset(reason?)` | 插件重载、策略切换等 | 重置策略运行时 |
-| `onTransmissionQueued?(text)` | 发射内容进入编码队列 | 可选通知 |
-
-`StrategyDecision` 接口：
-
-```typescript
-interface StrategyDecision {
-  stop?: boolean;        // 停止自动化；isReDecision 时还会中断当前发射
-  qsoFailure?: QSOFailureInfo;
-}
-
-interface StrategyDecisionMeta {
-  isReDecision?: boolean; // 是否为晚到解码的重决策
-}
-```
-
-#### Broadcast Hooks（所有活跃插件并发接收）
-
-Fire-and-forget，不阻塞主流程。
-
-| Hook | 签名 | 典型用途 |
-|------|------|---------|
-| `onSlotStart` | `(slotInfo, messages, ctx)` | 定时统计、状态检查 |
-| `onDecode` | `(messages, ctx)` | 监听模式、发现目标自动唤醒 |
-| `onQSOStart` | `(info: { targetCallsign, grid? }, ctx)` | 记录 QSO 开始时间 |
-| `onQSOComplete` | `(record: QSORecord, ctx)` | 统计、推送通知、外部上传 |
-| `onQSOFail` | `(info: QSOFailureInfo, ctx)` | 记录失败原因 |
-| `onTimer` | `(timerId, ctx)` | Band hopping、定时停止 |
-| `onUserAction` | `(actionId, payload, ctx)` | 响应用户点击 QuickAction |
-| `onConfigChange` | `(changes: Record<string, unknown>, ctx)` | 热更新内部状态 |
-
-`onConfigChange` 接收一个 `changes` 对象，只包含本次变更的 key/value。
-
-#### Autocall Proposal Hook
-
-对于"守候型" utility 插件，推荐实现 `onAutoCallCandidate(slotInfo, messages, ctx)`，返回 `AutoCallProposal | null`：
-
-```typescript
-{
-  callsign: string;
-  priority?: number;     // 优先级，越大越优先
-  lastMessage?: { message: FrameMessage; slotInfo: SlotInfo };
-}
-```
-
-- Host 收集所有 proposal 后统一仲裁：`priority` 高者优先 → 命中消息顺序 → 插件名稳定排序
-- 仲裁完成后最多执行一次 `requestCall()`
-- 触发源是 CQ 时，proposal 仍受宿主统一的 directed CQ / modifier 过滤
-
-#### Autocall Execution Hook
-
-proposal 胜出后，Host 串行调用 `onConfigureAutoCallExecution(request, plan, ctx)` 来修改执行计划：
-
-```typescript
-interface AutoCallExecutionRequest {
-  sourcePluginName: string;
-  callsign: string;
-  slotInfo: SlotInfo;
-  sourceSlotInfo?: SlotInfo;
-  lastMessage?: LastMessageInfo;
-}
-
-interface AutoCallExecutionPlan {
-  audioFrequency?: number;
-}
-```
-
-### 4.5 设置系统
-
-#### PluginSettingDescriptor
-
-```typescript
-interface PluginSettingDescriptor {
-  type: 'boolean' | 'number' | 'string' | 'string[]' | 'object[]' | 'keyedStringArrays' | 'info';
-  default: unknown;
-  label: string;         // i18n key
-  description?: string;
-  scope?: 'global' | 'operator';  // 默认 'global'
-  min?: number;
-  max?: number;
-  options?: Array<{ label: string; value: string }>;
-  /** 根据同一表单中的其它设置决定是否显示 */
-  visibleWhen?: PluginSettingCondition;
-  /** 根据同一表单中的其它设置切换说明文案 */
-  descriptionWhen?: Array<{
-    when: PluginSettingCondition;
-    description: string;
-  }>;
-  /** type='object[]' 时用于生成编辑器字段 */
-  itemFields?: Array<{
-    key: string;
-    type?: 'string' | 'number' | 'boolean';
-    label: string;
-    description?: string;
-    placeholder?: string;
-    required?: boolean;
-  }>;
-  /** type='keyedStringArrays' 时用于生成固定键多行列表 */
-  keys?: Array<{ key: string; label: string; description?: string }>;
-  /** 隐藏设置（持久化但不显示在 UI） */
-  hidden?: boolean;
-}
-
-type PluginSettingCondition = {
-  setting?: string;
-  equals?: unknown;
-  notEquals?: unknown;
-  allOf?: PluginSettingCondition[];
-  anyOf?: PluginSettingCondition[];
-};
-```
-
-- `info` 类型是纯展示节点，不参与持久化和脏数据比较
-- `hidden` 设置仍然持久化和注入 `ctx.config`，只是不在生成的 UI 中显示
-- `object[]` 适合简单的全局共享列表；复杂交互建议用 iframe 设置页面
-- `string[]` 带 `options` 时渲染为可搜索多选；不带 `options` 时仍是多行文本
-- `keyedStringArrays` 适合固定分类下的字符串数组配置，例如“每个波段一组规则”；带 `options` 时每个固定键渲染为可搜索多选，不带 `options` 时每个固定键渲染为多行文本
-- `visibleWhen` / `descriptionWhen` 只依赖同一表单中的当前设置值，适合轻量条件显示，不应承载复杂业务逻辑
-- 条件旧写法 `{ setting, equals, notEquals }` 继续有效；需要多个条件时用 `{ allOf: [...] }` 或 `{ anyOf: [...] }`
-
-#### ctx.config 的合并规则
-
-```
-最终值 = operator-scope 配置 覆盖 global-scope 配置 覆盖 defaults
-```
-
-同一个 key 不能同时是 global 和 operator scope。`info` 和 `hidden` 类型不参与上述合并中的 scope 覆盖逻辑。
-
-#### 持久化位置
-
-- **Global settings**：`config.plugins.configs[pluginName].settings`（在 `config.json` 中）
-- **Operator settings**：`config.plugins.operatorSettings[operatorId][pluginName]`（在 `config.json` 中）
-
-#### 配置自更新
-
-插件可通过 `ctx.updateConfig(patch)` 修改自身设置：
-
-```typescript
-await ctx.updateConfig({ lastSyncTime: Date.now() });
-```
-
-此时会走完整的 validate → persist → onConfigChange → 推送前端流程。
-
-### 4.6 QuickActions 与 QuickSettings
-
-#### QuickActions
-
-QuickActions 出现在操作员面板右上角的自动化下拉面板中，点击触发 `hooks.onUserAction`。
-
-```typescript
-interface PluginQuickAction {
-  id: string;
-  label: string;  // i18n key 或直接文本
-  icon?: string;  // 图标名
-}
-```
-
-#### QuickSettings
-
-QuickSettings 引用一个 operator-scope setting，在自动化面板中渲染为紧凑的开关控件。
-
-```typescript
-interface PluginQuickSetting {
-  settingKey: string;  // 必须是 operator-scope boolean setting
-}
-```
-
-**工作原理**：
-1. 前端读取 `operatorSettings[pluginName][settingKey]` 决定开关状态
-2. 用户切换后直接更新对应 operator-scope setting
-3. 服务端触发 `onConfigChange`，`ctx.config` 动态反映新值
-
-**与 QuickAction 的区别**：
-- QuickAction（button）：点击 → `hooks.onUserAction`
-- QuickSetting（toggle）：切换 → 更新 setting → `onConfigChange`
-
-### 4.7 Panels
-
-```typescript
-interface PluginPanelDescriptor {
-  id: string;
-  title: string;  // i18n key 或直接文本
-  component: 'table' | 'key-value' | 'chart' | 'log' | 'iframe';
-  /** 仅 component='iframe' 时需要，引用 ui.pages 中的页面 id */
-  pageId?: string;
-  /** 可选字符串参数，传入 iframe */
-  params?: Record<string, string>;
-  /** 渲染位置，默认 'operator' */
-  slot?: 'operator' | 'automation' | 'main-right' | 'voice-left-top' | 'voice-right-top' | 'cw-left-top' | 'cw-right-top' | 'radio-control-toolbar';
-  /** 宽度偏好，默认 'half' */
-  width?: 'half' | 'full';
-  /** 工具栏类入口的 FontAwesome Free 图标名，如 'satellite-dish' 或 'brands:github' */
-  icon?: string;
-  /** 工具栏类入口的打开方式 */
-  openMode?: 'popover' | 'modal';
-  /** 工具栏类入口的尺寸提示 */
-  uiSize?: 'sm' | 'md' | 'lg';
-}
-```
-
-#### 数据格式
-
-| component | 期望的 data 格式 |
-|-----------|--------------|
-| `key-value` | `{ [key: string]: string \| number }` |
-| `table` | `Array<Record<string, unknown>>` |
-| `log` | `string[]` |
-| `chart` | 自定义（JSON 格式原样显示） |
-| `iframe` | 不需要 `ctx.ui.send()` 推送，iframe 通过 Bridge SDK 通信 |
-
-#### 数据推送
-
-```typescript
-ctx.ui.send('panel-id', { '总通联': 42, '今日': 5 });
-```
-
-数据通过 WebSocket `pluginData` 事件实时推送。
-
-#### 运行期 UI Contribution
-
-`PluginDefinition.panels` 是静态面板声明。运行时动态增减面板使用：
-
-```typescript
-ctx.ui.setPanelContributions('my-group', [
-  { id: 'tab-1', title: 'Tab 1', component: 'iframe', pageId: 'my-page', slot: 'voice-right-top' },
-]);
-
-ctx.ui.clearPanelContributions('my-group');
-```
-
-`groupId` 不能使用保留的 `manifest`。`setPanelContributions` 是替换整个 group 的语义。
-
-#### RadioControl 工具栏 iframe 入口
-
-`slot: 'radio-control-toolbar'` 可把插件 iframe 页面扩展到 RadioControl 顶部的一排小按钮中。该入口仅支持 `type: 'utility'` 且 `instanceScope: 'global'` 的插件，且引用的页面必须使用 `resourceBinding: 'none'`。
-
-```typescript
-export default {
-  name: 'rotator-control',
-  version: '0.1.0',
+```ts
+export default definePlugin({
+  apiVersion: 2,
+  name: 'remote-call-integration',
+  version: '1.0.0',
   type: 'utility',
-  instanceScope: 'global',
-  permissions: ['host:hamlib'],
-  ui: {
-    pages: [{
-      id: 'rotator',
-      title: 'Rotator',
-      entry: 'rotator.html',
-      accessScope: 'operator',
-      resourceBinding: 'none',
-    }],
+  permissions: ['operator:transmit-control'],
+
+  isTransmitControlEnabled: (ctx) => ctx.config.enabled === true,
+
+  hooks: {
+    async onUserAction(actionId, payload, ctx) {
+      if (actionId !== 'call') return;
+      const { callsign } = payload as { callsign: string };
+      const result = await ctx.operatorCommands.submit({
+        type: 'request-call',
+        callsign,
+      });
+      ctx.log.info('Call command settled', {
+        epoch: result.epoch,
+        outcome: result.outcome,
+      });
+    },
   },
-  panels: [{
-    id: 'rotator-button',
-    title: 'rotatorTitle',
-    component: 'iframe',
-    pageId: 'rotator',
-    slot: 'radio-control-toolbar',
-    icon: 'satellite-dish',
-    openMode: 'popover',
-    uiSize: 'md',
-  }],
-};
+});
 ```
 
-图标支持当前前端已安装的 FontAwesome Free solid 和 brands 图标。默认按 solid 查找；brands 图标使用 `brands:` 前缀，例如 `brands:github`。找不到图标时前端会回退到 `puzzle-piece`。该入口不会自动传入 `operatorId`，iframe 收到的默认参数为 `{ panelId, ...panel.params }`。
+`isAutoCallEnabled(ctx)` 只用于真正会自主起呼的插件。它会让插件进入操作员卡片的
+自动起呼状态和暂停控制。QSO UDP 广播、遥控桥等外部集成即使需要命令权限，也应
+只实现 `isTransmitControlEnabled(ctx)`，不要实现 `isAutoCallEnabled(ctx)`。
 
-### 4.8 持久化存储
+### 4.4 电台、日志本与网络
 
-```typescript
-// global scope
-ctx.store.global.set('blacklist', ['BG5DRB', 'BG5CAM']);
-const blacklist = ctx.store.global.get<string[]>('blacklist', []);
+- `radioCommands` 接受 Host 仲裁的 `set-frequency` 和 `switch-band`；后者可用
+  `autoTune: true` 在同一物理空闲事务中完成切频与调谐。
+- `radioTunerCommands` 只接受 `set-enabled` 和 `start-manual-tune`。这些写操作都会在
+  Digital、Voice、CW、Tune 或人工 PTT 占用时拒绝，不会中断正在发射的帧。
+- `radioPowerCommands` 只接受 `set-power`。
+- `logbook:write` 的 Promise 在 Host 完成 durable commit 后才成功。
+- `logbook:sync` 用于注册 `LogbookSyncProvider`，不要自行模拟 Host 同步状态。
+- `network` 提供受控 HTTP 和 UDP；网络资源应在 unload 时关闭。
+- `eventBus` topic 建议使用 `<plugin-name>.<domain>.<event>`，订阅函数会返回
+  unsubscribe callback。
 
-// operator scope
-ctx.store.operator.set('qsoCount', 42);
-```
+## 5. Utility hooks
 
-**存储文件路径**：
-- Global：`{dataDir}/plugin-data/{name}/global.json`
-- Operator：`{dataDir}/plugin-data/{name}/operator-{operatorId}.json`
+常用 hook：
 
-写入有 300ms debounce；卸载时自动 flush。需要立即持久化时调用 `await ctx.store.global.flush()`。
+| hook | 用途 |
+|---|---|
+| `onFilterCandidates` | 过滤自动目标候选，返回新的数组 |
+| `onScoreCandidates` | 调整候选 `score` |
+| `onAutoCallCandidate` | 声明式提出一个自动起呼候选 |
+| `onConfigureAutoCallExecution` | 调整 Host 已接受起呼的执行计划 |
+| `onSlotStart` | 接收时隙开始与解析后的消息 |
+| `onSlotActivity` | 接收时隙、原始 frame 和解析消息 |
+| `onDecode` | 接收新解码消息 |
+| `onFrequencyChange` | 接收频率或波段变化 |
+| `onQSOStart` | QSO 开始通知 |
+| `onQSOComplete` | 日志已经成功提交后的 QSO 完成通知 |
+| `onQSOFail` | QSO 失败通知 |
+| `onTimer` | `ctx.timers` 的命名 timer 触发 |
+| `onUserAction` | quick action 或 Host 用户操作 |
+| `onConfigChange` | 持久设置变化 |
 
-### 4.9 自定义 UI（iframe 页面与面板）
+自动起呼优先使用 `onAutoCallCandidate()` 返回 proposal，让 Host 统一仲裁：
 
-插件可以通过 iframe 托管自定义 HTML 页面。
-
-#### 声明页面
-
-```typescript
-const plugin: PluginDefinition = {
-  name: 'my-plugin',
-  ui: {
-    dir: 'ui',
-    pages: [
-      {
-        id: 'settings',
-        title: 'Settings',
-        entry: 'settings.html',
-        accessScope: 'operator',           // 'admin' | 'operator', 默认 'admin'
-        resourceBinding: 'callsign',       // 'none' | 'callsign' | 'operator', 默认 'none'
-      },
-    ],
+```ts
+hooks: {
+  onAutoCallCandidate(_slotInfo, messages) {
+    const candidate = messages.find((entry) => entry.message.type === 'cq');
+    if (!candidate || candidate.message.type !== 'cq') return null;
+    return {
+      callsign: candidate.message.senderCallsign,
+      priority: 10,
+    };
   },
-};
+}
 ```
 
-- `accessScope`: `admin` 仅管理员可访问；`operator` 操作员也可访问
-- `resourceBinding`: 宿主据此校验请求中是否携带对应资源并做访问控制
+上例不需要 frame 上下文。若要填写可选 `lastMessage`，应从
+`onSlotActivity` 保存 Host 提供的 `FrameMessage` 与对应 `SlotInfo`，不要从
+`ParsedFT8Message` 构造不存在的字段。
 
-#### 将 iframe 面板嵌入 UI
+Hook 应尽快返回。耗时 I/O 应显式 `await`、处理失败，并允许 invocation 被取消；
+不要在 hook 中启动无法追踪的后台 continuation。
 
-```typescript
-panels: [
-  { id: 'live-view', title: 'liveView', component: 'iframe', pageId: 'dashboard' },
-  { id: 'controls', title: 'controls', component: 'iframe', pageId: 'settings', slot: 'automation' },
-],
-```
+## 6. StrategyRuntime v2
 
-#### Bridge SDK
+strategy 必须实现完整 v2 runtime：
 
-宿主自动在每个 iframe 页面中注入 Bridge SDK，通过 `window.tx5dr` 访问：
+```ts
+import {
+  definePlugin,
+  type ParsedFT8Message,
+  type StrategyDecisionMetaV2,
+  type StrategyDecisionResult,
+  type StrategyPluginContext,
+  type StrategyRuntime,
+  type StrategyRuntimeCheckpoint,
+  type StrategyRuntimeContext,
+  type StrategyRuntimeSlot,
+  type StrategyRuntimeSlotContentUpdate,
+} from '@tx5dr/plugin-api';
 
-| 方法/属性 | 说明 |
-|-----------|------|
-| `tx5dr.params` | 只读参数对象 |
-| `tx5dr.theme` | 当前主题：`'dark'` / `'light'` |
-| `tx5dr.locale` | 当前语言：`'zh'` / `'en'` |
-| `tx5dr.pageSessionId` | 宿主分配的页面 session ID |
-| `tx5dr.ready` | Promise，首次宿主 init 后 resolve |
-| `tx5dr.getState()` | 返回 Bridge 状态快照 |
-| `tx5dr.onStateChange(cb)` | 监听状态变化，返回取消函数 |
-| `tx5dr.onLocaleChange(cb)` | 监听语言变化，返回取消函数 |
-| `tx5dr.onThemeChange(cb)` | 监听主题变化，返回取消函数 |
-| `tx5dr.invoke(action, data)` | 发送请求到服务端 → `registerPageHandler` |
-| `tx5dr.onPush(action, cb)` | 监听服务端主动推送 |
-| `tx5dr.offPush(action, cb)` | 取消推送监听 |
-| `tx5dr.resize(height)` | 报告内容高度 |
-| `tx5dr.requestClose()` | 请求关闭当前页面 |
-| `tx5dr.storeGet(key, default?)` | 读取页面 scope KV |
-| `tx5dr.storeSet(key, value)` | 写入页面 scope KV |
-| `tx5dr.storeDelete(key)` | 删除页面 scope KV |
-| `tx5dr.fileUpload(path, file)` | 上传文件到页面 scope |
-| `tx5dr.fileRead(path)` | 读取页面 scope 文件 |
-| `tx5dr.fileDelete(path)` | 删除页面 scope 文件 |
-| `tx5dr.fileList(prefix?)` | 列出页面 scope 文件 |
+class Runtime implements StrategyRuntime {
+  private state: StrategyRuntimeSlot = 'TX6';
+  private slots: Partial<Record<StrategyRuntimeSlot, string>> = {};
+  private context: StrategyRuntimeContext = {};
 
-#### invoke / onPush 通信
+  constructor(private readonly ctx: StrategyPluginContext) {}
 
-**iframe → 服务端**：
+  checkpoint(): StrategyRuntimeCheckpoint {
+    return structuredClone({
+      state: this.state,
+      slots: this.slots,
+      context: this.context,
+    });
+  }
 
-```javascript
-// iframe
-const result = await tx5dr.invoke('getState', { key: 'counter' });
-```
+  restore(checkpoint: StrategyRuntimeCheckpoint): void {
+    const saved = checkpoint as {
+      state: StrategyRuntimeSlot;
+      slots: Partial<Record<StrategyRuntimeSlot, string>>;
+      context: StrategyRuntimeContext;
+    };
+    this.state = saved.state;
+    this.slots = { ...saved.slots };
+    this.context = { ...saved.context };
+  }
 
-```typescript
-// 服务端（onLoad 中注册）
-ctx.ui.registerPageHandler({
-  async onMessage(pageId, action, data) {
-    if (action === 'getState') {
-      return { counter: ctx.store.operator.get('counter', 0) };
+  decide(
+    messages: ParsedFT8Message[],
+    meta: StrategyDecisionMetaV2,
+  ): StrategyDecisionResult {
+    if (meta.signal.aborted) {
+      throw meta.signal.reason ?? new Error('Decision aborted');
     }
+
+    // 根据 messages 更新本 runtime 的 speculative state。
+    return {
+      transmission: this.getTransmitText(),
+      snapshot: this.getSnapshot(),
+    };
+  }
+
+  getTransmitText(): string | null {
+    return this.slots[this.state] ?? null;
+  }
+
+  getSnapshot() {
+    return {
+      currentState: this.state,
+      slots: { ...this.slots },
+      context: { ...this.context },
+    };
+  }
+
+  requestCall(callsign: string): void {
+    this.context.targetCallsign = callsign;
+    this.state = 'TX1';
+    this.ctx.log.info('Call requested', { callsign });
+  }
+
+  patchContext(patch: Partial<StrategyRuntimeContext>): void {
+    Object.assign(this.context, patch);
+  }
+
+  setState(state: StrategyRuntimeSlot): void {
+    this.state = state;
+  }
+
+  setSlotContent(update: StrategyRuntimeSlotContentUpdate): void {
+    this.slots[update.slot] = update.content;
+  }
+
+  reset(): void {
+    this.state = 'TX6';
+    this.slots = {};
+    this.context = {};
+  }
+}
+
+export default definePlugin({
+  apiVersion: 2,
+  name: 'my-strategy',
+  version: '1.0.0',
+  type: 'strategy',
+
+  createStrategyRuntime(ctx) {
+    return new Runtime(ctx);
   },
 });
 ```
 
-**服务端 → iframe**：
+必须实现：
 
-```typescript
-// 服务端
-ctx.ui.pushToPage('dashboard', 'dataUpdated', { value: 42 });
+```text
+checkpoint / restore / decide / getTransmitText / getSnapshot
+requestCall / patchContext / setState / setSlotContent / reset
+```
 
-// 或者精确推送到特定 session
-for (const session of ctx.ui.listActivePageSessions('dashboard')) {
-  ctx.ui.pushToSession(session.sessionId, 'refresh', { reason: 'timer' });
+### 6.1 speculative decision 规则
+
+- `checkpoint()` 的返回值必须能被 `structuredClone()`；不要包含 Promise、函数、
+  socket、文件句柄或 Host context。
+- `decide(messages, meta)` 是 speculative phase。被新命令、晚到解码、reload 或
+  shutdown 取代时，Host 可以 abort 并恢复 checkpoint。
+- `meta` 包含 `epoch`、`source`、`isReDecision` 和 `signal`。异步逻辑必须传递并
+  响应 `AbortSignal`。
+- `decide()` 内不要写日志本、操作 PTT、提交 operator command 或产生不可撤销的
+  外部副作用。
+- `StrategyPluginContext` 仅包含 `config`、`log` 和只读 `operator`，不含命令端口。
+
+### 6.2 decision result
+
+每次 decision 必须返回准确的 `transmission` 和 `snapshot`：
+
+```ts
+return {
+  transmission: 'CQ BA8BLK OM20', // 或 null
+  snapshot: this.getSnapshot(),
+  stop: false,                    // 可选：停止后续自动化，不是 RF 硬中断
+  silentListen: undefined,        // 可选：QSO 后的声明式静默监听窗口
+  qsoFailure: undefined,          // 可选：结构化失败信息
+  qsoCompletion: undefined,       // 可选：durable QSO effect
+};
+```
+
+完成 QSO 时，不要在 `decide()` 中直接写 ADIF。返回声明式 effect：
+
+```ts
+qsoCompletion: {
+  record,
+  lifecycleEpoch,
 }
 ```
 
-```javascript
-// iframe
-tx5dr.onPush('dataUpdated', (data) => {
-  document.getElementById('value').textContent = data.value;
-});
+Host 完成持久化后，可通过可选的 `settleQSOCompletion({ lifecycleEpoch, recordId,
+status })` 通知 runtime。旧 lifecycle 的结果不会成为新 QSO 的 RF 决策依据。
+
+## 7. Settings、存储与 UI
+
+### 7.1 Settings
+
+```ts
+settings: {
+  enabled: {
+    type: 'boolean',
+    default: true,
+    label: 'enabled',
+    description: 'enabledDesc',
+    scope: 'operator',
+  },
+  threshold: {
+    type: 'number',
+    default: -15,
+    label: 'threshold',
+    scope: 'global',
+    min: -30,
+    max: 10,
+  },
+},
+quickSettings: [{ settingKey: 'enabled' }],
+quickActions: [{ id: 'reset', label: 'reset' }],
 ```
 
-#### CSS Design Tokens
+支持的 setting type：`boolean`、`number`、`string`、`string[]`、`object[]`、
+`keyedStringArrays`、`keyedObjectArrays`、`keyedObjects` 和 `info`。
 
-宿主自动注入 CSS 变量，适配明暗主题：
+- `scope: 'global'`：全站共享。
+- `scope: 'operator'`：按操作员隔离。
+- `quickSettings` 只能引用已声明、非 `info` 的 operator-scope setting。
+- `ctx.config` 是已合并、只读的当前值；使用 `await ctx.updateConfig(patch)` 更新。
+- `label`、`description` 可以使用 `locales/<locale>.json` 中的翻译 key。
 
-| 变量 | 说明 |
-|------|------|
-| `--tx5dr-bg` / `--tx5dr-bg-content` / `--tx5dr-bg-hover` | 背景色 |
-| `--tx5dr-text` / `--tx5dr-text-secondary` | 文字颜色 |
-| `--tx5dr-primary` | 主题色 |
-| `--tx5dr-success` / `--tx5dr-warning` / `--tx5dr-danger` | 状态色 |
-| `--tx5dr-border` | 边框颜色 |
-| `--tx5dr-radius-sm` / `-md` / `-lg` | 圆角 |
-| `--tx5dr-spacing-xs` / `-sm` / `-md` / `-lg` / `-xl` | 间距 |
-| `--tx5dr-font` / `--tx5dr-font-mono` | 字体 |
-| `--tx5dr-font-size-sm` / `-md` / `-lg` | 字号 |
+### 7.2 KV 与文件
 
-#### 固定宿主路由
+```ts
+const count = ctx.store.operator.get<number>('count', 0);
+ctx.store.operator.set('count', count + 1);
+await ctx.store.operator.flush(); // 只在确需立即落盘时调用
 
-- `GET /api/plugins/:name/ui/*`：返回静态页面，自动注入 Bridge SDK
-- `POST /api/plugins/:name/ui-invoke`：`tx5dr.invoke()` 转发
-- `POST /api/plugins/:name/ui-store`：`tx5dr.store*()` 请求
-- `POST /api/plugins/:name/ui-files`：`tx5dr.file*()` 请求
-- `POST /api/plugins/:name/ui-session/heartbeat`：刷新 session TTL
-
-iframe 页面应通过 Bridge SDK 调用，不应自行手写 fetch 伪造 session。
-
-### 4.10 文件存储
-
-```typescript
-interface PluginFileStore {
-  write(path: string, data: Buffer): Promise<void>;
-  read(path: string): Promise<Buffer | null>;
-  delete(path: string): Promise<boolean>;
-  list(prefix?: string): Promise<string[]>;
-}
+await ctx.files.write('cache/data.bin', buffer);
+const data = await ctx.files.read('cache/data.bin');
 ```
 
-**存储路径**：`{dataDir}/plugin-data/{pluginName}/files/`
+小型 JSON 兼容数据使用 `store`；二进制或较大文件使用 `files`。路径由 Host 限制
+在插件私有目录内。
 
-**安全约束**：所有路径禁止目录穿越（`..`、绝对路径等被拒绝）。
+### 7.3 Panels
 
-### 4.11 日志同步 Provider
+声明式 panel 支持 `table`、`key-value`、`chart`、`log` 和 `iframe`：
 
-工具插件可以通过 `ctx.logbookSync.register()` 注册日志同步 Provider。
+```ts
+panels: [
+  {
+    id: 'status',
+    title: 'statusTitle',
+    component: 'key-value',
+    slot: 'operator',
+    width: 'half',
+  },
+],
 
-#### LogbookSyncProvider 接口
-
-```typescript
-interface LogbookSyncProvider {
-  readonly id: string;
-  readonly displayName: string;
-  readonly icon?: string;
-  readonly color?: 'default' | 'primary' | 'secondary' | 'success' | 'warning' | 'danger';
-  readonly accessScope?: 'admin' | 'operator';
-  readonly settingsPageId: string;
-  readonly actions?: SyncAction[];
-
-  testConnection(callsign: string): Promise<SyncTestResult>;
-  upload(callsign: string, options?: SyncUploadOptions): Promise<SyncUploadResult>;
-  download(callsign: string, options?: SyncDownloadOptions): Promise<SyncDownloadResult>;
-  isConfigured(callsign: string): boolean;
-  isAutoUploadEnabled(callsign: string): boolean;
-
-  /** 可选：上传前检查 */
-  getUploadPreflight?(callsign: string): Promise<SyncUploadPreflightResult>;
-}
-```
-
-#### SyncAction
-
-```typescript
-interface SyncAction {
-  id: string;
-  label: string;
-  description?: string;
-  icon?: 'download' | 'upload' | 'sync';
-  operation?: 'upload' | 'download' | 'full_sync';  // 直接执行
-  pageId?: string;                                    // 打开 iframe 页面
-}
-```
-
-#### 注册流程
-
-```typescript
 onLoad(ctx) {
-  const provider = new MyProvider(ctx);
-  ctx.logbookSync.register(provider);
+  ctx.ui.send('status', { state: 'ready' });
+},
+```
 
+可用 slot：`operator`、`automation`、`main-right`、`voice-left-top`、
+`voice-right-top`、`cw-left-top`、`cw-right-top`、`radio-control-toolbar`。
+运行期 panel 使用 `setPanelContributions()` / `clearPanelContributions()` 管理。
+
+### 7.4 iframe 页面
+
+```ts
+ui: {
+  dir: 'ui',
+  pages: [
+    {
+      id: 'settings',
+      title: 'settingsTitle',
+      entry: 'settings.html',
+      accessScope: 'admin',
+    },
+  ],
+},
+
+onLoad(ctx) {
   ctx.ui.registerPageHandler({
-    async onMessage(pageId, action, data) {
-      // 处理设置页面的 invoke 请求
+    async onMessage(pageId, action) {
+      if (pageId === 'settings' && action === 'read') {
+        return { value: ctx.store.global.get('value', '') };
+      }
+      return null;
     },
   });
 },
 ```
 
-推荐声明为 `type: 'utility'` + `instanceScope: 'global'`，使用 `ctx.logbook.forCallsign(callsign)` 访问日志本。
-
-### 4.12 宿主设置访问
-
-插件可通过 `ctx.settings` 访问宿主级设置，每个命名空间需要对应的 `settings:*` 权限：
-
-```typescript
-interface HostSettingsControl {
-  readonly ft8: HostSettingsNamespace<HostFT8Settings, HostFT8SettingsPatch>;
-  readonly decodeWindows: HostSettingsNamespace<DecodeWindowSettings, DecodeWindowSettings>;
-  readonly realtime: HostSettingsNamespace<RealtimeSettings, RealtimeSettings>;
-  readonly frequencyPresets: HostFrequencyPresetsSettingsNamespace;
-  readonly station: HostSettingsNamespace<StationInfo, HostStationInfoPatch>;
-  readonly pskReporter: HostSettingsNamespace<PSKReporterConfig, HostPSKReporterSettingsPatch>;
-  readonly ntp: HostSettingsNamespace<NtpServerListSettings, UpdateNtpServerListRequest>;
-}
-
-interface HostSettingsNamespace<TValue, TPatch> {
-  get(): Promise<TValue>;
-  update(patch: TPatch): Promise<TValue>;
-}
-```
-
-### 4.13 插件市场
-
-系统内置官方插件市场，支持从远端 catalog 安装、更新和卸载插件。
-
-#### REST API
-
-| Method | Path | 说明 |
-|--------|------|------|
-| `GET` | `/api/plugins/market/catalog` | 获取市场插件索引 |
-| `GET` | `/api/plugins/market/catalog/:name` | 获取单个市场条目 |
-| `POST` | `/api/plugins/market/:name/install` | 从市场安装插件 |
-| `POST` | `/api/plugins/market/:name/update` | 从市场更新插件 |
-| `DELETE` | `/api/plugins/market/:name` | 卸载市场插件（保留 plugin-data） |
-
-市场条目包含 `name`、`latestVersion`、`minHostVersion`、`artifactUrl`、`sha256`、`size`、`channel`（`stable`/`nightly`）、`categories`、`keywords` 等字段。
-
----
-
-## 5. 编写你的第一个插件
-
-### 5.1 最简工具插件（JS）
+iframe 内由 Host 注入 `window.tx5dr`：
 
 ```js
-// {pluginDir}/snr-guard/plugin.js
-
-/** @type {import('@tx5dr/plugin-api').PluginDefinition} */
-export default {
-  name: 'snr-guard',
-  version: '1.0.0',
-  type: 'utility',
-  description: 'Block candidates below minimum SNR',
-
-  settings: {
-    minSNR: {
-      type: 'number',
-      default: -15,
-      label: 'Minimum SNR (dB)',
-      scope: 'global',
-      min: -30,
-      max: 10,
-    },
-  },
-
-  hooks: {
-    onFilterCandidates(candidates, ctx) {
-      const minSNR = /** @type {number} */ (ctx.config.minSNR ?? -15);
-      return candidates.filter(c => c.snr >= minSNR);
-    },
-  },
-};
+await window.tx5dr.ready;
+const result = await window.tx5dr.invoke('read');
+window.tx5dr.onPush('updated', (data) => console.log(data));
 ```
 
-放入插件目录后，在前端「设置 → 插件」中重载即可生效。
-
-### 5.2 TypeScript 完整项目
-
-```
-my-plugin/
-├── src/
-│   └── index.ts
-├── locales/
-│   ├── zh.json
-│   └── en.json
-├── package.json
-├── tsconfig.json
-└── README.md
-```
-
-**package.json**
-
-```json
-{
-  "name": "my-plugin",
-  "type": "module",
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch --outDir ../path/to/TX-5DR/plugins/my-plugin"
-  },
-  "devDependencies": {
-    "@tx5dr/plugin-api": "^1.6.0",
-    "typescript": "^5.0.0"
-  }
-}
-```
-
-**tsconfig.json**
+启用类型补全：
 
 ```json
 {
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "target": "ESNext",
-    "outDir": "dist",
-    "strict": true
-  },
-  "include": ["src"]
+    "types": ["@tx5dr/plugin-api/bridge"]
+  }
 }
 ```
 
-**src/index.ts**
+页面只能通过 Bridge 与自己的 server-side handler 通信，不会直接获得 server
+context capability。`requestContext.user`、resource binding 和 page session 都由
+Host 验证；不要相信 iframe 自行提交的 operatorId、callsign 或权限信息。
 
-```typescript
-import type { PluginDefinition, PluginContext, ParsedFT8Message } from '@tx5dr/plugin-api';
+## 8. Invocation 与生命周期
 
-const plugin: PluginDefinition = {
-  name: 'my-plugin',
-  version: '1.0.0',
-  type: 'utility',
+每个 hook、timer 和 page handler 都有 Host 管理的 invocation 生命周期。
 
-  settings: {
-    targetPrefix: {
-      type: 'string',
-      default: 'JA',
-      label: 'targetPrefix',
-      scope: 'operator',
-    },
-  },
+- 使用 `ctx.timers.set(id, intervalMs)`，在 `hooks.onTimer` 中处理；不要使用 raw
+  timer 保存长期可写 context。
+- invocation timeout、plugin disable、reload、unload 或 shutdown 后，旧异步
+  continuation 再调用命令型 capability 会得到 `PLUGIN_INVOCATION_EXPIRED`。
+- strategy 收到 `AbortSignal` 后应立即停止；其他 invocation 失效后不要继续提交
+  operator、radio、logbook 或 UI 命令。
+- hook throw/reject 会被隔离到当前插件实例；仍应捕获可预期错误并写清晰日志。
+- `onUnload(ctx)` 只提供 `store`、`log`、`timers`、`files`，用于清理插件资源。
+- UDP socket、event bus subscription 和外部客户端应保存自己的 cleanup handle，
+  在 unload 时关闭；Host timer 会自动清理。
 
-  onLoad(ctx: PluginContext) {
-    ctx.log.info('Plugin loaded', { operatorId: ctx.operator.id });
-  },
+## 9. 测试与发布检查
 
-  hooks: {
-    onFilterCandidates(candidates: ParsedFT8Message[], ctx: PluginContext) {
-      const prefix = ctx.config.targetPrefix as string;
-      if (!prefix) return candidates;
-      return candidates.filter(c =>
-        c.message.senderCallsign?.startsWith(prefix)
-      );
-    },
+测试工具从 `@tx5dr/plugin-api/testing` 导入：
 
-    onQSOComplete(record, ctx) {
-      const count = ctx.store.operator.get<number>('qsoCount', 0) + 1;
-      ctx.store.operator.set('qsoCount', count);
-      ctx.log.info('QSO completed', { callsign: record.callsign, total: count });
-    },
-  },
-};
-
-export default plugin;
-```
-
-### 5.3 策略插件示例
-
-```typescript
-import type { PluginDefinition, StrategyRuntime, ParsedFT8Message } from '@tx5dr/plugin-api';
-
-const plugin: PluginDefinition = {
-  name: 'simple-strategy',
-  version: '1.0.0',
-  type: 'strategy',
-
-  createStrategyRuntime(ctx): StrategyRuntime {
-    let target: string | undefined;
-    let attempts = 0;
-
-    return {
-      async decide(messages: ParsedFT8Message[]) {
-        const call = messages.find(m =>
-          m.message.targetCallsign === ctx.operator.callsign
-        );
-
-        if (call) {
-          target = call.message.senderCallsign;
-          attempts = 0;
-        } else if (target) {
-          attempts++;
-          if (attempts > 5) target = undefined;
-        }
-
-        return { stop: false };
-      },
-
-      getTransmitText() {
-        if (!target) return `CQ ${ctx.operator.callsign} ${ctx.operator.grid}`;
-        return `${target} ${ctx.operator.callsign} -01`;
-      },
-
-      requestCall(callsign) { target = callsign; attempts = 0; },
-      patchContext() {},
-      setState() {},
-      setSlotContent() {},
-      reset() { target = undefined; attempts = 0; },
-      getSnapshot() {
-        return {
-          currentState: target ? 'TX2' : 'TX6',
-          context: { targetCallsign: target },
-          availableSlots: ['TX1', 'TX2', 'TX3', 'TX4', 'TX5', 'TX6'],
-        };
-      },
-    };
-  },
-};
-
-export default plugin;
-```
-
----
-
-## 6. 内置插件参考
-
-内置插件位于 `packages/builtin-plugins/src/`，共 12 个。均为 `@tx5dr/builtin-plugins` 包的一部分，由 `PluginManager` 在启动时自动加载。
-
-### standard-qso
-
-内置标准 FT8/FT4 QSO 策略。所有操作员默认使用此策略。
-
-**Settings**（均为 operator scope）：
-
-| Key | 类型 | 默认值 | 说明 |
-|-----|------|--------|------|
-| `strategyOverview` | info | `''` | 策略说明节点 |
-| `autoReplyToCQ` | boolean | false | 自动回复 CQ |
-| `autoResumeCQAfterFail` | boolean | false | 失败后自动恢复 CQ |
-| `autoResumeCQAfterSuccess` | boolean | false | 成功后自动恢复 CQ |
-| `replyToWorkedStations` | boolean | false | 回复已通联电台 |
-| `targetSelectionPriorityMode` | string | `'dxcc_first'` | 优先级：`dxcc_first` / `new_callsign_first` / `balanced` |
-| `maxQSOTimeoutCycles` | number | 6 | 超时周期数 |
-| `maxCallAttempts` | number | 5 | TX1 最大呼叫次数 |
-
-**QuickSettings**：`autoReplyToCQ`、`autoResumeCQAfterFail`、`autoResumeCQAfterSuccess`、`replyToWorkedStations`
-
-### snr-filter
-
-展示 `onFilterCandidates` 的最简工具插件。默认未启用。
-
-| Key（global） | 类型 | 默认值 |
-|------|------|--------|
-| `minSNR` | number | -15 |
-
-### no-reply-memory-filter
-
-无回复记忆过滤插件。默认未启用。跟踪哪些呼号在过去一段时间内未回复自己的呼叫，在下一次决策时过滤。
-
-### callsign-filter
-
-展示 `string[]` 设置、按波段规则、DXCC 实体屏蔽和 `onFilterCandidates` 的过滤插件。默认未启用。呼号规则与 DXCC 屏蔽同时生效；未识别 DXCC 的呼号不会因 DXCC 规则被屏蔽。开启按波段后，呼号规则和 DXCC 屏蔽都按当前波段读取，未填写的波段不继承通用规则。
-
-| Key（operator scope） | 类型 | 默认值 |
-|------|------|--------|
-| `filterMode` | string | `blocklist` |
-| `filterRules` | string[] | `[]` |
-| `perBandEnabled` | boolean | `false` |
-| `bandFilterRules` | keyedStringArrays | `{}` |
-| `dxccBlockEnabled` | boolean | `false` |
-| `blockedDxccEntityCodes` | string[] options | `[]` |
-| `bandBlockedDxccEntityCodes` | keyedStringArrays options | `{}` |
-| `filterScope` | string | `auto-reply` |
-
-### worked-station-bias
-
-展示 `onScoreCandidates` 和日志本查询的评分插件。对未通联过的呼号加分，对已通联过的减分，影响候选排序但不直接控制起呼。
-
-### watched-callsign-autocall
-
-守候指定呼号列表自动起呼。支持精确匹配和正则语法，`#` 开头行为注释。
-
-| Key（operator scope） | 类型 | 默认值 |
-|------|------|--------|
-| `watchList` | string[] | `[]` |
-| `triggerMode` | string | `'cq'` |
-| `autocallPriority` | number | `100` |
-
-### watched-novelty-autocall
-
-守候新 DXCC / 新网格 / 新呼号自动起呼。依赖 `ParsedFT8Message.logbookAnalysis`。
-
-| Key（operator scope） | 类型 | 默认值 |
-|------|------|--------|
-| `watchNewDxcc` | boolean | `false` |
-| `watchNewGrid` | boolean | `false` |
-| `watchNewCallsign` | boolean | `false` |
-| `autocallPriority` | number | `80` |
-
-### autocall-idle-frequency
-
-自动起呼执行层插件：在自动起呼前挑选更空闲的发射音频频率。通过 `onConfigureAutoCallExecution` 实现。默认启用。
-
-| Key（operator scope） | 类型 | 默认值 |
-|------|------|--------|
-| `autoSelectIdleFrequency` | boolean | `false` |
-
-### lotw-sync
-
-ARRL Logbook of The World 日志同步插件。展示完整 Provider 实现：证书管理、TQ8 上传、ADIF 下载。默认启用。`instanceScope: 'global'`。
-
-### qrz-sync
-
-QRZ.com 日志同步插件。最简 Provider 实现。默认启用。`instanceScope: 'global'`。
-
-### wavelog-sync
-
-WaveLog 自托管日志服务同步插件。支持多步配置和站台选择。默认启用。`instanceScope: 'global'`。
-
-### qso-udp-broadcast
-
-QSO 完成时通过 UDP 广播通联记录。服务端插件，无前端 UI。默认启用。
-
----
-
-## 7. 插件系统架构
-
-### 7.1 生命周期
-
-```
-应用启动 / 插件子系统启动（独立于引擎是否成功启动）
-  └─ PluginManager.start()
-       ├─ 注册所有内置插件（@tx5dr/builtin-plugins 中的 BUILTIN_PLUGINS 数组）
-       ├─ 扫描 {dataDir}/plugins/ 加载用户插件
-       ├─ 为当前所有操作员调用 initInstancesForOperator()
-       └─ 广播插件系统快照
-
-新增操作员
-  └─ initInstancesForOperator(operatorId)
-       ├─ 为该操作员上的所有插件创建 PluginContext
-       ├─ 为策略插件创建 StrategyRuntime
-       └─ 对已启用实例调用 onLoad()
-
-移除操作员
-  └─ removeInstancesForOperator(operatorId)
-       └─ 为该操作员上的相关插件调用 onUnload()
-
-插件重载 / 重扫
-  └─ reloadPlugins() / reloadPlugin(name) / rescanPlugins()
-       ├─ 把插件系统状态切到 reloading 并广播快照
-       ├─ 卸载受影响实例（onUnload）
-       ├─ 重新加载插件定义
-       ├─ 为相关操作员重新创建实例（onLoad）
-       └─ 切回 ready / error 并广播新的插件系统快照
-
-应用关闭
-  └─ PluginManager.shutdown()
-       └─ 为所有实例调用 onUnload()
-            ├─ 清理所有定时器
-            └─ flush 持久化存储
-```
-
-插件子系统与引擎运行状态解耦：电台未连接、引擎未成功启动，都不影响插件的加载、重载、设置管理和客户端同步。
-
-### 7.2 Hook 分发机制
-
-```
-onFilterCandidates（Pipeline）：
-  active-plugin-A → active-plugin-B → ... → 最终候选列表
-  每步：200ms 超时 + 空列表安全网
-
-strategy runtime：
-  仅活跃策略插件 → runtime.decide() / runtime.getTransmitText()
-  用户编辑上下文 / 状态 / 槽位 → 直接调用 runtime
-
-onQSOComplete（Broadcast）：
-  utility-A, utility-B, strategy 并发执行（Promise.allSettled）
-  单个出错不影响其他
-```
-
-所有 hook 调用都有 **200ms 超时**。显式 strategy runtime 方法不受此超时约束。
-
-### 7.3 策略运行时实现
-
-策略插件在插件目录内直接实现自己的运行时，不再通过 bridge / adapter 复用旧策略系统：
-
-```
-PluginContext.operator (OperatorControl)
-    │
-    ▼
-standard-qso/StandardQSOPluginRuntime.ts
-    │    直接读取 ctx.operator.* 和 ctx.config.*
-    │    直接维护状态机、槽位文本与 QSO 生命周期
-    │
-    ▼
-StrategyRuntime methods（decide / getTransmitText / patchContext / setState ...）
-```
-
-当前系统内部的核心控制链路：
-
-- WebSocket：`setOperatorRuntimeState` / `setOperatorRuntimeSlotContent` / `setOperatorTransmitCycles`
-- Server：`PluginManager.patchOperatorRuntimeContext()` / `setOperatorRuntimeState()` / `setOperatorRuntimeSlotContent()`
-- Runtime：`patchContext()` / `setState()` / `setSlotContent()` / `getSnapshot()`
-
-### 7.4 错误隔离
-
-```
-单次 hook 执行
-  ├─ 200ms 超时 → 超时报错
-  ├─ 抛出异常 → 捕获，记录错误
-  └─ 正常返回
-
-错误追踪（PluginErrorTracker）
-  ├─ 每个插件每个 hook 独立计数
-  ├─ 连续 5 次错误 → 自动禁用该插件
-  └─ 广播 pluginStatusChanged 事件通知前端
-
-Pipeline 额外安全网
-  └─ onFilterCandidates 返回空数组（输入非空）→ 跳过该插件
-```
-
-### 7.5 多插件冲突处理
-
-| 情景 | 处理方式 |
-|------|---------|
-| 两个工具插件同时定义 `onFilterCandidates` | Pipeline 链式执行 |
-| 两个工具插件同时定义 `onQSOComplete` | 并发 fire-and-forget |
-| 两个自动起呼工具插件同时定义 `onAutoCallCandidate` | Host 统一收集提议后仲裁 |
-| 两个策略插件（理论上不可能）| 每个操作员只能选择一个策略 |
-| 工具插件过滤器把候选清空 | 安全网保留上一步结果 |
-
----
-
-## 8. REST API 与 WebSocket 事件
-
-### REST API
-
-所有接口挂载在 `/api/plugins`：
-
-| Method | Path | 说明 |
-|--------|------|------|
-| `GET` | `/api/plugins` | 获取插件系统完整快照 |
-| `GET` | `/api/plugins/runtime-info` | 获取插件宿主目录与运行形态 |
-| `POST` | `/api/plugins/:name/enable` | 启用插件 |
-| `POST` | `/api/plugins/:name/disable` | 禁用插件 |
-| `POST` | `/api/plugins/:name/reload` | 重载单个插件 |
-| `POST` | `/api/plugins/reload` | 重载全部插件 |
-| `POST` | `/api/plugins/rescan` | 重扫插件目录 |
-| `GET` | `/api/plugins/:name/settings` | 获取 global-scope 设置 |
-| `PUT` | `/api/plugins/:name/settings` | 更新 global-scope 设置 |
-| `GET` | `/api/plugins/:name/operator/:id/settings` | 获取 operator-scope 设置 |
-| `PUT` | `/api/plugins/:name/operator/:id/settings` | 更新 operator-scope 设置 |
-| `PUT` | `/api/plugins/operators/:id/strategy` | 设置操作员策略插件 |
-| `GET` | `/api/plugins/:name/ui/*` | iframe 静态页面（自动注入 Bridge SDK） |
-| `GET` | `/api/plugins/_bridge/bridge.js` | Bridge SDK 脚本 |
-| `GET` | `/api/plugins/_bridge/tokens.css` | CSS Design Tokens |
-| `POST` | `/api/plugins/:name/ui-invoke` | iframe invoke 转发 |
-| `POST` | `/api/plugins/:name/ui-store` | iframe KV store 桥接 |
-| `POST` | `/api/plugins/:name/ui-files` | iframe 文件操作桥接 |
-| `POST` | `/api/plugins/:name/ui-session/heartbeat` | 页面 session 心跳 |
-| `GET` | `/api/plugins/sync-providers` | 获取同步 Provider 列表 |
-| `GET` | `/api/plugins/sync-providers/configured` | 获取 Provider 配置状态 |
-| `POST` | `/api/plugins/sync-providers/:id/test-connection` | 测试同步连接 |
-| `POST` | `/api/plugins/sync-providers/:id/upload-preflight` | 上传前检查 |
-| `POST` | `/api/plugins/sync-providers/:id/upload` | 触发上传 |
-| `POST` | `/api/plugins/sync-providers/:id/download` | 触发下载 |
-| `GET` | `/api/plugins/market/catalog` | 获取市场插件索引 |
-| `GET` | `/api/plugins/market/catalog/:name` | 获取单个市场条目 |
-| `POST` | `/api/plugins/market/:name/install` | 从市场安装 |
-| `POST` | `/api/plugins/market/:name/update` | 从市场更新 |
-| `DELETE` | `/api/plugins/market/:name` | 卸载市场插件 |
-
-管理类接口（启用/禁用/重载/全局设置）要求 `admin` 角色。运行期接口（日志同步、iframe、ui-invoke）可允许 `operator`，取决于插件的 `accessScope` 和 `resourceBinding` 声明。
-
-### WebSocket 事件
-
-| 事件 | 方向 | 说明 |
-|------|------|------|
-| `pluginListUpdated` | Server → Client | 插件系统完整快照 |
-| `pluginStatusChanged` | Server → Client | 单个插件状态变更 |
-| `pluginData` | Server → Client | `ctx.ui.send()` 推送的面板数据 |
-| `pluginLog` | Server → Client | `ctx.log.*` 日志条目 |
-| `pluginPagePush` | Server → Client | `ctx.ui.pushToPage()` 推送 |
-| `pluginPanelMeta` | Server → Client | 面板 meta 更新 |
-| `pluginPanelContribution` | Server → Client | 运行期面板贡献变更 |
-| `pluginUserAction` | Client → Server | 自定义用户动作 |
-
-操作员 runtime 核心控制命令走系统级 WebSocket 命令：
-- `setOperatorRuntimeState`
-- `setOperatorRuntimeSlotContent`
-- `setOperatorTransmitCycles`
-
-### 数据结构
-
-```typescript
-interface PluginSystemSnapshot {
-  state: 'ready' | 'reloading' | 'error';
-  generation: number;
-  plugins: PluginStatus[];
-  panelMeta: PluginPanelMetaPayload[];
-  panelContributions: PluginUIPanelContributionGroup[];
-  lastError?: string;
-}
-
-interface PluginStatus {
-  name: string;
-  type: 'strategy' | 'utility';
-  instanceScope: 'operator' | 'global';
-  version: string;
-  description?: string;
-  isBuiltIn: boolean;
-  loaded: boolean;
-  enabled: boolean;
-  autoDisabled: boolean;
-  errorCount: number;
-  lastError?: string;
-  assignedOperatorIds?: string[];
-  settings?: Record<string, PluginSettingDescriptor>;
-  quickActions?: PluginQuickAction[];
-  quickSettings?: PluginQuickSetting[];
-  panels?: PluginPanelDescriptor[];
-  permissions?: string[];
-  capabilities?: string[];
-  ui?: PluginUIConfig;
-  locales?: Record<string, Record<string, string>>;
-  source?: PluginSource;
-}
-```
-
----
-
-## 9. 前端 UI 集成
-
-### 插件出现的 UI 位置
-
-| 位置 | 内容 |
-|------|------|
-| 设置 → 插件 Tab | utility 插件启用状态 + global-scope 设置 |
-| 设置 → 插件 Tab | 插件日志面板 |
-| 设置 → 操作员配置 | 策略插件选择器 + operator-scope 设置 |
-| 操作员面板右上角 | QuickActions + QuickSettings |
-| 操作员卡片下方 | 插件声明的 Panels |
-| 日志本 → 同步设置 | 同步 Provider 设置页面（iframe） |
-
-### 翻译动态注册
-
-前端收到 `pluginListUpdated` 快照时，自动调用 `registerPluginLocales(name, locales)` 将翻译注册到 `i18next` 的 `plugin:{name}` 命名空间。
-
-### 设置保存模型
-
-- **插件管理页**：utility 启用状态与 global-scope 设置先进入草稿态，统一保存
-- **操作员插件设置**：按插件卡片局部保存
-- **QuickSetting toggle**：直接写入 operator-scope setting → `onConfigChange`
-
----
-
-## 10. 新增内置插件指南
-
-如需将新插件作为内置插件随系统发布：
-
-**1. 创建插件目录**
-
-```
-packages/builtin-plugins/src/my-new-plugin/
-├── index.ts
-└── locales/
-    ├── zh.json
-    └── en.json
-```
-
-**2. 实现 index.ts**
-
-```typescript
-import type { PluginDefinition } from '@tx5dr/plugin-api';
-import zhLocale from './locales/zh.json' with { type: 'json' };
-import enLocale from './locales/en.json' with { type: 'json' };
-
-export const BUILTIN_MY_NEW_PLUGIN_NAME = 'my-new-plugin';
-
-export const myNewPlugin: PluginDefinition = {
-  name: BUILTIN_MY_NEW_PLUGIN_NAME,
-  // ...
-};
-
-export const myNewPluginLocales = { zh: zhLocale, en: enLocale };
-```
-
-**3. 在 `packages/builtin-plugins/src/index.ts` 注册**
-
-```typescript
-// 添加 import
+```ts
 import {
-  myNewPlugin,
-  myNewPluginLocales,
-  BUILTIN_MY_NEW_PLUGIN_NAME,
-} from './my-new-plugin/index.js';
-
-// 在 BUILTIN_PLUGINS 数组中追加
-{
-  definition: myNewPlugin,
-  locales: myNewPluginLocales,
-  enabledByDefault: false,
-},
+  createMockContext,
+  createMockParsedMessage,
+  createMockSlotInfo,
+} from '@tx5dr/plugin-api/testing';
 ```
 
-如果插件包含 UI 静态文件，还需提供 `dirPath`（通过 `import.meta.url` 计算）。
+发布前至少检查：
 
----
+1. `definePlugin()` 能在 strict TypeScript 下通过，未使用任何未声明 capability。
+2. strategy checkpoint 可 `structuredClone()`，abort 后不会继续产生副作用。
+3. utility 只使用公开 command port，没有 raw PTT 或 server 内部 import。
+4. `isAutoCallEnabled` 只用于真正的自动起呼插件。
+5. operator/global setting 与 instance scope 合法。
+6. hook、network、timer、page handler 的失败和 unload 都能正确清理。
+7. iframe 的 access scope、resource binding 和服务端输入校验符合实际权限需求。
+8. 插件目录只包含发布所需入口、UI、locales 和依赖产物。
 
-## 11. 代码文件导航
+## 10. 从 v1 迁移到 v2
 
-| 关注点 | 文件路径 |
-|--------|---------|
-| 插件类型定义（TypeScript 接口）| `packages/plugin-api/src/` |
-| 插件 Schema（Zod 验证）| `packages/contracts/src/schema/plugin.schema.ts` |
-| WebSocket 协议 | `packages/contracts/src/schema/websocket.schema.ts` |
-| 插件管理器（中央编排）| `packages/server/src/plugin/PluginManager.ts` |
-| 插件加载器 | `packages/server/src/plugin/PluginLoader.ts` |
-| Hook 分发引擎 | `packages/server/src/plugin/PluginHookDispatcher.ts` |
-| PluginContext 工厂 | `packages/server/src/plugin/PluginContextFactory.ts` |
-| UI 桥接 | `packages/server/src/plugin/PluginUIBridge.ts` |
-| 错误追踪 | `packages/server/src/plugin/PluginErrorTracker.ts` |
-| 存储 Provider | `packages/server/src/plugin/PluginStorageProvider.ts` |
-| 文件存储 Provider | `packages/server/src/plugin/PluginFileStoreProvider.ts` |
-| 页面 Session 管理 | `packages/server/src/plugin/PluginPageSessionStore.ts` |
-| 日志同步 Host | `packages/server/src/plugin/LogbookSyncHost.ts` |
-| REST API 路由 | `packages/server/src/routes/plugins.ts` |
-| 内置插件包（全部 12 个）| `packages/builtin-plugins/src/` |
-| standard-qso 运行时 | `packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts` |
-| 前端插件组件 | `packages/web/src/components/plugins/` |
-| iframe 宿主组件 | `packages/web/src/components/plugins/PluginIframeHost.tsx` |
-| 面板渲染器 | `packages/web/src/components/plugins/PluginPanelRenderer.tsx` |
-| Slot 宿主布局 | `packages/web/src/components/plugins/PluginSlotHosts.tsx` |
-| 面板可见性逻辑 | `packages/web/src/components/plugins/pluginPanelSlots.ts` |
-| 插件市场 UI | `packages/web/src/components/plugins/PluginMarketplace.tsx` |
-| 插件管理列表 | `packages/web/src/components/plugins/PluginList.tsx` |
-| 操作员插件设置 | `packages/web/src/components/settings/OperatorPluginSettings.tsx` |
-| 前端插件辅助 API | `packages/web/src/utils/pluginApi.ts` |
-| Bridge SDK 类型 | `packages/plugin-api/src/bridge.d.ts` |
-| CSS Design Tokens 参考 | `packages/plugin-api/src/tokens.css` |
+- 改用 `definePlugin({ apiVersion: 2, ... })`。
+- strategy 实现完整 `StrategyRuntime` v2，尤其是 `checkpoint()`、`restore()` 和
+  `decide(messages, meta)`。
+- 将 strategy 中的直接日志写入改成 `qsoCompletion` effect。
+- 将旧 operator mutation 改成 utility 的 `operator:transmit-control` +
+  `operatorCommands.submit()`；strategy 本身不要申请该 permission。
+- 将 radio/logbook/settings/network 使用改成对应 capability，并从 permissions
+  删除未使用项。
+- 将直接 PTT、音频、Mixer、Encoder 和 server 内部调用删除。
+- 将 raw timer 改成 `ctx.timers`，并处理 `AbortSignal` 与
+  `PLUGIN_INVOCATION_EXPIRED`。
+- 将旧 `onUnload` 逻辑限制到 cleanup context。
+- 真正自动起呼实现 `isAutoCallEnabled`；遥控、UDP 或外部协议桥只实现
+  `isTransmitControlEnabled`。
+
+## 11. 公共源码导航
+
+| 内容 | 路径 |
+|---|---|
+| 定义与 `definePlugin()` | `packages/plugin-api/src/definition.ts` |
+| capability context | `packages/plugin-api/src/context.ts`、`capabilities.ts` |
+| utility hooks | `packages/plugin-api/src/hooks.ts` |
+| strategy runtime v2 | `packages/plugin-api/src/runtime.ts` |
+| context helper 接口 | `packages/plugin-api/src/helpers.ts` |
+| settings capability | `packages/plugin-api/src/settings.ts` |
+| logbook sync Provider | `packages/plugin-api/src/sync.ts` |
+| iframe Bridge | `packages/plugin-api/src/bridge.d.ts` |
+| 测试 helper | `packages/plugin-api/src/testing/index.ts` |
+| 脚手架模板 | `packages/create-tx5dr-plugin/src/index.ts` |
+| 完整 strategy 参考 | `packages/builtin-plugins/src/standard-qso/` |
+
+插件作者应以这些公开类型和实际导出为准。Host 内部 Coordinator、Manager、REST、
+WebSocket 与硬件实现不属于 Plugin API，不应被插件直接依赖。

--- a/packages/builtin-plugins/src/autocall-idle-frequency/index.ts
+++ b/packages/builtin-plugins/src/autocall-idle-frequency/index.ts
@@ -1,8 +1,8 @@
-import type {
-  AutoCallExecutionPlan,
-  AutoCallExecutionRequest,
-  PluginContext,
-  PluginDefinition,
+import {
+  definePlugin,
+  type AutoCallExecutionPlan,
+  type AutoCallExecutionRequest,
+  type PluginContext,
 } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
@@ -96,7 +96,7 @@ function configureIdleFrequency(
   };
 }
 
-export const autocallIdleFrequencyPlugin: PluginDefinition = {
+export const autocallIdleFrequencyPlugin = definePlugin({
   name: BUILTIN_AUTOCALL_IDLE_FREQUENCY_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
@@ -139,7 +139,7 @@ export const autocallIdleFrequencyPlugin: PluginDefinition = {
       return configureIdleFrequency(request, plan, ctx);
     },
   },
-};
+});
 
 export const autocallIdleFrequencyLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/callsign-filter/index.ts
+++ b/packages/builtin-plugins/src/callsign-filter/index.ts
@@ -1,4 +1,4 @@
-import type { PluginDefinition } from '@tx5dr/plugin-api';
+import { definePlugin } from '@tx5dr/plugin-api';
 import {
   evaluateCallsignFilter,
   evaluateDxccBlocklist,
@@ -48,7 +48,7 @@ const dxccEntityOptions = listDXCCEntities()
     value: String(entity.entityCode),
   }));
 
-export const callsignFilterPlugin: PluginDefinition = {
+export const callsignFilterPlugin = definePlugin({
   name: 'callsign-filter',
   version: '1.0.0',
   type: 'utility',
@@ -223,7 +223,7 @@ export const callsignFilterPlugin: PluginDefinition = {
       return filtered;
     },
   },
-};
+});
 
 export const callsignFilterLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/clublog-sync/index.ts
+++ b/packages/builtin-plugins/src/clublog-sync/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
-import type { PluginDefinition, PluginUIRequestContext } from '@tx5dr/plugin-api';
+import { definePlugin, type PluginUIRequestContext } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -42,14 +42,15 @@ function mergeDraftConfig(
   };
 }
 
-export const clublogSyncPlugin: PluginDefinition = {
+export const clublogSyncPlugin = definePlugin({
+  apiVersion: 2,
   name: BUILTIN_CLUBLOG_SYNC_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
   instanceScope: 'global',
   description: 'Upload QSO records to Club Log',
 
-  permissions: ['network'],
+  permissions: ['network', 'logbook:read', 'logbook:write', 'logbook:sync'],
 
   ui: {
     dir: 'ui',
@@ -156,7 +157,7 @@ export const clublogSyncPlugin: PluginDefinition = {
 
     ctx.log.info('Club Log sync provider registered');
   },
-};
+});
 
 export const clublogSyncLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/clublog-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/clublog-sync/provider.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { PluginContext } from '@tx5dr/plugin-api';
+import type { PluginContextFor } from '@tx5dr/plugin-api';
 import type { QSORecord } from '@tx5dr/contracts';
 import { ClubLogSyncProvider } from './provider.js';
 
@@ -218,3 +218,4 @@ describe('ClubLogSyncProvider', () => {
     ]);
   });
 });
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;

--- a/packages/builtin-plugins/src/clublog-sync/provider.ts
+++ b/packages/builtin-plugins/src/clublog-sync/provider.ts
@@ -1,6 +1,6 @@
 import type {
   LogbookSyncProvider,
-  PluginContext,
+  PluginContextFor,
   SyncAction,
   SyncDownloadResult,
   SyncFailure,
@@ -12,6 +12,8 @@ import type {
   SyncUploadProgress,
   SyncUploadResult,
 } from '@tx5dr/plugin-api';
+
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;
 import type { QSORecord } from '@tx5dr/contracts';
 import {
   convertQSOToADIF,

--- a/packages/builtin-plugins/src/index.ts
+++ b/packages/builtin-plugins/src/index.ts
@@ -10,7 +10,7 @@
  * host before calling each plugin's onLoad hook.
  */
 
-import type { PluginDefinition } from '@tx5dr/plugin-api';
+import type { AnyPluginDefinition } from '@tx5dr/plugin-api';
 
 // ===== Individual plugin imports =====
 
@@ -114,7 +114,7 @@ import {
 // ===== Shared types =====
 
 export interface BuiltinPluginEntry {
-  definition: PluginDefinition;
+  definition: AnyPluginDefinition;
   locales: Record<string, Record<string, string>>;
   /** standard-qso is always enabled; other built-ins default to disabled unless overridden */
   enabledByDefault: boolean;

--- a/packages/builtin-plugins/src/lotw-sync/index.ts
+++ b/packages/builtin-plugins/src/lotw-sync/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
-import type { PluginDefinition, PluginUIRequestContext } from '@tx5dr/plugin-api';
+import { definePlugin, type PluginUIRequestContext } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -103,14 +103,15 @@ function mergeDraftConfig(
  * Configuration is stored in the plugin's global KVStore keyed by callsign.
  * Certificate files are stored as JSON via ctx.files under certificates/.
  */
-export const lotwSyncPlugin: PluginDefinition = {
+export const lotwSyncPlugin = definePlugin({
+  apiVersion: 2,
   name: BUILTIN_LOTW_SYNC_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
   instanceScope: 'global',
   description: 'Sync QSO records with ARRL Logbook of The World',
 
-  permissions: ['network'],
+  permissions: ['network', 'logbook:read', 'logbook:write', 'logbook:sync'],
 
   ui: {
     dir: 'ui',
@@ -319,7 +320,7 @@ export const lotwSyncPlugin: PluginDefinition = {
 
     ctx.log.info('LoTW sync provider registered');
   },
-};
+});
 
 export const lotwSyncLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/lotw-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/lotw-sync/provider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { constants, createHash, generateKeyPairSync, publicDecrypt } from 'crypto';
 
-import type { PluginContext } from '@tx5dr/plugin-api';
+import type { PluginContextFor } from '@tx5dr/plugin-api';
 import type { QSORecord } from '@tx5dr/contracts';
 import { LoTWSyncProvider } from './provider.js';
 
@@ -1126,3 +1126,4 @@ describe('LoTWSyncProvider', () => {
     ]);
   });
 });
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;

--- a/packages/builtin-plugins/src/lotw-sync/provider.ts
+++ b/packages/builtin-plugins/src/lotw-sync/provider.ts
@@ -5,7 +5,7 @@ import { constants, createHash, privateEncrypt, randomUUID, X509Certificate } fr
 import { gzipSync } from 'zlib';
 import forge from 'node-forge';
 import type {
-  PluginContext,
+  PluginContextFor,
   LogbookSyncProvider,
   SyncAction,
   SyncTestResult,
@@ -19,6 +19,8 @@ import type {
   SyncUploadProgress,
   SyncDownloadProgress,
 } from '@tx5dr/plugin-api';
+
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;
 import type { QSORecord } from '@tx5dr/contracts';
 import {
   getBandFromFrequency,

--- a/packages/builtin-plugins/src/no-reply-memory-filter/index.ts
+++ b/packages/builtin-plugins/src/no-reply-memory-filter/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { FT8MessageType } from '@tx5dr/contracts';
 import { isUndecodedCallsignPlaceholder } from '@tx5dr/core';
 import type { ParsedFT8Message, QSORecord } from '@tx5dr/contracts';
-import type { PluginDefinition, PluginContext, QSOFailureInfo } from '@tx5dr/plugin-api';
+import { definePlugin, type PluginContext, type QSOFailureInfo } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -331,7 +331,7 @@ export function clearNoReplyMemoryEntry(ctx: PluginContext, callsignInput: unkno
   return { success: true };
 }
 
-export const noReplyMemoryFilterPlugin: PluginDefinition = {
+export const noReplyMemoryFilterPlugin = definePlugin({
   name: BUILTIN_NO_REPLY_MEMORY_FILTER_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
@@ -487,7 +487,7 @@ export const noReplyMemoryFilterPlugin: PluginDefinition = {
       ctx.log.debug('No-reply memory score cleared after QSO completion', { callsign });
     },
   },
-};
+});
 
 export const noReplyMemoryFilterLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/qrz-sync/index.ts
+++ b/packages/builtin-plugins/src/qrz-sync/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
-import type { PluginDefinition, PluginUIRequestContext } from '@tx5dr/plugin-api';
+import { definePlugin, type PluginUIRequestContext } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -35,14 +35,15 @@ function requireBoundCallsign(
  *
  * Configuration is stored in the plugin's global KVStore keyed by callsign.
  */
-export const qrzSyncPlugin: PluginDefinition = {
+export const qrzSyncPlugin = definePlugin({
+  apiVersion: 2,
   name: BUILTIN_QRZ_SYNC_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
   instanceScope: 'global',
   description: 'Sync QSO records with QRZ.com Logbook',
 
-  permissions: ['network'],
+  permissions: ['network', 'logbook:read', 'logbook:write', 'logbook:sync'],
 
   ui: {
     dir: 'ui',
@@ -103,7 +104,7 @@ export const qrzSyncPlugin: PluginDefinition = {
 
     ctx.log.info('QRZ.com sync provider registered');
   },
-};
+});
 
 export const qrzSyncLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/qrz-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/qrz-sync/provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { PluginContext } from '@tx5dr/plugin-api';
+import type { PluginContextFor } from '@tx5dr/plugin-api';
 import type { QSORecord } from '@tx5dr/contracts';
 import { QRZSyncProvider } from './provider.js';
 
@@ -179,3 +179,4 @@ describe('QRZSyncProvider', () => {
     }));
   });
 });
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;

--- a/packages/builtin-plugins/src/qrz-sync/provider.ts
+++ b/packages/builtin-plugins/src/qrz-sync/provider.ts
@@ -2,7 +2,7 @@
 // QRZSyncProvider — HTTP response handling requires any
 
 import type {
-  PluginContext,
+  PluginContextFor,
   LogbookSyncProvider,
   SyncAction,
   SyncTestResult,
@@ -12,6 +12,8 @@ import type {
   SyncUploadOptions,
   SyncFailure,
 } from '@tx5dr/plugin-api';
+
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;
 import type { QSORecord } from '@tx5dr/contracts';
 import {
   convertQSOToADIF,

--- a/packages/builtin-plugins/src/qso-udp-broadcast/index.ts
+++ b/packages/builtin-plugins/src/qso-udp-broadcast/index.ts
@@ -1,4 +1,7 @@
-import type { PluginContext, PluginDefinition } from '@tx5dr/plugin-api';
+import {
+  definePlugin,
+  type PluginContextFor,
+} from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -7,7 +10,10 @@ import { WsjtUdpSession, type UdpTarget, type WsjtUdpSettings } from './wsjtx-se
 export const BUILTIN_QSO_UDP_BROADCAST_PLUGIN_NAME = 'qso-udp-broadcast';
 
 const DEFAULT_TARGETS: UdpTarget[] = [{ host: '127.0.0.1', port: 2237 }];
-const sessions = new WeakMap<PluginContext, WsjtUdpSession>();
+type QsoUdpContext = PluginContextFor<readonly ['network', 'operator:transmit-control']>;
+// Cleanup receives the same context identity through a deliberately narrower
+// type, so session ownership is keyed by object identity rather than capability shape.
+const sessions = new WeakMap<object, WsjtUdpSession>();
 
 function readBoolean(value: unknown, fallback: boolean): boolean {
   return typeof value === 'boolean' ? value : fallback;
@@ -54,7 +60,7 @@ function readTargets(config: Readonly<Record<string, unknown>>): UdpTarget[] {
   }];
 }
 
-function readSettings(ctx: PluginContext): WsjtUdpSettings {
+function readSettings(ctx: QsoUdpContext): WsjtUdpSettings {
   const config = ctx.config;
   return {
     targets: readTargets(config),
@@ -77,7 +83,15 @@ function readSettings(ctx: PluginContext): WsjtUdpSettings {
   };
 }
 
-async function getOrStartSession(ctx: PluginContext): Promise<WsjtUdpSession> {
+function isRemoteTransmitControlEnabled(ctx: QsoUdpContext): boolean {
+  const settings = readSettings(ctx);
+  return settings.allowReplyRequests
+    || settings.allowHaltTxRequests
+    || settings.allowFreeTextRequests
+    || settings.allowConfigureRequests;
+}
+
+async function getOrStartSession(ctx: QsoUdpContext): Promise<WsjtUdpSession> {
   const existing = sessions.get(ctx);
   if (existing) return existing;
   const session = new WsjtUdpSession(ctx, readSettings(ctx));
@@ -86,12 +100,13 @@ async function getOrStartSession(ctx: PluginContext): Promise<WsjtUdpSession> {
   return session;
 }
 
-export const qsoUdpBroadcastPlugin: PluginDefinition = {
+export const qsoUdpBroadcastPlugin = definePlugin({
+  apiVersion: 2,
   name: BUILTIN_QSO_UDP_BROADCAST_PLUGIN_NAME,
   version: '2.0.0',
   type: 'utility',
   description: 'pluginDescription',
-  permissions: ['network'],
+  permissions: ['network', 'operator:transmit-control'],
 
   settings: {
     targets: {
@@ -232,35 +247,38 @@ export const qsoUdpBroadcastPlugin: PluginDefinition = {
   },
 
   async onUnload(ctx) {
-    const session = sessions.get(ctx);
+    // Timers and UDP sockets are host-owned and are already closed before this
+    // cleanup hook. Dropping the identity releases the remaining session state
+    // without reacquiring a revoked network capability.
     sessions.delete(ctx);
-    await session?.stop();
   },
+
+  isTransmitControlEnabled: isRemoteTransmitControlEnabled,
 
   hooks: {
     onConfigChange(_changes, ctx) {
       sessions.get(ctx)?.updateSettings(readSettings(ctx));
     },
     onTimer(timerId, ctx) {
-      void sessions.get(ctx)?.onTimer(timerId);
+      return sessions.get(ctx)?.onTimer(timerId);
     },
     onSlotActivity(event, ctx) {
-      void getOrStartSession(ctx)
+      return getOrStartSession(ctx)
         .then((session) => session.onSlotActivity(event))
         .catch((error) => ctx.log.error('WSJT-X UDP decode broadcast failed', error));
     },
     onFrequencyChange(state, ctx) {
-      void getOrStartSession(ctx)
+      return getOrStartSession(ctx)
         .then((session) => session.onFrequencyChange(state))
         .catch((error) => ctx.log.error('WSJT-X UDP frequency status broadcast failed', error));
     },
     onQSOComplete(record, ctx) {
-      void getOrStartSession(ctx)
+      return getOrStartSession(ctx)
         .then((session) => session.onQSOComplete(record))
         .catch((error) => ctx.log.error('WSJT-X UDP QSO broadcast failed', error));
     },
   },
-};
+});
 
 export const qsoUdpBroadcastLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/qso-udp-broadcast/wsjtx-session.test.ts
+++ b/packages/builtin-plugins/src/qso-udp-broadcast/wsjtx-session.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createMockContext,
   createMockNetworkControl,
+  createMockOperatorCommandPort,
   createMockParsedMessage,
   createMockSlotInfo,
   type MockNetworkControl,
@@ -10,6 +11,7 @@ import type { QSORecord } from '@tx5dr/plugin-api';
 import { decodeWsjtMessage, encodeWsjtMessage } from './wsjtx-codec.js';
 import { WsjtMessageType } from './wsjtx-types.js';
 import { WsjtUdpSession, type WsjtUdpSettings } from './wsjtx-session.js';
+import { qsoUdpBroadcastPlugin } from './index.js';
 
 function settings(overrides: Partial<WsjtUdpSettings> = {}): WsjtUdpSettings {
   return {
@@ -39,9 +41,19 @@ function sentBuffer(network: MockNetworkControl, index: number): Buffer {
 }
 
 describe('WSJT-X UDP session', () => {
+  it('uses generic transmit-control gating without declaring automatic calling', () => {
+    expect(qsoUdpBroadcastPlugin.isAutoCallEnabled).toBeUndefined();
+    expect(qsoUdpBroadcastPlugin.isTransmitControlEnabled?.({
+      config: { allowReplyRequests: true },
+    })).toBe(true);
+    expect(qsoUdpBroadcastPlugin.isTransmitControlEnabled?.({
+      config: { allowReplyRequests: false },
+    })).toBe(false);
+  });
+
   it('sends initial heartbeat/status and registers heartbeat timer', async () => {
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network });
+    const ctx = createMockContext({ permissions: ['network', 'operator:transmit-control'], network });
     const session = new WsjtUdpSession(ctx, settings());
 
     await session.start();
@@ -55,7 +67,7 @@ describe('WSJT-X UDP session', () => {
 
   it('negotiates schema from server heartbeat per target', async () => {
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network });
+    const ctx = createMockContext({ permissions: ['network', 'operator:transmit-control'], network });
     const session = new WsjtUdpSession(ctx, settings());
     await session.start();
 
@@ -73,7 +85,7 @@ describe('WSJT-X UDP session', () => {
 
   it('broadcasts decodes with raw frame confidence and replays them as old decodes', async () => {
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network });
+    const ctx = createMockContext({ permissions: ['network', 'operator:transmit-control'], network });
     const session = new WsjtUdpSession(ctx, settings());
     await session.start();
     network._sockets[0]._sent.length = 0;
@@ -103,9 +115,13 @@ describe('WSJT-X UDP session', () => {
   });
 
   it('keeps risky inbound commands denied until explicitly enabled', async () => {
-    const haltTransmission = vi.fn();
+    const submitCommand = vi.fn();
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network, operator: { haltTransmission } });
+    const ctx = createMockContext({
+      permissions: ['network', 'operator:transmit-control'],
+      network,
+      operatorCommands: createMockOperatorCommandPort(submitCommand),
+    });
     const session = new WsjtUdpSession(ctx, settings());
     await session.start();
 
@@ -114,13 +130,17 @@ describe('WSJT-X UDP session', () => {
       { address: '127.0.0.1', port: 2237 },
     );
 
-    expect(haltTransmission).not.toHaveBeenCalled();
+    expect(submitCommand).not.toHaveBeenCalled();
   });
 
   it('maps allowed FreeText requests to operator control', async () => {
-    const sendFreeText = vi.fn();
+    const submitCommand = vi.fn();
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network, operator: { sendFreeText } });
+    const ctx = createMockContext({
+      permissions: ['network', 'operator:transmit-control'],
+      network,
+      operatorCommands: createMockOperatorCommandPort(submitCommand),
+    });
     const session = new WsjtUdpSession(ctx, settings({ allowFreeTextRequests: true }));
     await session.start();
 
@@ -129,13 +149,17 @@ describe('WSJT-X UDP session', () => {
       { address: '127.0.0.1', port: 2237 },
     );
 
-    expect(sendFreeText).toHaveBeenCalledWith('TNX 73');
+    expect(submitCommand).toHaveBeenCalledWith({ type: 'send-free-text', text: 'TNX 73' });
   });
 
   it('uses the decoded slotPack cycle when handling remote Reply requests', async () => {
-    const replyToDecode = vi.fn();
+    const submitCommand = vi.fn();
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network, operator: { replyToDecode } });
+    const ctx = createMockContext({
+      permissions: ['network', 'operator:transmit-control'],
+      network,
+      operatorCommands: createMockOperatorCommandPort(submitCommand),
+    });
     const session = new WsjtUdpSession(ctx, settings({ allowReplyRequests: true }));
     await session.start();
 
@@ -175,17 +199,21 @@ describe('WSJT-X UDP session', () => {
       { address: '127.0.0.1', port: 2237 },
     );
 
-    expect(replyToDecode).toHaveBeenCalledTimes(1);
-    expect(replyToDecode.mock.calls[0][0].lastMessage.slotInfo).toMatchObject({
+    expect(submitCommand).toHaveBeenCalledTimes(1);
+    expect(submitCommand.mock.calls[0][0]).toMatchObject({
+      type: 'reply-to-decode',
+      lastMessage: { slotInfo: {
       id: 'slot-15000',
       startMs: 15_000,
       cycleNumber: 1,
+      } },
     });
   });
 
   it('sends Clear then Status with the new dial frequency on frequency changes', async () => {
     const network = createMockNetworkControl();
     const ctx = createMockContext({
+      permissions: ['network', 'operator:transmit-control'],
       network,
       radio: { frequency: 14_074_000 },
     });
@@ -215,7 +243,7 @@ describe('WSJT-X UDP session', () => {
 
   it('clears old decode history and deduplicates repeated frequency changes', async () => {
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network });
+    const ctx = createMockContext({ permissions: ['network', 'operator:transmit-control'], network });
     const session = new WsjtUdpSession(ctx, settings());
     await session.start();
     network._sockets[0]._sent.length = 0;
@@ -257,7 +285,7 @@ describe('WSJT-X UDP session', () => {
 
   it('sends Type 5, Type 12 and legacy raw ADIF on QSO completion', async () => {
     const network = createMockNetworkControl();
-    const ctx = createMockContext({ network });
+    const ctx = createMockContext({ permissions: ['network', 'operator:transmit-control'], network });
     const session = new WsjtUdpSession(ctx, settings());
     await session.start();
     network._sockets[0]._sent.length = 0;

--- a/packages/builtin-plugins/src/qso-udp-broadcast/wsjtx-session.ts
+++ b/packages/builtin-plugins/src/qso-udp-broadcast/wsjtx-session.ts
@@ -1,4 +1,4 @@
-import type { FrequencyChangeState, ParsedFT8Message, PluginContext, SlotActivityEvent, SlotInfo, QSORecord } from '@tx5dr/plugin-api';
+import type { FrequencyChangeState, ParsedFT8Message, PluginContextFor, SlotActivityEvent, SlotInfo, QSORecord } from '@tx5dr/plugin-api';
 import { FT8MessageType } from '@tx5dr/plugin-api';
 import { isUndecodedCallsignPlaceholder } from '@tx5dr/core';
 import {
@@ -12,6 +12,8 @@ import {
 import { decodeWsjtMessage, encodeWsjtMessage } from './wsjtx-codec.js';
 import { WSJTX_HEARTBEAT_SECONDS, WSJTX_UDP_SCHEMA, type WsjtDecodeMessage, type WsjtMessage, type WsjtStatusMessage } from './wsjtx-types.js';
 import { isRemoteMessageAllowed, logRemoteDenied, type RemotePolicySettings } from './remote-policy.js';
+
+type PluginContext = PluginContextFor<readonly ['network', 'operator:transmit-control']>;
 
 export interface UdpTarget {
   host: string;
@@ -50,10 +52,6 @@ export class WsjtUdpSession {
   }
 
   async start(): Promise<void> {
-    if (!this.ctx.network?.udp) {
-      this.ctx.log.warn('WSJT-X UDP disabled: host network UDP API is unavailable');
-      return;
-    }
     this.socket = this.ctx.network.udp.createSocket({ type: 'udp4', reuseAddr: true, broadcast: true });
     this.socket.onError((error) => this.ctx.log.warn('WSJT-X UDP socket error', { error: error.message }));
     this.socket.onMessage((data, remote) => this.handleDatagram(data, remote).catch((error) => {
@@ -221,33 +219,38 @@ export class WsjtUdpSession {
     switch (message.kind) {
       case 'clear':
         this.decodeHistory = [];
-        this.ctx.operator.clearDecodes(message.window);
+        await this.submitOperatorCommand({ type: 'clear-decodes', window: message.window });
         break;
       case 'replay':
         await this.replayDecodes();
         break;
       case 'reply':
-        this.handleReply(message);
+        await this.handleReply(message);
         break;
       case 'halt-tx':
-        this.ctx.operator.haltTransmission({ autoOnly: message.autoTxOnly });
+        await this.submitOperatorCommand({
+          type: message.autoTxOnly ? 'stop-automation' : 'remove-contribution',
+        });
         break;
       case 'free-text':
-        if (message.send) this.ctx.operator.sendFreeText(message.text || undefined);
-        else this.ctx.operator.setFreeText(message.text);
+        await this.submitOperatorCommand(message.send
+          ? { type: 'send-free-text', text: message.text || undefined }
+          : { type: 'set-free-text', text: message.text });
         break;
       case 'location':
-        this.ctx.operator.setTemporaryLocation(message.location);
+        await this.submitOperatorCommand({ type: 'set-temporary-location', location: message.location });
         break;
       case 'highlight-callsign':
-        this.handleHighlight(message);
+        await this.handleHighlight(message);
         break;
       case 'switch-configuration':
         this.ctx.log.warn('WSJT-X UDP SwitchConfiguration is parsed but unsupported by TX-5DR host', { configurationName: message.configurationName });
         break;
       case 'configure':
         this.ctx.log.info('WSJT-X UDP Configure received; applying supported fields only', { mode: message.mode, rxDf: message.rxDf, dxCall: message.dxCall, dxGrid: message.dxGrid, generateMessages: message.generateMessages });
-        if (message.dxCall) this.ctx.operator.call(message.dxCall);
+        if (message.dxCall) {
+          await this.submitOperatorCommand({ type: 'request-call', callsign: message.dxCall });
+        }
         break;
       case 'close':
         this.ctx.log.warn('WSJT-X UDP Close request received; closing only the plugin UDP session');
@@ -265,7 +268,7 @@ export class WsjtUdpSession {
     }
   }
 
-  private handleReply(message: Extract<WsjtMessage, { kind: 'reply' }>): void {
+  private async handleReply(message: Extract<WsjtMessage, { kind: 'reply' }>): Promise<void> {
     const match = this.decodeHistory.find((entry) => isDecodeMatch(entry.wsjt, message));
     if (!match) {
       this.ctx.log.warn('WSJT-X UDP Reply ignored: no matching decode in history', { message: message.message });
@@ -286,7 +289,8 @@ export class WsjtUdpSession {
       return;
     }
     if (callsign) {
-      this.ctx.operator.replyToDecode({
+      await this.submitOperatorCommand({
+        type: 'reply-to-decode',
         callsign,
         lastMessage: {
           message: { snr: match.wsjt.snr, dt: match.wsjt.deltaTime, freq: match.wsjt.deltaFrequency, message: match.wsjt.message, confidence: match.wsjt.lowConfidence ? 0.5 : 1 },
@@ -297,7 +301,7 @@ export class WsjtUdpSession {
     }
   }
 
-  private handleHighlight(message: Extract<WsjtMessage, { kind: 'highlight-callsign' }>): void {
+  private async handleHighlight(message: Extract<WsjtMessage, { kind: 'highlight-callsign' }>): Promise<void> {
     if (message.callsign === 'CLEARALL!') {
       this.highlightRules.clear();
     } else if (this.highlightRules.size >= this.settings.maxHighlightRules && !this.highlightRules.has(message.callsign)) {
@@ -306,12 +310,23 @@ export class WsjtUdpSession {
     } else {
       this.highlightRules.set(message.callsign, message);
     }
-    this.ctx.operator.highlightCallsign({
+    await this.submitOperatorCommand({
+      type: 'highlight-callsign',
       callsign: message.callsign,
       background: colorToCss(message.backgroundColor),
       foreground: colorToCss(message.foregroundColor),
       lastOnly: message.highlightLast,
     });
+  }
+
+  private async submitOperatorCommand(
+    command: import('@tx5dr/plugin-api').PluginOperatorCommand,
+  ): Promise<void> {
+    const port = this.ctx.operatorCommands;
+    if (!port) {
+      throw new Error('Host operator command capability is unavailable');
+    }
+    await port.submit(command);
   }
 
   private async replayDecodes(): Promise<void> {

--- a/packages/builtin-plugins/src/scheduled-band-switcher/index.test.ts
+++ b/packages/builtin-plugins/src/scheduled-band-switcher/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createMockContext } from '@tx5dr/plugin-api/testing';
-import type { CapabilityList, WriteCapabilityPayload } from '@tx5dr/contracts';
+import type { PluginRadioCommand } from '@tx5dr/plugin-api';
+import type { CapabilityList } from '@tx5dr/contracts';
 import { scheduledBandSwitcherTestables } from './index.js';
 
 function createTunerCapabilitySnapshot(options: {
@@ -55,6 +56,7 @@ function createTunerCapabilitySnapshot(options: {
 describe('scheduled-band-switcher', () => {
   it('selects a frequency from an active schedule window', () => {
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: {
         bandScheduleEntries: [
           { enabled: true, days: 'thu', startTime: '08:00', endTime: '10:00', frequencyMhz: 14.074 },
@@ -66,16 +68,40 @@ describe('scheduled-band-switcher', () => {
 
   it('rotates through configured frequencies by interval', () => {
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: { rotationFrequenciesMhz: ['14.074', '7.074'], rotationIntervalMinutes: 30 },
     });
-    expect(scheduledBandSwitcherTestables.getRotationTargetFrequency(ctx, new Date(2026, 0, 1, 8, 0))).toBe(14_074_000);
+    const first = new Date(2026, 0, 1, 8, 0);
+    expect(scheduledBandSwitcherTestables.getRotationTargetFrequency(ctx, first)).toBe(14_074_000);
+    scheduledBandSwitcherTestables.commitRotationTarget(ctx, 14_074_000, first);
     expect(scheduledBandSwitcherTestables.getRotationTargetFrequency(ctx, new Date(2026, 0, 1, 8, 10))).toBeNull();
     expect(scheduledBandSwitcherTestables.getRotationTargetFrequency(ctx, new Date(2026, 0, 1, 8, 31))).toBe(7_074_000);
   });
 
-  it('skips frequency changes while an operator is busy', async () => {
-    const setCalls: number[] = [];
+  it('does not advance rotation state when the host rejects a busy radio', async () => {
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
+      config: {
+        bandSwitchEnabled: true,
+        bandSwitchMode: 'rotation',
+        rotationFrequenciesMhz: ['14.074', '7.074'],
+        rotationIntervalMinutes: 30,
+      },
+      radio: { frequency: 3_573_000, isConnected: true },
+      radioCommands: { submit: async () => { throw new Error('physical transmitter is active'); } },
+      operator: { getOtherOperators: () => [] },
+    });
+    const now = new Date(2026, 0, 1, 8, 0);
+
+    await expect(scheduledBandSwitcherTestables.runBandSwitchCheck(ctx, now))
+      .rejects.toThrow('physical transmitter is active');
+    expect(scheduledBandSwitcherTestables.getRotationTargetFrequency(ctx, now)).toBe(14_074_000);
+  });
+
+  it('skips frequency changes while an operator is busy', async () => {
+    const commands: PluginRadioCommand[] = [];
+    const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: {
         bandSwitchEnabled: true,
         bandSwitchMode: 'schedule',
@@ -83,7 +109,8 @@ describe('scheduled-band-switcher', () => {
           { enabled: true, days: 'thu', startTime: '08:00', endTime: '10:00', frequencyMhz: 14.074 },
         ],
       },
-      radio: { frequency: 7_074_000, isConnected: true, setFrequency: async (freq) => { setCalls.push(freq); } },
+      radio: { frequency: 7_074_000, isConnected: true },
+      radioCommands: { submit: async (command) => { commands.push(command); } },
       operator: {
         getOtherOperators: () => [{
           id: 'op-1',
@@ -98,12 +125,13 @@ describe('scheduled-band-switcher', () => {
     });
 
     await scheduledBandSwitcherTestables.runBandSwitchCheck(ctx, new Date(2026, 0, 1, 9, 0));
-    expect(setCalls).toEqual([]);
+    expect(commands).toEqual([]);
   });
 
   it('sets the radio frequency when idle and connected', async () => {
-    const setCalls: number[] = [];
+    const commands: PluginRadioCommand[] = [];
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: {
         bandSwitchEnabled: true,
         bandSwitchMode: 'schedule',
@@ -111,19 +139,20 @@ describe('scheduled-band-switcher', () => {
           { enabled: true, days: 'thu', startTime: '08:00', endTime: '10:00', frequencyMhz: 14.074 },
         ],
       },
-      radio: { frequency: 7_074_000, isConnected: true, setFrequency: async (freq) => { setCalls.push(freq); } },
+      radio: { frequency: 7_074_000, isConnected: true },
+      radioCommands: { submit: async (command) => { commands.push(command); } },
       operator: { getOtherOperators: () => [] },
     });
 
     await scheduledBandSwitcherTestables.runBandSwitchCheck(ctx, new Date(2026, 0, 1, 9, 0));
-    expect(setCalls).toEqual([14_074_000]);
+    expect(commands).toEqual([{ type: 'switch-band', frequency: 14_074_000, autoTune: false }]);
   });
 
   it('enables the tuner and triggers one tune after a successful switch when configured', async () => {
-    const setCalls: number[] = [];
-    const writes: WriteCapabilityPayload[] = [];
+    const commands: PluginRadioCommand[] = [];
     const snapshot = createTunerCapabilitySnapshot({ tunerEnabled: false });
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: {
         bandSwitchEnabled: true,
         bandSwitchMode: 'schedule',
@@ -135,31 +164,26 @@ describe('scheduled-band-switcher', () => {
       radio: {
         frequency: 7_074_000,
         isConnected: true,
-        setFrequency: async (freq) => { setCalls.push(freq); },
-        capabilities: {
-          getSnapshot: () => snapshot,
-          getState: (id) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
-          refresh: async () => snapshot,
-          write: async (payload) => { writes.push(payload); },
-        },
       },
+      radioCapabilities: {
+        getSnapshot: () => snapshot,
+        getState: (id) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
+        refresh: async () => snapshot,
+      },
+      radioCommands: { submit: async (command) => { commands.push(command); } },
       operator: { getOtherOperators: () => [] },
     });
 
     await scheduledBandSwitcherTestables.runBandSwitchCheck(ctx, new Date(2026, 0, 1, 9, 0));
 
-    expect(setCalls).toEqual([14_074_000]);
-    expect(writes).toEqual([
-      { id: 'tuner_switch', value: true },
-      { id: 'tuner_tune', action: true },
-    ]);
+    expect(commands).toEqual([{ type: 'switch-band', frequency: 14_074_000, autoTune: true }]);
   });
 
   it('skips auto tuning when tuner capabilities are unavailable', async () => {
-    const setCalls: number[] = [];
-    const writes: WriteCapabilityPayload[] = [];
+    const commands: PluginRadioCommand[] = [];
     const snapshot = createTunerCapabilitySnapshot({ tuneSupported: false });
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: {
         bandSwitchEnabled: true,
         bandSwitchMode: 'schedule',
@@ -171,27 +195,26 @@ describe('scheduled-band-switcher', () => {
       radio: {
         frequency: 7_074_000,
         isConnected: true,
-        setFrequency: async (freq) => { setCalls.push(freq); },
-        capabilities: {
-          getSnapshot: () => snapshot,
-          getState: (id) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
-          refresh: async () => snapshot,
-          write: async (payload) => { writes.push(payload); },
-        },
       },
+      radioCapabilities: {
+        getSnapshot: () => snapshot,
+        getState: (id) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
+        refresh: async () => snapshot,
+      },
+      radioCommands: { submit: async (command) => { commands.push(command); } },
       operator: { getOtherOperators: () => [] },
     });
 
     await scheduledBandSwitcherTestables.runBandSwitchCheck(ctx, new Date(2026, 0, 1, 9, 0));
 
-    expect(setCalls).toEqual([14_074_000]);
-    expect(writes).toEqual([]);
+    expect(commands).toEqual([{ type: 'switch-band', frequency: 14_074_000, autoTune: false }]);
   });
 
   it('does not auto tune when no frequency switch is needed', async () => {
-    const writes: WriteCapabilityPayload[] = [];
+    const commands: PluginRadioCommand[] = [];
     const snapshot = createTunerCapabilitySnapshot();
     const ctx = createMockContext({
+      permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
       config: {
         bandSwitchEnabled: true,
         bandSwitchMode: 'schedule',
@@ -203,19 +226,20 @@ describe('scheduled-band-switcher', () => {
       radio: {
         frequency: 14_074_000,
         isConnected: true,
-        setFrequency: async () => { throw new Error('setFrequency should not be called'); },
-        capabilities: {
-          getSnapshot: () => snapshot,
-          getState: (id) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
-          refresh: async () => snapshot,
-          write: async (payload) => { writes.push(payload); },
-        },
       },
+      radioCapabilities: {
+        getSnapshot: () => snapshot,
+        getState: (id) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
+        refresh: async () => snapshot,
+      },
+      radioCommands: { submit: async (command) => {
+        commands.push(command);
+      } },
       operator: { getOtherOperators: () => [] },
     });
 
     await scheduledBandSwitcherTestables.runBandSwitchCheck(ctx, new Date(2026, 0, 1, 9, 0));
 
-    expect(writes).toEqual([]);
+    expect(commands).toEqual([]);
   });
 });

--- a/packages/builtin-plugins/src/scheduled-band-switcher/index.ts
+++ b/packages/builtin-plugins/src/scheduled-band-switcher/index.ts
@@ -1,5 +1,9 @@
 import type { CapabilityList, CapabilityState } from '@tx5dr/contracts';
-import type { OtherOperatorSnapshot, PluginContext, PluginDefinition } from '@tx5dr/plugin-api';
+import {
+  definePlugin,
+  type OtherOperatorSnapshot,
+  type PluginContextFor,
+} from '@tx5dr/plugin-api';
 import {
   isScheduleDayActive,
   isTimeInScheduleRange,
@@ -32,8 +36,13 @@ type RotationState = {
   index: number;
   lastSwitchMs: number;
 };
+type BandSwitcherContext = PluginContextFor<readonly [
+  'radio:read',
+  'radio:control',
+  'radio:tuner-control',
+]>;
 
-function getSwitchMode(ctx: PluginContext): SwitchMode {
+function getSwitchMode(ctx: BandSwitcherContext): SwitchMode {
   return ctx.config.bandSwitchMode === 'rotation' ? 'rotation' : 'schedule';
 }
 
@@ -58,7 +67,7 @@ function getRotationFrequencies(value: unknown): number[] {
   return frequencies;
 }
 
-function getScheduledTargetFrequency(ctx: PluginContext, now = new Date()): number | null {
+function getScheduledTargetFrequency(ctx: BandSwitcherContext, now = new Date()): number | null {
   for (const row of getScheduleEntries(ctx.config.bandScheduleEntries)) {
     if (row.enabled === false) continue;
     const days = parseScheduleDays(row.days);
@@ -73,7 +82,7 @@ function getScheduledTargetFrequency(ctx: PluginContext, now = new Date()): numb
   return null;
 }
 
-function getRotationTargetFrequency(ctx: PluginContext, now = new Date()): number | null {
+function getRotationTargetFrequency(ctx: BandSwitcherContext, now = new Date()): number | null {
   const frequencies = getRotationFrequencies(ctx.config.rotationFrequenciesMhz);
   if (frequencies.length === 0) return null;
 
@@ -87,11 +96,14 @@ function getRotationTargetFrequency(ctx: PluginContext, now = new Date()): numbe
   }
 
   const nextIndex = (Number.isInteger(state.index) ? state.index + 1 : 0) % frequencies.length;
-  ctx.store.global.set(ROTATION_STATE_KEY, {
-    index: nextIndex,
-    lastSwitchMs: now.getTime(),
-  });
   return frequencies[nextIndex] ?? null;
+}
+
+function commitRotationTarget(ctx: BandSwitcherContext, frequency: number, now: Date): void {
+  const frequencies = getRotationFrequencies(ctx.config.rotationFrequenciesMhz);
+  const index = frequencies.indexOf(frequency);
+  if (index < 0) return;
+  ctx.store.global.set(ROTATION_STATE_KEY, { index, lastSwitchMs: now.getTime() });
 }
 
 function isOperatorBusy(operator: OtherOperatorSnapshot): boolean {
@@ -104,7 +116,7 @@ function isOperatorBusy(operator: OtherOperatorSnapshot): boolean {
   return automation.currentState !== 'TX6' || targetCallsign.length > 0;
 }
 
-function canSwitchRadio(ctx: PluginContext): boolean {
+function canSwitchRadio(ctx: BandSwitcherContext): boolean {
   if (!ctx.radio.isConnected) {
     ctx.log.debug('Scheduled band switch skipped because radio is not connected');
     return false;
@@ -136,22 +148,17 @@ function isWritableCapabilityAvailable(snapshot: CapabilityList, id: string): bo
     && state.availability !== 'unavailable';
 }
 
-async function autoTuneAfterSwitch(ctx: PluginContext): Promise<void> {
-  if (ctx.config.autoTuneAfterSwitchEnabled !== true) return;
+async function shouldAutoTuneAfterSwitch(ctx: BandSwitcherContext): Promise<boolean> {
+  if (ctx.config.autoTuneAfterSwitchEnabled !== true) return false;
   if (!ctx.radio.isConnected) {
     ctx.log.debug('Scheduled band switch auto tune skipped because radio is not connected');
-    return;
+    return false;
   }
 
-  let snapshot: CapabilityList;
-  try {
-    snapshot = await ctx.radio.capabilities.refresh();
-  } catch (error) {
-    ctx.log.warn('Scheduled band switch auto tune skipped because radio capabilities could not be refreshed', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return;
-  }
+  // Capability refresh performs radio I/O and must not run outside the Host's
+  // physical-idle fence. Use the cached projection here; the Host revalidates
+  // the writable capabilities inside the composite switch-band transaction.
+  const snapshot: CapabilityList = ctx.radioCapabilities.getSnapshot();
 
   const hasTunerSwitch = isWritableCapabilityAvailable(snapshot, TUNER_SWITCH_CAPABILITY_ID);
   const hasManualTune = isWritableCapabilityAvailable(snapshot, TUNER_TUNE_CAPABILITY_ID);
@@ -160,24 +167,12 @@ async function autoTuneAfterSwitch(ctx: PluginContext): Promise<void> {
       tunerSwitch: hasTunerSwitch,
       tunerTune: hasManualTune,
     });
-    return;
+    return false;
   }
-
-  try {
-    const tunerSwitch = getCapabilityState(snapshot, TUNER_SWITCH_CAPABILITY_ID);
-    if (tunerSwitch?.value !== true) {
-      await ctx.radio.capabilities.write({ id: TUNER_SWITCH_CAPABILITY_ID, value: true });
-    }
-    await ctx.radio.capabilities.write({ id: TUNER_TUNE_CAPABILITY_ID, action: true });
-    ctx.log.info('Scheduled band switch auto tune triggered');
-  } catch (error) {
-    ctx.log.warn('Scheduled band switch auto tune failed', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  return true;
 }
 
-function configureTimer(ctx: PluginContext): void {
+function configureTimer(ctx: BandSwitcherContext): void {
   if (ctx.config.bandSwitchEnabled === true) {
     ctx.timers.set(TIMER_ID, TIMER_INTERVAL_MS);
     return;
@@ -185,16 +180,18 @@ function configureTimer(ctx: PluginContext): void {
   ctx.timers.clear(TIMER_ID);
 }
 
-async function runBandSwitchCheck(ctx: PluginContext, now = new Date()): Promise<void> {
+async function runBandSwitchCheck(ctx: BandSwitcherContext, now = new Date()): Promise<void> {
   if (ctx.config.bandSwitchEnabled !== true) return;
   if (!canSwitchRadio(ctx)) return;
 
-  const targetFrequency = getSwitchMode(ctx) === 'rotation'
+  const switchMode = getSwitchMode(ctx);
+  const targetFrequency = switchMode === 'rotation'
     ? getRotationTargetFrequency(ctx, now)
     : getScheduledTargetFrequency(ctx, now);
   if (!targetFrequency) return;
 
   if (Math.abs(ctx.radio.frequency - targetFrequency) <= FREQUENCY_TOLERANCE_HZ) {
+    if (switchMode === 'rotation') commitRotationTarget(ctx, targetFrequency, now);
     return;
   }
 
@@ -203,16 +200,23 @@ async function runBandSwitchCheck(ctx: PluginContext, now = new Date()): Promise
     targetFrequency,
     mode: getSwitchMode(ctx),
   });
-  await ctx.radio.setFrequency(targetFrequency);
-  await autoTuneAfterSwitch(ctx);
+  const autoTune = await shouldAutoTuneAfterSwitch(ctx);
+  await ctx.radioCommands.submit({
+    type: 'switch-band',
+    frequency: targetFrequency,
+    autoTune,
+  });
+  if (switchMode === 'rotation') commitRotationTarget(ctx, targetFrequency, now);
+  if (autoTune) ctx.log.info('Scheduled band switch auto tune triggered');
 }
 
-export const scheduledBandSwitcherPlugin: PluginDefinition = {
+export const scheduledBandSwitcherPlugin = definePlugin({
+  apiVersion: 2,
   name: 'scheduled-band-switcher',
   version: '1.0.0',
   type: 'utility',
   instanceScope: 'global',
-  permissions: ['radio:read', 'radio:control'],
+  permissions: ['radio:read', 'radio:control', 'radio:tuner-control'],
   description: 'Switch the station radio frequency from a global schedule or rotation list',
 
   settings: {
@@ -291,7 +295,7 @@ export const scheduledBandSwitcherPlugin: PluginDefinition = {
       });
     },
   },
-};
+});
 
 export const scheduledBandSwitcherLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,
@@ -302,7 +306,8 @@ export const scheduledBandSwitcherLocales: Record<string, Record<string, string>
 export const scheduledBandSwitcherTestables = {
   getScheduledTargetFrequency,
   getRotationTargetFrequency,
+  commitRotationTarget,
   isOperatorBusy,
   runBandSwitchCheck,
-  autoTuneAfterSwitch,
+  shouldAutoTuneAfterSwitch,
 };

--- a/packages/builtin-plugins/src/scheduled-cq-autocall/index.test.ts
+++ b/packages/builtin-plugins/src/scheduled-cq-autocall/index.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { createMockContext } from '@tx5dr/plugin-api/testing';
+import { createMockContext, createMockOperatorCommandPort } from '@tx5dr/plugin-api/testing';
 import { scheduledCqAutocallTestables } from './index.js';
 
 describe('scheduled-cq-autocall', () => {
+  const startCommands = (onStart: () => void) => createMockOperatorCommandPort((command) => {
+    if (command.type === 'start-automation') onStart();
+  });
+
   it('finds a due schedule key for a matching local minute', () => {
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqTasks: [{ id: 'morning', enabled: true, days: 'thu', time: '08:30' }],
       },
@@ -15,14 +20,15 @@ describe('scheduled-cq-autocall', () => {
   it('starts transmitting once per matching schedule minute', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqTasks: [{ id: 'morning', enabled: true, days: 'thu', time: '08:30' }],
       },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push('start'),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
     const now = new Date(2026, 0, 1, 8, 30);
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, now);
@@ -33,6 +39,7 @@ describe('scheduled-cq-autocall', () => {
   it('uses only the current band schedule when per-band mode is enabled', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqPerBandEnabled: true,
@@ -44,9 +51,9 @@ describe('scheduled-cq-autocall', () => {
       },
       radio: { band: '20m' },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push('start'),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
 
     expect(scheduledCqAutocallTestables.getDueScheduleKey(ctx, new Date(2026, 0, 1, 8, 30))).toContain('band:20m');
@@ -58,6 +65,7 @@ describe('scheduled-cq-autocall', () => {
   it('does not inherit common schedules for an empty band in per-band mode', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqPerBandEnabled: true,
@@ -68,9 +76,9 @@ describe('scheduled-cq-autocall', () => {
       },
       radio: { band: '20m' },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push('start'),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
 
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 30));
@@ -81,15 +89,16 @@ describe('scheduled-cq-autocall', () => {
   it('starts transmitting at a fixed interval after the first full interval elapses', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqIntervalEnabled: true,
         scheduledCqIntervalMinutes: 10,
       },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push('start'),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
 
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 0));
@@ -104,6 +113,7 @@ describe('scheduled-cq-autocall', () => {
     const starts: string[] = [];
     let currentBand = '20m';
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqPerBandEnabled: true,
@@ -116,15 +126,15 @@ describe('scheduled-cq-autocall', () => {
       },
       radio: { band: currentBand },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push(`${currentBand}:start`),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push(`${currentBand}:start`); }),
     });
 
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 0));
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 10));
     currentBand = '40m';
-    (ctx.radio as any).band = currentBand;
+    (ctx.radio as { band: string }).band = currentBand;
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 10));
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 15));
 
@@ -134,6 +144,7 @@ describe('scheduled-cq-autocall', () => {
   it('skips per-band CQ when the current band is unknown', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqPerBandEnabled: true,
@@ -146,9 +157,9 @@ describe('scheduled-cq-autocall', () => {
       },
       radio: { band: 'unknown' },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push('start'),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
 
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 30));
@@ -160,6 +171,7 @@ describe('scheduled-cq-autocall', () => {
   it('supports fixed time and interval CQ together without double-starting at the same moment', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqTasks: [{ id: 'morning', enabled: true, days: 'thu', time: '08:30' }],
@@ -167,9 +179,9 @@ describe('scheduled-cq-autocall', () => {
         scheduledCqIntervalMinutes: 10,
       },
       operator: {
-        automation: { currentState: 'TX6', slots: {}, context: {} } as any,
-        startTransmitting: () => starts.push('start'),
+        automation: { currentState: 'TX6', slots: {}, context: {} },
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
 
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 20));
@@ -183,14 +195,15 @@ describe('scheduled-cq-autocall', () => {
   it('skips when the operator is not in pure standby', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqTasks: [{ id: 'morning', enabled: true, days: 'thu', time: '08:30' }],
       },
       operator: {
         isTransmitting: true,
-        startTransmitting: () => starts.push('start'),
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 30));
     expect(starts).toEqual([]);
@@ -199,6 +212,7 @@ describe('scheduled-cq-autocall', () => {
   it('skips interval CQ when the operator is not in pure standby', () => {
     const starts: string[] = [];
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control'],
       config: {
         scheduledCqEnabled: true,
         scheduledCqIntervalEnabled: true,
@@ -206,8 +220,8 @@ describe('scheduled-cq-autocall', () => {
       },
       operator: {
         isTransmitting: true,
-        startTransmitting: () => starts.push('start'),
       },
+      operatorCommands: startCommands(() => { starts.push('start'); }),
     });
 
     scheduledCqAutocallTestables.runScheduledCqCheck(ctx, new Date(2026, 0, 1, 8, 0));

--- a/packages/builtin-plugins/src/scheduled-cq-autocall/index.ts
+++ b/packages/builtin-plugins/src/scheduled-cq-autocall/index.ts
@@ -1,4 +1,4 @@
-import type { PluginContext, PluginDefinition } from '@tx5dr/plugin-api';
+import { definePlugin, type PluginContextFor } from '@tx5dr/plugin-api';
 import { isPureStandby } from '../_shared/autocall-utils.js';
 import {
   isSameScheduleMinute,
@@ -15,6 +15,7 @@ const TIMER_INTERVAL_MS = 15_000;
 const LAST_TRIGGER_KEY = 'lastScheduledCqTriggerKey';
 const LAST_INTERVAL_TRIGGER_MS_KEY = 'lastScheduledCqIntervalTriggerMs';
 const DEFAULT_INTERVAL_MINUTES = 30;
+type ScheduledCqContext = PluginContextFor<readonly ['operator:transmit-control']>;
 const SCHEDULED_CQ_BANDS = [
   '160m',
   '80m',
@@ -113,7 +114,7 @@ function getDueScheduleKeyForRows(
   return null;
 }
 
-function resolveScheduledCqConfig(ctx: PluginContext): ResolvedScheduledCqConfig {
+function resolveScheduledCqConfig(ctx: ScheduledCqContext): ResolvedScheduledCqConfig {
   if (ctx.config.scheduledCqPerBandEnabled === true) {
     const band = normalizeBandKey(ctx.radio.band);
     if (!band || band === 'unknown') {
@@ -142,7 +143,7 @@ function resolveScheduledCqConfig(ctx: PluginContext): ResolvedScheduledCqConfig
   };
 }
 
-function getDueScheduleKey(ctx: PluginContext, now = new Date()): string | null {
+function getDueScheduleKey(ctx: ScheduledCqContext, now = new Date()): string | null {
   const config = resolveScheduledCqConfig(ctx);
   return getDueScheduleKeyForRows(config.scheduleRows, config.scopeKey, now);
 }
@@ -154,7 +155,7 @@ function getIntervalStoreKey(config: ResolvedScheduledCqConfig): string {
 }
 
 function getDueIntervalKeyForConfig(
-  ctx: PluginContext,
+  ctx: ScheduledCqContext,
   config: ResolvedScheduledCqConfig,
   now = new Date(),
 ): string | null {
@@ -166,16 +167,16 @@ function getDueIntervalKeyForConfig(
   return `${config.scopeKey}:interval:${config.intervalMinutes}:${Math.floor(now.getTime() / intervalMs)}`;
 }
 
-function getDueIntervalKey(ctx: PluginContext, now = new Date()): string | null {
+function getDueIntervalKey(ctx: ScheduledCqContext, now = new Date()): string | null {
   return getDueIntervalKeyForConfig(ctx, resolveScheduledCqConfig(ctx), now);
 }
 
-function markIntervalBaseline(ctx: PluginContext, config: ResolvedScheduledCqConfig, now = new Date()): void {
+function markIntervalBaseline(ctx: ScheduledCqContext, config: ResolvedScheduledCqConfig, now = new Date()): void {
   if (!config.intervalEnabled) return;
   ctx.store.operator.set(getIntervalStoreKey(config), now.getTime());
 }
 
-function ensureIntervalBaseline(ctx: PluginContext, config: ResolvedScheduledCqConfig, now = new Date()): void {
+function ensureIntervalBaseline(ctx: ScheduledCqContext, config: ResolvedScheduledCqConfig, now = new Date()): void {
   if (!config.intervalEnabled) return;
   const lastTriggerMs = ctx.store.operator.get<number>(getIntervalStoreKey(config), 0);
   if (!Number.isFinite(lastTriggerMs) || lastTriggerMs <= 0) {
@@ -183,7 +184,7 @@ function ensureIntervalBaseline(ctx: PluginContext, config: ResolvedScheduledCqC
   }
 }
 
-function configureTimer(ctx: PluginContext): void {
+function configureTimer(ctx: ScheduledCqContext): void {
   if (ctx.config.scheduledCqEnabled === true) {
     ctx.timers.set(TIMER_ID, TIMER_INTERVAL_MS);
     return;
@@ -191,7 +192,7 @@ function configureTimer(ctx: PluginContext): void {
   ctx.timers.clear(TIMER_ID);
 }
 
-function runScheduledCqCheck(ctx: PluginContext, now = new Date()): void {
+async function runScheduledCqCheck(ctx: ScheduledCqContext, now = new Date()): Promise<void> {
   if (ctx.config.scheduledCqEnabled !== true) return;
 
   const resolvedConfig = resolveScheduledCqConfig(ctx);
@@ -207,7 +208,7 @@ function runScheduledCqCheck(ctx: PluginContext, now = new Date()): void {
     }
 
     ctx.log.info('Scheduled CQ starting transmit automation', { dueKey: dueScheduleKey });
-    ctx.operator.startTransmitting();
+    await ctx.operatorCommands?.submit({ type: 'start-automation' });
     return;
   }
 
@@ -224,14 +225,15 @@ function runScheduledCqCheck(ctx: PluginContext, now = new Date()): void {
   }
 
   ctx.log.info('Scheduled CQ starting transmit automation', { dueKey: dueIntervalKey });
-  ctx.operator.startTransmitting();
+  await ctx.operatorCommands?.submit({ type: 'start-automation' });
 }
 
-function isScheduledCqAutoCallEnabled(ctx: PluginContext): boolean {
+function isScheduledCqAutoCallEnabled(ctx: { config: Readonly<Record<string, unknown>> }): boolean {
   return ctx.config.scheduledCqEnabled === true;
 }
 
-export const scheduledCqAutocallPlugin: PluginDefinition = {
+export const scheduledCqAutocallPlugin = definePlugin({
+  apiVersion: 2,
   name: 'scheduled-cq-autocall',
   version: '1.0.0',
   type: 'utility',
@@ -352,12 +354,12 @@ export const scheduledCqAutocallPlugin: PluginDefinition = {
     onConfigChange(_changes, ctx) {
       configureTimer(ctx);
     },
-    onTimer(timerId, ctx) {
+    async onTimer(timerId, ctx) {
       if (timerId !== TIMER_ID) return;
-      runScheduledCqCheck(ctx);
+      await runScheduledCqCheck(ctx);
     },
   },
-};
+});
 
 export const scheduledCqAutocallLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/snr-filter/index.ts
+++ b/packages/builtin-plugins/src/snr-filter/index.ts
@@ -1,4 +1,4 @@
-import type { PluginDefinition, ScoredCandidate } from '@tx5dr/plugin-api';
+import { definePlugin, type ScoredCandidate } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -18,7 +18,7 @@ const SNR_PRIORITY_SCORE_MULTIPLIER = 1000;
  *
  * 用户可以将此插件作为编写工具插件的参考范本。
  */
-export const snrFilterPlugin: PluginDefinition = {
+export const snrFilterPlugin = definePlugin({
   name: BUILTIN_SNR_FILTER_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
@@ -84,7 +84,7 @@ export const snrFilterPlugin: PluginDefinition = {
       return scored;
     },
   },
-};
+});
 
 /** 内置翻译，随插件一起编译进 bundle */
 export const snrFilterLocales: Record<string, Record<string, string>> = {

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
@@ -31,7 +31,6 @@ function createOperator(overrides: Partial<OperatorConfig> = {}): StandardQSOPlu
     },
     hasWorkedCallsign: vi.fn(async () => false),
     isTargetBeingWorkedByOthers: vi.fn(() => false),
-    recordQSOLog: vi.fn(async record => record),
     notifySlotsUpdated: vi.fn(),
     notifyStateChanged: vi.fn(),
   };
@@ -50,79 +49,117 @@ function createParsedMessage(rawMessage: string, overrides: Partial<ParsedFT8Mes
   };
 }
 
-function completedQSORecord(id = 'persisted-1') {
+function decisionMeta(overrides: Partial<{
+  epoch: number;
+  source: 'slot-auto' | 'late-decode';
+  isReDecision: boolean;
+  signal: AbortSignal;
+}> = {}) {
   return {
-    id,
-    callsign: 'JA1AAA',
-    frequency: 7_074_000,
-    mode: 'FT8',
-    startTime: 1,
-    messageHistory: [],
-    myCallsign: 'BG5DRB',
+    epoch: 1,
+    source: 'slot-auto' as const,
+    isReDecision: false,
+    signal: new AbortController().signal,
+    ...overrides,
   };
 }
 
-describe('StandardQSOPluginRuntime durable QSO lifecycle', () => {
-  it('keeps the final frame available while joining concurrent QSO persistence', async () => {
-    let resolvePersistence!: (record: ReturnType<typeof completedQSORecord>) => void;
+describe('StandardQSOPluginRuntime v2 decision lifecycle', () => {
+  it('returns QSO completion as a declarative effect without blocking the final frame', async () => {
     const operator = createOperator();
-    operator.recordQSOLog = vi.fn(() => new Promise((resolve) => {
-      resolvePersistence = resolve;
-    }));
     const runtime = new StandardQSOPluginRuntime(operator);
-    runtime.patchContext({ targetCallsign: 'JA1AAA' });
-    runtime.setState('TX4');
+    runtime.patchContext({
+      targetCallsign: 'JA1AAA',
+      targetGrid: 'PM95',
+      reportSent: -10,
+      reportReceived: -8,
+    });
+    await runtime.changeState('TX4');
 
-    const first = runtime.persistCompletedQSO(completedQSORecord('temporary-1'));
-    const second = runtime.persistCompletedQSO(completedQSORecord('temporary-2'));
-    await Promise.resolve();
+    const result = await runtime.decide([], decisionMeta());
 
-    expect(operator.recordQSOLog).toHaveBeenCalledTimes(1);
-    expect(runtime.getTransmitText()).toBe('JA1AAA BG5DRB RR73');
-    resolvePersistence(completedQSORecord());
-
-    await expect(first).resolves.toMatchObject({ id: 'persisted-1' });
-    await expect(second).resolves.toMatchObject({ id: 'persisted-1' });
-    await expect(runtime.persistCompletedQSO(completedQSORecord('temporary-3')))
-      .resolves.toMatchObject({ id: 'persisted-1' });
-    expect(operator.recordQSOLog).toHaveBeenCalledTimes(1);
+    expect(result.transmission).toBe('JA1AAA BG5DRB RR73');
+    expect(result.snapshot.currentState).toBe('TX4');
+    expect(result.qsoCompletion?.record).toMatchObject({
+      callsign: 'JA1AAA',
+      grid: 'PM95',
+      reportSent: '-10',
+      reportReceived: '-8',
+    });
+    expect(result.qsoCompletion?.lifecycleEpoch).toBe(
+      result.snapshot.qsoLifecycleEpoch,
+    );
   });
 
-  it('keeps the failed lifecycle stopped without starting a second persistence attempt', async () => {
-    const operator = createOperator();
-    operator.recordQSOLog = vi.fn().mockRejectedValue(new Error('disk full'));
-    const runtime = new StandardQSOPluginRuntime(operator);
+  it('holds a direct handoff until the previous QSO is durable, then starts a distinct lifecycle', async () => {
+    const runtime = new StandardQSOPluginRuntime(createOperator());
+    expect(runtime.requestCall('JA1AAA', undefined)).toBe(true);
+    runtime.patchContext({ reportSent: -10, reportReceived: -8 });
+    await runtime.changeState('TX4');
 
-    await expect(runtime.persistCompletedQSO(completedQSORecord())).rejects.toThrow('disk full');
-    expect(await runtime.decide([])).toEqual({ stop: true });
-    expect(runtime.getTransmitText()).toBeNull();
+    const first = await runtime.decide([
+      createParsedMessage('BG5DRB JA1AAA 73'),
+      createParsedMessage('BG5DRB JA2BBB PM95', { snr: -3 }),
+    ], decisionMeta());
 
-    runtime.requestCall('JA2BBB', undefined);
-    expect(runtime.getSnapshot().context?.targetCallsign).toBeUndefined();
-    expect(operator.recordQSOLog).toHaveBeenCalledTimes(1);
+    expect(first.qsoCompletion?.record.callsign).toBe('JA1AAA');
+    expect(first.snapshot.currentState).toBe('TX6');
+    expect(first.snapshot.context?.targetCallsign).toBeUndefined();
+
+    const blocked = await runtime.decide([
+      createParsedMessage('BG5DRB JA2BBB PM95', { snr: -3 }),
+    ], decisionMeta({ epoch: 2 }));
+    expect(blocked.snapshot.currentState).toBe('TX6');
+    expect(blocked.snapshot.context?.targetCallsign).toBeUndefined();
+
+    runtime.settleQSOCompletion({
+      lifecycleEpoch: first.qsoCompletion!.lifecycleEpoch,
+      recordId: first.qsoCompletion!.record.id,
+      status: 'committed',
+    });
+    const second = await runtime.decide([
+      createParsedMessage('BG5DRB JA2BBB PM95', { snr: -3 }),
+    ], decisionMeta({ epoch: 3 }));
+
+    expect(second.snapshot.currentState).toBe('TX2');
+    expect(second.snapshot.context?.targetCallsign).toBe('JA2BBB');
+    expect(second.snapshot.qsoLifecycleEpoch).toBeGreaterThan(
+      first.qsoCompletion!.lifecycleEpoch,
+    );
+
+    runtime.patchContext({ reportSent: -3, reportReceived: -6 });
+    await runtime.changeState('TX4');
+    const secondCompletion = await runtime.decide([], decisionMeta({ epoch: 4 }));
+    expect(secondCompletion.qsoCompletion?.record.callsign).toBe('JA2BBB');
+    expect(secondCompletion.qsoCompletion?.lifecycleEpoch).toBe(
+      second.snapshot.qsoLifecycleEpoch,
+    );
   });
 
-  it('rejects a duplicate requestCall for the already committed target', async () => {
-    const operator = createOperator();
-    const runtime = new StandardQSOPluginRuntime(operator);
-    runtime.patchContext({ targetCallsign: 'JA1AAA' });
+  it('produces a structured-cloneable checkpoint and restores speculative state', async () => {
+    const runtime = new StandardQSOPluginRuntime(createOperator());
+    runtime.requestCall('JA1AAA', undefined);
+    const checkpoint = structuredClone(runtime.checkpoint());
 
-    await runtime.persistCompletedQSO(completedQSORecord());
+    runtime.patchContext({ targetCallsign: 'JA2BBB', reportSent: -4 });
+    runtime.setState('TX5');
+    runtime.restore(checkpoint);
 
-    expect(runtime.requestCall('JA1AAA', undefined)).toBe(false);
-    expect(operator.recordQSOLog).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      currentState: 'TX1',
+      context: { targetCallsign: 'JA1AAA' },
+    });
   });
 
-  it('allows a new lifecycle only after the previous QSO context is cleared', async () => {
-    const operator = createOperator();
-    const runtime = new StandardQSOPluginRuntime(operator);
+  it('rejects an already-aborted decision before mutating runtime state', async () => {
+    const runtime = new StandardQSOPluginRuntime(createOperator());
+    const checkpoint = structuredClone(runtime.checkpoint());
+    const controller = new AbortController();
+    controller.abort();
 
-    await runtime.persistCompletedQSO(completedQSORecord('persisted-1'));
-    await runtime.persistCompletedQSO(completedQSORecord('duplicate'));
-    runtime.clearQSOContext();
-    await runtime.persistCompletedQSO(completedQSORecord('persisted-2'));
-
-    expect(operator.recordQSOLog).toHaveBeenCalledTimes(2);
+    await expect(runtime.decide([], decisionMeta({ signal: controller.signal })))
+      .rejects.toMatchObject({ name: 'AbortError' });
+    expect(runtime.checkpoint()).toEqual(checkpoint);
   });
 });
 
@@ -291,15 +328,15 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
     });
     runtime.setState('TX3');
 
-    await runtime.decide([parsedMessage]);
+    const decision = await runtime.decide([parsedMessage], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX5');
     expect(snapshot.slots?.TX5).toBe('EX8ABR BD4XYR 73');
-    expect(operator.recordQSOLog).toHaveBeenCalledWith(expect.objectContaining({
+    expect(decision.qsoCompletion?.record).toMatchObject({
       callsign: 'EX8ABR',
       myCallsign: 'BD4XYR',
-    }));
+    });
   });
 
   it('advances from TX3 when a portable Fox/Hound RR73 is clipped after the Fox callsign', async () => {
@@ -315,15 +352,15 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
     });
     runtime.setState('TX3');
 
-    await runtime.decide([parsedMessage]);
+    const decision = await runtime.decide([parsedMessage], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX5');
     expect(snapshot.slots?.TX5).toBe('EX8ABR BH5HIE 73');
-    expect(operator.recordQSOLog).toHaveBeenCalledWith(expect.objectContaining({
+    expect(decision.qsoCompletion?.record).toMatchObject({
       callsign: 'EX8ABR',
       myCallsign: 'BH5HIE',
-    }));
+    });
   });
 
   it('matches a portable Fox callsign response against a base target callsign', async () => {
@@ -338,7 +375,7 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
     });
     runtime.setState('TX1');
 
-    await runtime.decide([parsedMessage]);
+    await runtime.decide([parsedMessage], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX3');
@@ -357,7 +394,7 @@ describe('StandardQSOPluginRuntime partial-decode `<...>` handling', () => {
       slotId: 'slot-partial-rrr',
     });
 
-    await runtime.decide([parsedMessage]);
+    await runtime.decide([parsedMessage], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX6');
@@ -372,7 +409,7 @@ describe('StandardQSOPluginRuntime partial-decode `<...>` handling', () => {
       slotId: 'slot-partial-cq',
     });
 
-    await runtime.decide([parsedMessage]);
+    await runtime.decide([parsedMessage], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX6');

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
@@ -18,8 +18,10 @@ import {
     normalizeCallsign,
     type PluginLogger,
     StrategyDecision,
-    StrategyDecisionMeta,
+    StrategyDecisionMetaV2,
+    StrategyDecisionResult,
     StrategyRuntime,
+    StrategyRuntimeCheckpoint,
     StrategyRuntimeContext,
     StrategyRuntimeSnapshot,
     StrategyRuntimeSlotContentUpdate,
@@ -98,7 +100,6 @@ export interface StandardQSOPluginOperator {
     readonly config: StandardQSOOperatorConfig;
     hasWorkedCallsign(callsign: string, options?: { anyBand?: boolean }): Promise<boolean>;
     isTargetBeingWorkedByOthers(targetCallsign: string): boolean;
-    recordQSOLog(qsoRecord: QSORecord): Promise<QSORecord>;
     notifySlotsUpdated?(slots: OperatorSlots): void;
     notifyStateChanged?(state: string): void;
 }
@@ -195,6 +196,10 @@ async function trySwitchToDirectedProtocol(
         acceptFollowUpProtocol?: boolean;
     },
 ): Promise<StateHandleResult | null> {
+    if (strategy.hasUnsettledQSOCompletion()) {
+        strategy.logger.debug(`${options?.logPrefix ?? 'direct call'}: waiting for QSO durability before starting another lifecycle`);
+        return null;
+    }
     const excluded = (options?.excludeCallsigns ?? [])
         .filter((callsign): callsign is string => typeof callsign === 'string' && callsign.trim().length > 0);
     const myCallsign = strategy.context.config.myCallsign;
@@ -249,7 +254,7 @@ async function trySwitchToDirectedProtocol(
             strategy.clearPost73RetryContext(options.clearPost73Reason);
         }
         strategy.clearQSOContext();
-        strategy.context.targetCallsign = callsign;
+        strategy.beginQsoWithTarget(callsign, `${prefix}: directed protocol handoff`);
 
         if (msg.type === FT8MessageType.CALL) {
             strategy.logger.debug(`${prefix}: switching to direct call ${callsign} (SNR: ${directCall.snr})`);
@@ -412,7 +417,7 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             strategy.clearQSOContext();
 
                             // 切换到新呼号
-                            strategy.context.targetCallsign = newCallsign;
+                            strategy.beginQsoWithTarget(newCallsign, 'TX1 direct-call handoff');
 
                             // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
                             if (!strategy.restoreContext(newCallsign)) {
@@ -458,7 +463,7 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             strategy.clearQSOContext();
 
                             // 切换到新呼号
-                            strategy.context.targetCallsign = newCallsign;
+                            strategy.beginQsoWithTarget(newCallsign, 'TX1 signal-report handoff');
 
                             // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
                             if (!strategy.restoreContext(newCallsign)) {
@@ -728,30 +733,8 @@ const states: { [key in SlotsIndex]: StandardState } = {
         }
     },
     TX4: {
-        async onEnter(strategy: StandardQSOPluginRuntime) {
-            // 记录QSO日志
-            // 优先使用actualFrequency（包含音频偏移的精确频率）
-            // 如果actualFrequency无效（< 1MHz），则使用config.frequency（基础频率）
-            const frequency = (strategy.context.actualFrequency && strategy.context.actualFrequency > 1000000)
-                ? strategy.context.actualFrequency
-                : (strategy.context.config.frequency || 0);
-
-            const qsoRecord: QSORecord = {
-                id: Date.now().toString(),
-                callsign: strategy.context.targetCallsign!,
-                grid: strategy.context.targetGrid,
-                frequency: frequency,
-                mode: strategy.context.config.mode.name,
-                startTime: strategy.qsoStartTime || Date.now(),
-                endTime: Date.now(),
-                reportSent: strategy.context.reportSent?.toString(),
-                reportReceived: strategy.context.reportReceived?.toString(),
-                messageHistory: [],
-                comment: undefined,
-                myCallsign: strategy.context.config.myCallsign,
-                myGrid: strategy.context.config.myGrid
-            };
-            await strategy.persistCompletedQSO(qsoRecord);
+        onEnter(strategy: StandardQSOPluginRuntime) {
+            strategy.prepareCompletedQSOEffect();
         },
         async handle(strategy: StandardQSOPluginRuntime, messages: ParsedFT8Message[]): Promise<StateHandleResult> {
             // 首先检查是否收到对方的73
@@ -830,30 +813,8 @@ const states: { [key in SlotsIndex]: StandardState } = {
         }
     },
     TX5: {
-        async onEnter(strategy: StandardQSOPluginRuntime) {
-            // 记录QSO日志
-            // 优先使用actualFrequency（包含音频偏移的精确频率）
-            // 如果actualFrequency无效（< 1MHz），则使用config.frequency（基础频率）
-            const frequency = (strategy.context.actualFrequency && strategy.context.actualFrequency > 1000000)
-                ? strategy.context.actualFrequency
-                : (strategy.context.config.frequency || 0);
-
-            const qsoRecord: QSORecord = {
-                id: Date.now().toString(),
-                callsign: strategy.context.targetCallsign!,
-                grid: strategy.context.targetGrid,
-                frequency: frequency,
-                mode: strategy.context.config.mode.name,
-                startTime: strategy.qsoStartTime || Date.now(),
-                endTime: Date.now(),
-                reportSent: strategy.context.reportSent?.toString(),
-                reportReceived: strategy.context.reportReceived?.toString(),
-                messageHistory: [],
-                comment: undefined,
-                myCallsign: strategy.context.config.myCallsign,
-                myGrid: strategy.context.config.myGrid
-            };
-            await strategy.persistCompletedQSO(qsoRecord);
+        onEnter(strategy: StandardQSOPluginRuntime) {
+            strategy.prepareCompletedQSOEffect();
         },
         async handle(strategy: StandardQSOPluginRuntime, messages: ParsedFT8Message[]): Promise<StateHandleResult> {
             // 【修复】首先检查是否收到对方重发的RRR/RR73
@@ -1003,7 +964,11 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             }
 
                             strategy.logger.debug(`TX6: replying to CQ from ${callsign} (not worked, SNR: ${cqCall.snr}dB, by signal strength)`);
-                            strategy.context.targetCallsign = callsign;
+                            if (strategy.hasUnsettledQSOCompletion()) {
+                                strategy.logger.debug(`TX6: delaying CQ reply to ${callsign} until QSO durability settles`);
+                                continue;
+                            }
+                            strategy.beginQsoWithTarget(callsign, 'TX6 CQ reply');
 
                             // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
                             if (!strategy.restoreContext(callsign)) {
@@ -1049,8 +1014,29 @@ interface Post73RetryContext {
     reportSent?: number;
     reportReceived?: number;
     actualFrequency?: number;
-    persistedQSO?: QSORecord;
+    completedQSO?: QSORecord;
     expiresAt: number;
+}
+
+interface StandardQSOCheckpoint {
+    state: SlotsIndex;
+    slots: Slots;
+    context: Omit<QSOContext, 'config'>;
+    tx6MessageOverride: string;
+    lastConfigTx6MessageOverride?: string;
+    timeoutCycles: number;
+    callAttempts: number;
+    qsoStartTime?: number;
+    tx5TransmissionQueued: boolean;
+    completedQSORecord?: QSORecord;
+    pendingQSOCompletion?: {
+        record: QSORecord;
+        lifecycleEpoch: number;
+    };
+    qsoLifecycleEpoch: number;
+    post73RetryContext?: Post73RetryContext;
+    qsoContextHistory: Array<[string, CachedQSOContext]>;
+    foxHash?: string;
 }
 
 export class StandardQSOPluginRuntime implements StrategyRuntime {
@@ -1071,9 +1057,13 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
     public callAttempts: number = 0; // 呼叫尝试次数计数器（TX1状态专用）
     public qsoStartTime?: number; // QSO开始时间
     public tx5TransmissionQueued = false;
-    private qsoPersistencePromise?: Promise<QSORecord>;
-    private persistedQSO?: QSORecord;
-    private qsoPersistenceFailed = false;
+    private completedQSORecord?: QSORecord;
+    private pendingQSOCompletion?: {
+        record: QSORecord;
+        lifecycleEpoch: number;
+    };
+    private qsoLifecycleEpoch = 0;
+    private speculativeDecisionDepth = 0;
     public post73RetryContext?: Post73RetryContext;
 
     // QSO上下文历史缓存（呼号 -> 上下文）
@@ -1171,54 +1161,78 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
         // 调用新状态的onEnter
         const newState = states[this.state];
         if (newState.onEnter) {
-            try {
-                await newState.onEnter(this);
-            } catch (error) {
-                if (state === 'TX4' || state === 'TX5') {
-                    this.qsoPersistenceFailed = true;
-                    this.logger.error(`State ${state} failed to durably persist its completed QSO`, error);
-                }
-                throw error;
-            }
+            await newState.onEnter(this);
         }
     }
 
-    async persistCompletedQSO(qsoRecord: QSORecord): Promise<QSORecord> {
-        if (this.persistedQSO) {
-            this.logger.debug('Skipping duplicate QSO persistence within the current lifecycle', {
-                callsign: this.persistedQSO.callsign,
-                id: this.persistedQSO.id,
-            });
-            return this.persistedQSO;
-        }
-        if (this.qsoPersistencePromise) {
-            this.logger.debug('Joining the in-flight QSO persistence for the current lifecycle');
-            return this.qsoPersistencePromise;
+    prepareCompletedQSOEffect(): void {
+        if (this.completedQSORecord || !this.context.targetCallsign) {
+            return;
         }
 
-        const persistence = Promise.resolve()
-            .then(() => this.operator.recordQSOLog(qsoRecord))
-            .then((persisted) => {
-                this.persistedQSO = persisted;
-                this.qsoStartTime = undefined;
-                this.qsoPersistenceFailed = false;
-                return persisted;
-            })
-            .catch((error) => {
-                this.qsoPersistenceFailed = true;
-                throw error;
-            })
-            .finally(() => {
-                this.qsoPersistencePromise = undefined;
+        const now = Date.now();
+        const frequency = (this.context.actualFrequency && this.context.actualFrequency > 1_000_000)
+            ? this.context.actualFrequency
+            : (this.context.config.frequency || 0);
+        const record: QSORecord = {
+            id: now.toString(),
+            callsign: this.context.targetCallsign,
+            grid: this.context.targetGrid,
+            frequency,
+            mode: this.context.config.mode.name,
+            startTime: this.qsoStartTime || now,
+            endTime: now,
+            reportSent: this.context.reportSent?.toString(),
+            reportReceived: this.context.reportReceived?.toString(),
+            messageHistory: [],
+            comment: undefined,
+            myCallsign: this.context.config.myCallsign,
+            myGrid: this.context.config.myGrid,
+        };
+        this.completedQSORecord = record;
+        this.pendingQSOCompletion = {
+            record,
+            lifecycleEpoch: this.qsoLifecycleEpoch,
+        };
+    }
+
+    private beginQsoLifecycle(reason: string): void {
+        this.qsoLifecycleEpoch += 1;
+        this.completedQSORecord = undefined;
+        this.logger.debug('Started QSO lifecycle', {
+            epoch: this.qsoLifecycleEpoch,
+            reason,
+        });
+    }
+
+    hasUnsettledQSOCompletion(): boolean {
+        return this.completedQSORecord !== undefined;
+    }
+
+    beginQsoWithTarget(callsign: string, reason: string): void {
+        if (!callsignMatches(callsign, this.context.targetCallsign)) {
+            this.beginQsoLifecycle(reason);
+        }
+        this.context.targetCallsign = callsign;
+    }
+
+    settleQSOCompletion(settlement: import('@tx5dr/plugin-api').StrategyQSOCompletionSettlement): void {
+        if (settlement.lifecycleEpoch !== this.qsoLifecycleEpoch
+            || settlement.recordId !== this.completedQSORecord?.id) {
+            this.logger.debug('Ignored stale QSO completion settlement', {
+                currentEpoch: this.qsoLifecycleEpoch,
+                settledEpoch: settlement.lifecycleEpoch,
+                recordId: settlement.recordId,
+                status: settlement.status,
             });
-        this.qsoPersistencePromise = persistence;
-        return persistence;
+            return;
+        }
+        if (settlement.status === 'committed') {
+            this.completedQSORecord = undefined;
+        }
     }
 
     async handleReceivedAndDicideNext(messages: ParsedFT8Message[], options?: { isReDecision?: boolean }): Promise<StrategyDecision> {
-        if (this.qsoPersistencePromise || this.qsoPersistenceFailed) {
-            return { stop: true };
-        }
         const currentState = states[this.state];
 
         // 过滤掉发送者是我自己的消息；部分解码消息（含 `<...>` 占位符）绝不参与 QSO 决策
@@ -1281,13 +1295,12 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
     }
 
     handleTransmitSlot(): string | null {
-        // Durability gates completion side effects and future QSOs, not the
-        // time-critical final frame that is already due in this RF slot.
-        if (this.qsoPersistenceFailed) return null;
         return this.slots[this.state];
     }
 
     onTransmissionQueued(transmission: string): void {
+        // The host invokes this compatibility hook only after the physical
+        // frame reaches terminal success, never when encoding is merely queued.
         if (this.state === 'TX5' && transmission === this.slots.TX5) {
             this.tx5TransmissionQueued = true;
         }
@@ -1298,12 +1311,8 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
     }
 
     requestCall(callsign: string, lastMessage: { message: FrameMessage, slotInfo: SlotInfo } | undefined): boolean {
-        if (this.qsoPersistencePromise || this.qsoPersistenceFailed) {
-            this.logger.warn('requestCall ignored while a completed QSO is not durably saved');
-            return false;
-        }
-        if (this.persistedQSO && callsignMatches(callsign, this.context.targetCallsign)) {
-            this.logger.warn('requestCall ignored for an already persisted QSO lifecycle', { callsign });
+        if (this.hasUnsettledQSOCompletion()) {
+            this.logger.warn('requestCall ignored while QSO durability is unsettled', { callsign });
             return false;
         }
         if (isUndecodedCallsignPlaceholder(callsign)) {
@@ -1313,16 +1322,13 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
         this.syncOperatorConfig();
         this.logger.debug(`requestCall: myCallsign=${this.operator.config.myCallsign}, target=${callsign}`, lastMessage);
         this.clearPost73RetryContext('manual requestCall');
-        if (this.persistedQSO) {
-            this.clearQSOContext();
-        }
         if (!lastMessage) {
-            this.context.targetCallsign = callsign;
+            this.beginQsoWithTarget(callsign, 'manual requestCall');
             this.updateSlots();
             this.changeStateSafely(this.getInitialOutboundCallState());  // 呼叫他
             return true;
         }
-        this.context.targetCallsign = callsign;
+        this.beginQsoWithTarget(callsign, 'manual requestCall with decoded message');
         this.context.reportSent = lastMessage.message.snr;
         const msg = FT8MessageParser.parseMessage(lastMessage.message.message);
         const parsedMessage: ParsedFT8Message = {
@@ -1405,11 +1411,99 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
         return true;
     }
 
-    decide(messages: ParsedFT8Message[], meta?: StrategyDecisionMeta): Promise<StrategyDecision> {
+    checkpoint(): StrategyRuntimeCheckpoint {
+        const { config: _config, ...context } = this._context;
+        const checkpoint: StandardQSOCheckpoint = {
+            state: this.state,
+            slots: { ...this.slots },
+            context: { ...context },
+            tx6MessageOverride: this.tx6MessageOverride,
+            lastConfigTx6MessageOverride: this.lastConfigTx6MessageOverride,
+            timeoutCycles: this.timeoutCycles,
+            callAttempts: this.callAttempts,
+            qsoStartTime: this.qsoStartTime,
+            tx5TransmissionQueued: this.tx5TransmissionQueued,
+            completedQSORecord: this.completedQSORecord ? { ...this.completedQSORecord } : undefined,
+            pendingQSOCompletion: this.pendingQSOCompletion ? {
+                lifecycleEpoch: this.pendingQSOCompletion.lifecycleEpoch,
+                record: { ...this.pendingQSOCompletion.record },
+            } : undefined,
+            qsoLifecycleEpoch: this.qsoLifecycleEpoch,
+            post73RetryContext: this.post73RetryContext ? { ...this.post73RetryContext } : undefined,
+            qsoContextHistory: Array.from(this.qsoContextHistory.entries(), ([callsign, cached]) => [
+                callsign,
+                { ...cached },
+            ]),
+            foxHash: this.foxHash,
+        };
+        return checkpoint;
+    }
+
+    restore(checkpoint: StrategyRuntimeCheckpoint): void {
+        if (!checkpoint || typeof checkpoint !== 'object') {
+            throw new Error('Invalid Standard QSO strategy checkpoint');
+        }
+        const state = checkpoint as StandardQSOCheckpoint;
+        if (!Object.prototype.hasOwnProperty.call(states, state.state)) {
+            throw new Error(`Invalid Standard QSO strategy checkpoint state: ${String(state.state)}`);
+        }
+
+        this.state = state.state;
+        this.slots = { ...state.slots };
+        this._context = {
+            config: this.operator.config,
+            ...state.context,
+        };
+        this.tx6MessageOverride = state.tx6MessageOverride;
+        this.lastConfigTx6MessageOverride = state.lastConfigTx6MessageOverride;
+        this.timeoutCycles = state.timeoutCycles;
+        this.callAttempts = state.callAttempts;
+        this.qsoStartTime = state.qsoStartTime;
+        this.tx5TransmissionQueued = state.tx5TransmissionQueued;
+        this.completedQSORecord = state.completedQSORecord ? { ...state.completedQSORecord } : undefined;
+        this.pendingQSOCompletion = state.pendingQSOCompletion ? {
+            lifecycleEpoch: state.pendingQSOCompletion.lifecycleEpoch,
+            record: { ...state.pendingQSOCompletion.record },
+        } : undefined;
+        this.qsoLifecycleEpoch = state.qsoLifecycleEpoch;
+        this.post73RetryContext = state.post73RetryContext ? { ...state.post73RetryContext } : undefined;
+        this.qsoContextHistory = new Map(
+            state.qsoContextHistory.map(([callsign, cached]) => [callsign, { ...cached }]),
+        );
+        this.foxHash = state.foxHash;
+    }
+
+    async decide(messages: ParsedFT8Message[], meta: StrategyDecisionMetaV2): Promise<StrategyDecisionResult> {
         this.syncOperatorConfig();
-        return this.handleReceivedAndDicideNext(messages, {
-            isReDecision: meta?.isReDecision,
-        });
+        if (meta.signal.aborted) {
+            throw new DOMException('Strategy decision aborted', 'AbortError');
+        }
+
+        this.speculativeDecisionDepth += 1;
+        try {
+            const decision = await this.handleReceivedAndDicideNext(messages, {
+                isReDecision: meta.isReDecision,
+            });
+            if (meta.signal.aborted) {
+                throw new DOMException('Strategy decision aborted', 'AbortError');
+            }
+
+            const qsoCompletion = this.pendingQSOCompletion
+                ? {
+                    lifecycleEpoch: this.pendingQSOCompletion.lifecycleEpoch,
+                    record: { ...this.pendingQSOCompletion.record },
+                }
+                : undefined;
+            this.pendingQSOCompletion = undefined;
+            return {
+                ...decision,
+                transmission: this.handleTransmitSlot(),
+                snapshot: this.getSnapshot(),
+                qsoCompletion,
+            };
+        } finally {
+            this.speculativeDecisionDepth -= 1;
+        }
     }
 
     getTransmitText(): string | null {
@@ -1430,6 +1524,7 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
                 actualFrequency: this.context.actualFrequency,
             },
             availableSlots: ['TX1', 'TX2', 'TX3', 'TX4', 'TX5', 'TX6'],
+            qsoLifecycleEpoch: this.qsoLifecycleEpoch,
         };
     }
 
@@ -1438,6 +1533,10 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
         if (patch.targetCallsign && isUndecodedCallsignPlaceholder(patch.targetCallsign)) {
             this.logger.warn(`patchContext: refusing undecoded placeholder callsign ${patch.targetCallsign}`);
             return;
+        }
+        if (patch.targetCallsign
+            && !callsignMatches(patch.targetCallsign, this._context.targetCallsign)) {
+            this.beginQsoLifecycle('context target changed');
         }
         this._context = {
             ...this._context,
@@ -1674,7 +1773,7 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
             reportSent: this.context.reportSent,
             reportReceived: this.context.reportReceived,
             actualFrequency: this.context.actualFrequency,
-            persistedQSO: this.persistedQSO,
+            completedQSO: this.completedQSORecord,
             expiresAt: Date.now() + retryWindowMs,
         };
 
@@ -1709,7 +1808,7 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
         this.context.reportSent = context.reportSent;
         this.context.reportReceived = context.reportReceived;
         this.context.actualFrequency = context.actualFrequency;
-        this.persistedQSO = context.persistedQSO;
+        this.completedQSORecord = context.completedQSO;
         this.tx5TransmissionQueued = false;
         this.updateSlots();
     }
@@ -1731,9 +1830,6 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
         this.context.reportReceived = undefined;
         this.context.actualFrequency = undefined;
         this.foxHash = undefined;
-        this.persistedQSO = undefined;
-        this.qsoPersistenceFailed = false;
-
         // 更新slots（TX1-TX5会变为空，只保留TX6的CQ）
         this.updateSlots();
 
@@ -1741,13 +1837,13 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
     }
 
     resetRuntime(reason?: string): void {
+        this.qsoLifecycleEpoch += 1;
         this.timeoutCycles = 0;
         this.callAttempts = 0;
         this.qsoStartTime = undefined;
         this.tx5TransmissionQueued = false;
-        this.qsoPersistencePromise = undefined;
-        this.persistedQSO = undefined;
-        this.qsoPersistenceFailed = false;
+        this.completedQSORecord = undefined;
+        this.pendingQSOCompletion = undefined;
         this.clearPost73RetryContext(`runtime reset${reason ? `: ${reason}` : ''}`);
         this.clearQSOContext();
         this.changeStateSafely('TX6');
@@ -1763,6 +1859,9 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
      * 通知slots更新
      */
     private notifySlotsUpdated(): void {
+        if (this.speculativeDecisionDepth > 0) {
+            return;
+        }
         // 通过operator通知slots更新
         this.operator.notifySlotsUpdated?.(this.getSlots());
     }
@@ -1771,6 +1870,9 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
      * 通知状态变化
      */
     private notifyStateChanged(): void {
+        if (this.speculativeDecisionDepth > 0) {
+            return;
+        }
         // 通过operator通知状态变化
         this.operator.notifyStateChanged?.(this.state);
     }

--- a/packages/builtin-plugins/src/standard-qso/index.ts
+++ b/packages/builtin-plugins/src/standard-qso/index.ts
@@ -1,9 +1,4 @@
-import type {
-  OperatorSlots,
-  PluginDefinition,
-  QSORecord,
-  TargetSelectionPriorityMode,
-} from '@tx5dr/plugin-api';
+import { definePlugin, type TargetSelectionPriorityMode } from '@tx5dr/plugin-api';
 import type {
   OperatorConfig,
 } from '@tx5dr/contracts';
@@ -72,7 +67,8 @@ function getStandardQSOConfig(ctx: {
   };
 }
 
-export const standardQSOStrategyPlugin: PluginDefinition = {
+export const standardQSOStrategyPlugin = definePlugin({
+  apiVersion: 2,
   name: BUILTIN_STANDARD_QSO_PLUGIN_NAME,
   version: '1.0.0',
   type: 'strategy',
@@ -201,15 +197,6 @@ export const standardQSOStrategyPlugin: PluginDefinition = {
       isTargetBeingWorkedByOthers(targetCallsign: string): boolean {
         return ctx.operator.isTargetBeingWorkedByOthers(targetCallsign);
       },
-      recordQSOLog(record: QSORecord): Promise<QSORecord> {
-        return ctx.operator.recordQSO(record);
-      },
-      notifySlotsUpdated(slots: OperatorSlots): void {
-        ctx.operator.notifySlotsUpdated(slots);
-      },
-      notifyStateChanged(state: string): void {
-        ctx.operator.notifyStateChanged(state);
-      },
     };
     const strategy = new StandardQSOPluginRuntime(runtime, ctx.log);
     ctx.log.info('Standard QSO strategy initialized', { operatorId });
@@ -221,7 +208,7 @@ export const standardQSOStrategyPlugin: PluginDefinition = {
       ctx.log.debug('Standard QSO config changed');
     },
   },
-};
+});
 
 /** 内置翻译，随插件一起编译进 bundle */
 export const standardQSOLocales: Record<string, Record<string, string>> = {

--- a/packages/builtin-plugins/src/watched-callsign-autocall/index.test.ts
+++ b/packages/builtin-plugins/src/watched-callsign-autocall/index.test.ts
@@ -6,9 +6,11 @@ import { watchedCallsignAutocallPlugin, watchedCallsignAutocallTestables } from 
 describe('watched-callsign-autocall', () => {
   it('reports auto-call enabled only when watch list has active entries', () => {
     expect(watchedCallsignAutocallTestables.isWatchedCallsignAutoCallEnabled(createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: { watchList: ['JA1AAA'] },
     }))).toBe(true);
     expect(watchedCallsignAutocallTestables.isWatchedCallsignAutoCallEnabled(createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: { watchList: ['  ', '# JA1AAA'] },
     }))).toBe(false);
   });
@@ -19,6 +21,7 @@ describe('watched-callsign-autocall', () => {
   ])('defers the current slot when history is %s', async (code) => {
     const countQSOs = vi.fn().mockRejectedValue(Object.assign(new Error(code), { code }));
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: {
         watchList: ['JA1AAA'],
         watchMatchMode: 'exact',
@@ -42,6 +45,7 @@ describe('watched-callsign-autocall', () => {
   it('does not hide unexpected logbook query failures', async () => {
     const error = new Error('query invariant failed');
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: {
         watchList: ['JA1AAA'],
         watchMatchMode: 'exact',

--- a/packages/builtin-plugins/src/watched-callsign-autocall/index.ts
+++ b/packages/builtin-plugins/src/watched-callsign-autocall/index.ts
@@ -2,11 +2,13 @@ import {
   type AutoCallProposal,
   type LastMessageInfo,
   type ParsedFT8Message,
-  type PluginContext,
-  type PluginDefinition,
+  type PluginContextFor,
   type SlotInfo,
+  definePlugin,
   normalizeCallsign,
 } from '@tx5dr/plugin-api';
+
+type PluginContext = PluginContextFor<readonly ['operator:transmit-control', 'logbook:read']>;
 import type { QSORecord } from '@tx5dr/contracts';
 import {
   compileLegacyAutoRegexTextMatchRules,
@@ -137,12 +139,13 @@ function findMatchedTarget(
   return matches[0] ?? null;
 }
 
-export const watchedCallsignAutocallPlugin: PluginDefinition = {
+export const watchedCallsignAutocallPlugin = definePlugin({
+  apiVersion: 2,
   name: 'watched-callsign-autocall',
   version: '1.0.0',
   type: 'utility',
   description: 'Automatically start calling watched callsigns when they appear while the operator is idle',
-  permissions: ['operator:transmit-control'],
+  permissions: ['operator:transmit-control', 'logbook:read'],
 
   settings: {
     watchOverview: {
@@ -319,7 +322,7 @@ export const watchedCallsignAutocallPlugin: PluginDefinition = {
       };
     },
   },
-};
+});
 
 export const watchedCallsignAutocallLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/watched-grid-autocall/index.test.ts
+++ b/packages/builtin-plugins/src/watched-grid-autocall/index.test.ts
@@ -6,13 +6,14 @@ import { watchedGridAutocallPlugin, watchedGridAutocallTestables } from './index
 describe('watched-grid-autocall', () => {
   it('proposes an autocall when a watched grid appears', async () => {
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: {
         gridWatchList: ['PM95'],
         gridMatchMode: 'exact',
         triggerMode: 'cq',
         workedGridSkipEnabled: false,
       },
-      operator: { automation: { currentState: 'TX6', slots: {}, context: {} } as any },
+      operator: { automation: { currentState: 'TX6', slots: {}, context: {} } },
     });
     const message = createMockParsedMessage({
       message: { type: FT8MessageType.CQ, senderCallsign: 'JA1AAA', grid: 'PM95AB' },
@@ -25,8 +26,9 @@ describe('watched-grid-autocall', () => {
 
   it('ignores messages without a grid', async () => {
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: { gridWatchList: ['PM95'], gridMatchMode: 'exact', triggerMode: 'cq' },
-      operator: { automation: { currentState: 'TX6', slots: {}, context: {} } as any },
+      operator: { automation: { currentState: 'TX6', slots: {}, context: {} } },
     });
     const message = createMockParsedMessage({
       message: { type: FT8MessageType.CQ, senderCallsign: 'JA1AAA' },
@@ -39,13 +41,14 @@ describe('watched-grid-autocall', () => {
 
   it('skips already worked grids when enabled', async () => {
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: {
         gridWatchList: ['PM95'],
         gridMatchMode: 'exact',
         triggerMode: 'cq',
         workedGridSkipEnabled: true,
       },
-      operator: { automation: { currentState: 'TX6', slots: {}, context: {} } as any },
+      operator: { automation: { currentState: 'TX6', slots: {}, context: {} } },
       logbook: { hasWorkedGrid: async () => true },
     });
     const message = createMockParsedMessage({
@@ -59,6 +62,7 @@ describe('watched-grid-autocall', () => {
   it('skips callsigns worked on any band even when the previous QSO had no grid', async () => {
     const hasWorked = vi.fn(async () => true);
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: {
         gridWatchList: ['PM95'],
         gridMatchMode: 'exact',
@@ -86,6 +90,7 @@ describe('watched-grid-autocall', () => {
 
   it('does not interrupt a non-idle operator', async () => {
     const ctx = createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: { gridWatchList: ['PM95'], gridMatchMode: 'exact', triggerMode: 'cq' },
       operator: { isTransmitting: true },
     });
@@ -99,9 +104,11 @@ describe('watched-grid-autocall', () => {
 
   it('reports auto-call enabled only when grid watch list has active entries', () => {
     expect(watchedGridAutocallTestables.isWatchedGridAutoCallEnabled(createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: { gridWatchList: ['PM95'] },
     }))).toBe(true);
     expect(watchedGridAutocallTestables.isWatchedGridAutoCallEnabled(createMockContext({
+      permissions: ['operator:transmit-control', 'logbook:read'],
       config: { gridWatchList: ['  ', '# PM95'] },
     }))).toBe(false);
   });

--- a/packages/builtin-plugins/src/watched-grid-autocall/index.ts
+++ b/packages/builtin-plugins/src/watched-grid-autocall/index.ts
@@ -1,11 +1,13 @@
-import type {
-  AutoCallProposal,
-  LastMessageInfo,
-  ParsedFT8Message,
-  PluginContext,
-  PluginDefinition,
-  SlotInfo,
+import {
+  definePlugin,
+  type AutoCallProposal,
+  type LastMessageInfo,
+  type ParsedFT8Message,
+  type PluginContextFor,
+  type SlotInfo,
 } from '@tx5dr/plugin-api';
+
+type PluginContext = PluginContextFor<readonly ['operator:transmit-control', 'logbook:read']>;
 import type { QSORecord } from '@tx5dr/contracts';
 import { getFourCharacterGrid } from '@tx5dr/contracts';
 import { isUndecodedCallsignPlaceholder } from '@tx5dr/core';
@@ -108,12 +110,13 @@ function findMatchedTarget(
   return matches[0] ?? null;
 }
 
-export const watchedGridAutocallPlugin: PluginDefinition = {
+export const watchedGridAutocallPlugin = definePlugin({
+  apiVersion: 2,
   name: 'watched-grid-autocall',
   version: '1.0.0',
   type: 'utility',
   description: 'Automatically call stations from watched Maidenhead grids while the operator is idle',
-  permissions: ['operator:transmit-control'],
+  permissions: ['operator:transmit-control', 'logbook:read'],
 
   settings: {
     gridWatchOverview: {
@@ -258,7 +261,7 @@ export const watchedGridAutocallPlugin: PluginDefinition = {
       };
     },
   },
-};
+});
 
 export const watchedGridAutocallLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/watched-novelty-autocall/index.ts
+++ b/packages/builtin-plugins/src/watched-novelty-autocall/index.ts
@@ -3,8 +3,8 @@ import {
   type LastMessageInfo,
   type ParsedFT8Message,
   type PluginContext,
-  type PluginDefinition,
   type SlotInfo,
+  definePlugin,
 } from '@tx5dr/plugin-api';
 import {
   getSenderCallsign,
@@ -83,7 +83,8 @@ function findMatchedTarget(
   return matches[0] ?? null;
 }
 
-export const watchedNoveltyAutocallPlugin: PluginDefinition = {
+export const watchedNoveltyAutocallPlugin = definePlugin({
+  apiVersion: 2,
   name: 'watched-novelty-autocall',
   version: '1.0.0',
   type: 'utility',
@@ -188,7 +189,7 @@ export const watchedNoveltyAutocallPlugin: PluginDefinition = {
       };
     },
   },
-};
+});
 
 export const watchedNoveltyAutocallLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/wavelog-sync/index.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/index.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'url';
 import path from 'path';
-import type { PluginDefinition, PluginUIRequestContext } from '@tx5dr/plugin-api';
+import { definePlugin, type PluginUIRequestContext } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 import jaLocale from './locales/ja.json' with { type: 'json' };
@@ -35,14 +35,15 @@ function requireBoundCallsign(
  *
  * Configuration is stored in the plugin's global KVStore keyed by callsign.
  */
-export const wavelogSyncPlugin: PluginDefinition = {
+export const wavelogSyncPlugin = definePlugin({
+  apiVersion: 2,
   name: BUILTIN_WAVELOG_SYNC_PLUGIN_NAME,
   version: '1.0.0',
   type: 'utility',
   instanceScope: 'global',
   description: 'Sync QSO records with a WaveLog server',
 
-  permissions: ['network'],
+  permissions: ['network', 'logbook:read', 'logbook:write', 'logbook:sync'],
 
   ui: {
     dir: 'ui',
@@ -116,7 +117,7 @@ export const wavelogSyncPlugin: PluginDefinition = {
 
     ctx.log.info('WaveLog sync provider registered');
   },
-};
+});
 
 export const wavelogSyncLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/builtin-plugins/src/wavelog-sync/provider.test.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { PluginContext } from '@tx5dr/plugin-api';
+import type { PluginContextFor } from '@tx5dr/plugin-api';
 import type { QSORecord } from '@tx5dr/contracts';
 import { WaveLogSyncProvider, buildWavelogQslStatusUpdates } from './provider.js';
 
@@ -682,3 +682,4 @@ describe('WaveLogSyncProvider', () => {
     expect(notifyUpdated).toHaveBeenCalledTimes(1);
   });
 });
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;

--- a/packages/builtin-plugins/src/wavelog-sync/provider.ts
+++ b/packages/builtin-plugins/src/wavelog-sync/provider.ts
@@ -2,7 +2,7 @@
 // WaveLogSyncProvider — HTTP response handling requires any
 
 import type {
-  PluginContext,
+  PluginContextFor,
   LogbookSyncProvider,
   SyncAction,
   SyncTestResult,
@@ -12,6 +12,8 @@ import type {
   SyncUploadOptions,
   SyncFailure,
 } from '@tx5dr/plugin-api';
+
+type PluginContext = PluginContextFor<readonly ['network', 'logbook:read', 'logbook:write']>;
 import type { QSORecord } from '@tx5dr/contracts';
 import {
   convertQSOToADIF,

--- a/packages/builtin-plugins/src/worked-station-bias/index.ts
+++ b/packages/builtin-plugins/src/worked-station-bias/index.ts
@@ -1,4 +1,4 @@
-import type { PluginDefinition, ScoredCandidate } from '@tx5dr/plugin-api';
+import { definePlugin, type ScoredCandidate } from '@tx5dr/plugin-api';
 import { isUndecodedCallsignPlaceholder } from '@tx5dr/core';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
@@ -12,11 +12,12 @@ function getSenderCallsign(message: unknown): string {
   return '';
 }
 
-export const workedStationBiasPlugin: PluginDefinition = {
+export const workedStationBiasPlugin = definePlugin({
   name: 'worked-station-bias',
   version: '1.0.0',
   type: 'utility',
   description: 'Bias candidate scores based on whether the callsign was already worked',
+  permissions: ['logbook:read'],
 
   settings: {
     biasOverview: {
@@ -79,7 +80,7 @@ export const workedStationBiasPlugin: PluginDefinition = {
       return scored;
     },
   },
-};
+});
 
 export const workedStationBiasLocales: Record<string, Record<string, string>> = {
   zh: zhLocale,

--- a/packages/contracts/src/schema/__tests__/plugin-market.schema.test.ts
+++ b/packages/contracts/src/schema/__tests__/plugin-market.schema.test.ts
@@ -93,11 +93,13 @@ describe('plugin market schema', () => {
       enabled: true,
       errorCount: 0,
       permissions: ['operator:transmit-control'],
+      capabilities: ['auto_call_control'],
       autoCallEnabledOperatorIds: ['operator-1'],
       pausedOperatorIds: ['operator-2'],
     });
     expect(status.autoCallEnabledOperatorIds).toEqual(['operator-1']);
     expect(status.pausedOperatorIds).toEqual(['operator-2']);
+    expect(status.capabilities).toContain('auto_call_control');
   });
 
   it('accepts persisted operator plugin pause state with defaults', () => {

--- a/packages/contracts/src/schema/__tests__/radio.schema.test.ts
+++ b/packages/contracts/src/schema/__tests__/radio.schema.test.ts
@@ -5,7 +5,7 @@ describe('HamlibConfigSchema digital mode radio mode preference', () => {
   it('accepts legacy configs without a digital mode radio mode preference', () => {
     const parsed = HamlibConfigSchema.parse({ type: 'none' });
 
-    expect(parsed.digitalModeRadioMode ?? 'none').toBe('none');
+    expect(parsed.digitalModeRadioMode).toBeUndefined();
   });
 
   it('accepts supported FT8/FT4 radio mode preferences', () => {

--- a/packages/contracts/src/schema/plugin.schema.ts
+++ b/packages/contracts/src/schema/plugin.schema.ts
@@ -43,7 +43,11 @@ export const PluginPermissionSchema = z.enum([
   'operator:transmit-control',
   'radio:read',
   'radio:control',
+  'radio:tuner-control',
   'radio:power',
+  'logbook:read',
+  'logbook:write',
+  'logbook:sync',
   'settings:ft8',
   'settings:decode-windows',
   'settings:realtime',
@@ -244,6 +248,7 @@ export type PluginQuickSetting = z.infer<typeof PluginQuickSettingSchema>;
  * about plugin roles without hard-coding specific plugin names.
  */
 export const PluginCapabilitySchema = z.enum([
+  'auto_call_control',
   'auto_call_candidate',
   'auto_call_execution',
 ]);
@@ -468,6 +473,7 @@ export type PluginStorageConfig = z.infer<typeof PluginStorageConfigSchema>;
  * host can expose to management UI and diagnostics.
  */
 export const PluginManifestSchema = z.object({
+  apiVersion: z.literal(2).optional(),
   name: z.string(),
   version: z.string(),
   type: PluginTypeSchema,

--- a/packages/contracts/src/schema/radio.schema.ts
+++ b/packages/contracts/src/schema/radio.schema.ts
@@ -277,7 +277,7 @@ export const HamlibConfigSchema = z.object({
   // Hamlib 频谱配置（当前仅用于官方频谱流 speed）
   spectrum: HamlibSpectrumConfigSchema.optional(),
 
-  // FT8/FT4 切换频率时是否主动设置电台 CAT 模式；未设置按 none 处理
+  // FT8/FT4 切换频率时是否主动设置电台 CAT 模式；旧配置未设置时迁移为 USB
   digitalModeRadioMode: DigitalModeRadioModePreferenceSchema.optional(),
 
   // 发射时序补偿（毫秒）- 用于补偿电台和网络的处理延迟

--- a/packages/contracts/src/schema/websocket.schema.ts
+++ b/packages/contracts/src/schema/websocket.schema.ts
@@ -357,6 +357,9 @@ export type SpectrumControlInvocation = z.infer<typeof SpectrumControlInvocation
 export const PTTStatusSchema = z.object({
   isTransmitting: z.boolean(),
   operatorIds: z.array(z.string()),
+  phase: z.enum(['idle', 'starting', 'on_air', 'draining', 'stopping', 'unknown']).optional(),
+  frameId: z.string().optional(),
+  source: z.enum(['digital', 'voice', 'voice-keyer', 'cw', 'tune-tone', 'manual', 'test']).optional(),
 });
 
 export const TuneToneStartPayloadSchema = z.object({
@@ -886,6 +889,11 @@ export const WSTransmissionLogMessageSchema = WSBaseMessageSchema.extend({
   type: z.literal(WSMessageType.TRANSMISSION_LOG),
   data: z.object({
     operatorId: z.string(),
+    frameId: z.string(),
+    revision: z.number().int().nonnegative(),
+    playbackGeneration: z.number().int().positive(),
+    phase: z.literal('on_air'),
+    physicalConfirmed: z.literal(true),
     time: z.string(),
     message: z.string(),
     frequency: z.number(),
@@ -1591,6 +1599,10 @@ export const TransmitRequestSchema = z.object({
   transmission: z.string(),
   /** 是否覆盖同一操作员在同一时隙的现有 TX 帧（自动重决策时为 true） */
   replaceExisting: z.boolean().optional(),
+  source: z.enum(['standard-qso', 'plugin', 'late-decode', 'operator-edit', 'manual']).optional(),
+  reason: z.string().optional(),
+  /** Host command epoch used to tombstone stale encode/mix callbacks. */
+  decisionEpoch: z.number().int().nonnegative().optional(),
 });
 
 export type TransmitRequest = z.infer<typeof TransmitRequestSchema>;
@@ -1603,6 +1615,9 @@ export type TransmitRequest = z.infer<typeof TransmitRequestSchema>;
 export const TransmissionCompleteInfoSchema = z.object({
   operatorId: z.string(),
   success: z.boolean(),
+  frameId: z.string().optional(),
+  physicalConfirmed: z.boolean().optional(),
+  terminalReason: z.string().optional(),
   duration: z.number().optional(),
   error: z.string().optional(),
   mixedWith: z.array(z.string()).optional(), // 与其他操作员混音的ID列表
@@ -1635,6 +1650,11 @@ export interface DigitalRadioEngineEvents {
   transmissionComplete: (info: TransmissionCompleteInfo) => void;
   transmissionLog: (data: {
     operatorId: string;
+    frameId: string;
+    revision: number;
+    playbackGeneration: number;
+    phase: 'on_air';
+    physicalConfirmed: true;
     time: string;
     message: string;
     frequency: number;
@@ -1772,9 +1792,23 @@ export interface DigitalRadioEngineEvents {
   operatorSlotChanged: (data: { operatorId: string; slot: string }) => void;
   operatorSlotContentChanged: (data: { operatorId: string; slot: string; content: string }) => void;
   operatorFrequencyChanged: (data: { operatorId: string; frequency: number }) => void;
-  operatorTransmitCyclesChanged: (data: { operatorId: string; transmitCycles: number[] }) => void;
+  operatorTransmitCyclesChanged: (data: {
+    operatorId: string;
+    transmitCycles: number[];
+    commandEpoch?: number;
+    source?: 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+    reason?: string;
+  }) => void;
+  qsoLifecycleChanged: (data: {
+    operatorId: string;
+    lifecycleEpoch: number;
+    runtimeGeneration?: number;
+  }) => void;
   recordQSO: (data: {
     operatorId: string;
+    qsoLifecycleId?: string;
+    qsoLifecycleEpoch?: number;
+    qsoRuntimeGeneration?: number;
     qsoRecord: z.infer<typeof QSORecordSchema>;
     retryAttemptId?: string;
     resolve?: (record: z.infer<typeof QSORecordSchema>) => void;

--- a/packages/core/src/operator/RadioOperator.ts
+++ b/packages/core/src/operator/RadioOperator.ts
@@ -12,9 +12,23 @@ import { createLogger } from '../utils/logger.js';
 const logger = createLogger('RadioOperator');
 
 interface RadioOperatorEvents extends DigitalRadioEngineEvents {
-    operatorTransmitCyclesChanged: (data: { operatorId: string; transmitCycles: number[] }) => void;
+    operatorTransmitCyclesChanged: (data: {
+        operatorId: string;
+        transmitCycles: number[];
+        commandEpoch?: number;
+        source?: 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+        reason?: string;
+    }) => void;
+    qsoLifecycleChanged: (data: {
+        operatorId: string;
+        lifecycleEpoch: number;
+        runtimeGeneration?: number;
+    }) => void;
     recordQSO: (data: {
         operatorId: string;
+        qsoLifecycleId?: string;
+        qsoLifecycleEpoch?: number;
+        qsoRuntimeGeneration?: number;
         qsoRecord: QSORecord;
         retryAttemptId?: string;
         resolve?: (record: QSORecord) => void;
@@ -112,11 +126,19 @@ export class RadioOperator {
         this._config.mode = mode;
     }
 
-    setTransmitCycles(transmitCycles: number | number[]): void {
+    setTransmitCycles(
+        transmitCycles: number | number[],
+        mutation?: {
+            commandEpoch?: number;
+            source?: 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+            reason?: string;
+        },
+    ): void {
         this._config.transmitCycles = Array.isArray(transmitCycles) ? transmitCycles : [transmitCycles];
         this._eventEmitter.emit('operatorTransmitCyclesChanged', {
             operatorId: this._config.id,
             transmitCycles: this._config.transmitCycles,
+            ...mutation,
         });
     }
 
@@ -124,10 +146,18 @@ export class RadioOperator {
         return [...this._config.transmitCycles];
     }
 
-    recordQSOLog(qsoRecord: QSORecord, options?: { retryAttemptId?: string }): Promise<QSORecord> {
+    recordQSOLog(qsoRecord: QSORecord, options?: {
+        retryAttemptId?: string;
+        qsoLifecycleId?: string;
+        qsoLifecycleEpoch?: number;
+        qsoRuntimeGeneration?: number;
+    }): Promise<QSORecord> {
         return new Promise<QSORecord>((resolve, reject) => {
             this._eventEmitter.emit('recordQSO', {
                 operatorId: this._config.id,
+                qsoLifecycleId: options?.qsoLifecycleId,
+                qsoLifecycleEpoch: options?.qsoLifecycleEpoch,
+                qsoRuntimeGeneration: options?.qsoRuntimeGeneration,
                 qsoRecord,
                 retryAttemptId: options?.retryAttemptId,
                 resolve,

--- a/packages/create-tx5dr-plugin/src/index.ts
+++ b/packages/create-tx5dr-plugin/src/index.ts
@@ -226,32 +226,39 @@ dist/
 function generateLocaleZh(config: PluginConfig): string {
   return JSON.stringify({
     pluginDescription: `${config.name} plugin`,
+    enabled: '启用自动发射控制',
+    enabledDesc: '允许此插件通过宿主发射协调器影响当前操作员的自动通联',
   }, null, 2) + '\n';
 }
 
 function generateLocaleEn(config: PluginConfig): string {
   return JSON.stringify({
     pluginDescription: `${config.name} plugin`,
+    enabled: 'Enable automatic transmit control',
+    enabledDesc: 'Allow this plugin to influence operator automation through the host coordinator',
   }, null, 2) + '\n';
 }
 
 // ===== Server-side plugin definition templates =====
 
 function generateTsUtilityPlugin(config: PluginConfig): string {
-  return `import type {
-  PluginDefinition,
-  PluginContext,
-  ParsedFT8Message,
-  SlotInfo,
+  return `import {
+  definePlugin,
+  type ParsedFT8Message,
+  type SlotInfo,
 } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 
-export const plugin: PluginDefinition = {
+export const plugin = definePlugin({
+  apiVersion: 2,
   name: '${config.name}',
   version: '0.1.0',
   type: 'utility',
   description: 'pluginDescription',
+  // Add only the capabilities this plugin actually uses. The host omits all
+  // undeclared privileged APIs from both the TypeScript type and runtime context.
+  permissions: [],
 
   settings: {
     // Define your plugin settings here
@@ -265,18 +272,18 @@ export const plugin: PluginDefinition = {
   },
 
   hooks: {
-    onSlotStart(slotInfo: SlotInfo, messages: ParsedFT8Message[], ctx: PluginContext): void {
+    onSlotStart(slotInfo: SlotInfo, messages: ParsedFT8Message[], ctx): void {
       ctx.log.debug('Slot started', { slotId: slotInfo.id, messageCount: messages.length });
     },
 
-    onDecode(messages: ParsedFT8Message[], ctx: PluginContext): void {
+    onDecode(messages: ParsedFT8Message[], ctx): void {
       // Process decoded messages
       for (const msg of messages) {
         ctx.log.debug('Decoded message', { raw: msg.rawMessage, snr: msg.snr });
       }
     },
   },
-};
+});
 
 export const locales: Record<string, Record<string, string>> = {
   zh: zhLocale,
@@ -288,19 +295,20 @@ export default plugin;
 }
 
 function generateTsStrategyPlugin(config: PluginConfig): string {
-  return `import type {
-  PluginDefinition,
-  PluginContext,
-  StrategyRuntime,
-  StrategyRuntimeSnapshot,
-  StrategyRuntimeSlot,
-  StrategyRuntimeSlotContentUpdate,
-  StrategyRuntimeContext,
-  ParsedFT8Message,
-  StrategyDecision,
-  StrategyDecisionMeta,
-  FrameMessage,
-  SlotInfo,
+  return `import {
+  definePlugin,
+  type StrategyPluginContext,
+  type StrategyRuntime,
+  type StrategyRuntimeSnapshot,
+  type StrategyRuntimeSlot,
+  type StrategyRuntimeSlotContentUpdate,
+  type StrategyRuntimeContext,
+  type StrategyRuntimeCheckpoint,
+  type ParsedFT8Message,
+  type StrategyDecisionResult,
+  type StrategyDecisionMetaV2,
+  type FrameMessage,
+  type SlotInfo,
 } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
@@ -310,11 +318,32 @@ class PluginRuntime implements StrategyRuntime {
   private slots: Partial<Record<StrategyRuntimeSlot, string>> = {};
   private context: StrategyRuntimeContext = {};
 
-  constructor(private ctx: PluginContext) {}
+  constructor(private ctx: StrategyPluginContext) {}
 
-  decide(messages: ParsedFT8Message[], meta?: StrategyDecisionMeta): StrategyDecision {
+  checkpoint(): StrategyRuntimeCheckpoint {
+    return structuredClone({ state: this.state, slots: this.slots, context: this.context });
+  }
+
+  restore(checkpoint: StrategyRuntimeCheckpoint): void {
+    const saved = checkpoint as {
+      state: StrategyRuntimeSlot;
+      slots: Partial<Record<StrategyRuntimeSlot, string>>;
+      context: StrategyRuntimeContext;
+    };
+    this.state = saved.state;
+    this.slots = { ...saved.slots };
+    this.context = { ...saved.context };
+  }
+
+  decide(messages: ParsedFT8Message[], meta: StrategyDecisionMetaV2): StrategyDecisionResult {
+    if (meta.signal.aborted) {
+      throw meta.signal.reason ?? new Error('Strategy decision aborted');
+    }
     // Implement your QSO strategy logic here
-    return {};
+    return {
+      transmission: this.getTransmitText(),
+      snapshot: this.getSnapshot(),
+    };
   }
 
   getTransmitText(): string | null {
@@ -356,15 +385,16 @@ class PluginRuntime implements StrategyRuntime {
   }
 }
 
-export const plugin: PluginDefinition = {
+export const plugin = definePlugin({
+  apiVersion: 2,
   name: '${config.name}',
   version: '0.1.0',
   type: 'strategy',
   description: 'pluginDescription',
+  // Selecting a strategy is the explicit grant for declarative RF decisions.
+  // Add operator:transmit-control only to utility plugins that submit commands.
 
-  settings: {},
-
-  createStrategyRuntime(ctx: PluginContext): StrategyRuntime {
+  createStrategyRuntime(ctx: StrategyPluginContext): StrategyRuntime {
     return new PluginRuntime(ctx);
   },
 
@@ -373,7 +403,7 @@ export const plugin: PluginDefinition = {
       ctx.log.debug('Slot started', { slotId: slotInfo.id });
     },
   },
-};
+});
 
 export const locales: Record<string, Record<string, string>> = {
   zh: zhLocale,
@@ -385,20 +415,22 @@ export default plugin;
 }
 
 function generateTsUtilityPluginWithUI(config: PluginConfig): string {
-  return `import type {
-  PluginDefinition,
-  PluginContext,
-  ParsedFT8Message,
-  SlotInfo,
+  return `import {
+  definePlugin,
+  type ParsedFT8Message,
+  type SlotInfo,
 } from '@tx5dr/plugin-api';
 import zhLocale from './locales/zh.json' with { type: 'json' };
 import enLocale from './locales/en.json' with { type: 'json' };
 
-export const plugin: PluginDefinition = {
+export const plugin = definePlugin({
+  apiVersion: 2,
   name: '${config.name}',
   version: '0.1.0',
   type: 'utility',
   description: 'pluginDescription',
+  // Add only the capabilities this plugin actually uses.
+  permissions: [],
 
   settings: {
     // Define your plugin settings here
@@ -416,7 +448,7 @@ export const plugin: PluginDefinition = {
     ],
   },
 
-  onLoad(ctx: PluginContext): void {
+  onLoad(ctx): void {
     ctx.ui.registerPageHandler({
       async onMessage(pageId, action, data) {
         if (action === 'getSettings') {
@@ -436,17 +468,17 @@ export const plugin: PluginDefinition = {
   },
 
   hooks: {
-    onSlotStart(slotInfo: SlotInfo, messages: ParsedFT8Message[], ctx: PluginContext): void {
+    onSlotStart(slotInfo: SlotInfo, messages: ParsedFT8Message[], ctx): void {
       ctx.log.debug('Slot started', { slotId: slotInfo.id, messageCount: messages.length });
     },
 
-    onDecode(messages: ParsedFT8Message[], ctx: PluginContext): void {
+    onDecode(messages: ParsedFT8Message[], ctx): void {
       for (const msg of messages) {
         ctx.log.debug('Decoded message', { raw: msg.rawMessage, snr: msg.snr });
       }
     },
   },
-};
+});
 
 export const locales: Record<string, Record<string, string>> = {
   zh: zhLocale,
@@ -458,12 +490,15 @@ export default plugin;
 }
 
 function generateJsUtilityPlugin(config: PluginConfig): string {
-  return `/** @type {import('@tx5dr/plugin-api').PluginDefinition} */
-export const plugin = {
+  return `import { definePlugin } from '@tx5dr/plugin-api';
+
+export const plugin = definePlugin({
+  apiVersion: 2,
   name: '${config.name}',
   version: '0.1.0',
   type: 'utility',
   description: 'pluginDescription',
+  permissions: [],
 
   settings: {
     // Define your plugin settings here
@@ -480,19 +515,22 @@ export const plugin = {
       }
     },
   },
-};
+});
 
 export default plugin;
 `;
 }
 
 function generateJsUtilityPluginWithUI(config: PluginConfig): string {
-  return `/** @type {import('@tx5dr/plugin-api').PluginDefinition} */
-export const plugin = {
+  return `import { definePlugin } from '@tx5dr/plugin-api';
+
+export const plugin = definePlugin({
+  apiVersion: 2,
   name: '${config.name}',
   version: '0.1.0',
   type: 'utility',
   description: 'pluginDescription',
+  permissions: [],
 
   settings: {},
 
@@ -537,7 +575,7 @@ export const plugin = {
       }
     },
   },
-};
+});
 
 export default plugin;
 `;

--- a/packages/plugin-api/README.md
+++ b/packages/plugin-api/README.md
@@ -15,12 +15,14 @@ npm install --save-dev @tx5dr/plugin-api
 ### TypeScript
 
 ```typescript
-import type { PluginDefinition, PluginContext } from '@tx5dr/plugin-api';
+import { definePlugin } from '@tx5dr/plugin-api';
 
-const plugin: PluginDefinition = {
+const plugin = definePlugin({
+  apiVersion: 2,
   name: 'my-plugin',
   version: '1.0.0',
   type: 'utility',
+  permissions: [],
   hooks: {
     onDecode(messages, ctx) {
       for (const msg of messages) {
@@ -28,7 +30,7 @@ const plugin: PluginDefinition = {
       }
     },
   },
-};
+});
 
 export default plugin;
 ```
@@ -36,11 +38,14 @@ export default plugin;
 ### JavaScript (with JSDoc types)
 
 ```javascript
-/** @type {import('@tx5dr/plugin-api').PluginDefinition} */
-export default {
+import { definePlugin } from '@tx5dr/plugin-api';
+
+export default definePlugin({
+  apiVersion: 2,
   name: 'my-plugin',
   version: '1.0.0',
   type: 'utility',
+  permissions: [],
   hooks: {
     onDecode(messages, ctx) {
       for (const msg of messages) {
@@ -48,31 +53,111 @@ export default {
       }
     },
   },
-};
+});
 ```
 
 ## Exports
 
 | Subpath | Description |
 |---------|-------------|
-| `@tx5dr/plugin-api` | Core types: `PluginDefinition`, `PluginContext`, `PluginHooks`, helper interfaces, radio/message types |
+| `@tx5dr/plugin-api` | `definePlugin()`, capability-derived contexts, hooks, structured command ports, and radio/message types |
 | `@tx5dr/plugin-api/testing` | Mock factories for unit testing: `createMockContext()`, `createMockSlotInfo()`, `createMockParsedMessage()`, `createMockEventBus()` |
 | `@tx5dr/plugin-api/bridge` | Ambient type declarations for the iframe Bridge SDK (`window.tx5dr`) |
 
-## Radio Permissions
+## Capability Model
 
-Server-side plugins can use `ctx.radio` to inspect negotiated radio capabilities and, when explicitly permitted, control radio capabilities or physical power:
+Privileged Host APIs use an allowlist model. A plugin must declare every
+capability in `permissions`; the Host then projects only those properties into
+that plugin's context. Undeclared properties are absent from both the inferred
+TypeScript type and the runtime object. Use `definePlugin()` without manually
+widening callbacks to `PluginContext`, otherwise TypeScript cannot preserve the
+literal permission tuple.
+
+Capabilities grant structured Host ports, not physical device ownership. The
+capability-derived context does not directly expose raw PTT, audio playback,
+the mixer, encoder, physical frame lease, arbitrary radio capability writes,
+or global emergency stop. Strategy runtimes receive a narrower speculative
+context and return declarative decisions; they never receive command ports.
+
+For a strategy plugin, `type: 'strategy'` plus `apiVersion: 2` is the explicit
+declaration that it may produce RF decisions when selected by an operator. It
+does not need `operator:transmit-control`. That permission is reserved for
+utility plugins that need the imperative, Host-coordinated
+`ctx.operatorCommands` port.
+
+API v2 is required for strategy plugins and any plugin requesting a mutation
+capability. The Host validates and freezes the loaded definition so permissions
+cannot be expanded after load.
+
+This is a Host API contract, not a sandbox for hostile Node.js code. Third-party
+plugins currently execute in the server process; process isolation is a
+separate security boundary.
+
+## Operator Transmit Control
+
+Utility plugins that need to submit operator commands must declare
+`operator:transmit-control` and submit one of the high-level commands accepted
+by `ctx.operatorCommands`. The permission grants API access; it does not by
+itself classify the plugin as an automatic caller.
+
+Automatic calling plugins implement `isAutoCallEnabled()`. This both gates the
+command port and opts the plugin into the operator auto-call indicator and pause
+controls:
 
 ```ts
-permissions: ['radio:read', 'radio:control', 'radio:power']
+const plugin = definePlugin({
+  apiVersion: 2,
+  name: 'scheduled-caller',
+  version: '1.0.0',
+  type: 'utility',
+  permissions: ['operator:transmit-control'],
+  isAutoCallEnabled: (ctx) => ctx.config.enabled === true,
+  hooks: {
+    async onTimer(_timerId, ctx) {
+      await ctx.operatorCommands.submit({
+        type: 'request-call',
+        callsign: 'W1AW',
+      });
+    },
+  },
+});
 ```
 
-- `radio:read` enables `ctx.radio.capabilities.getSnapshot()` and `ctx.radio.power.getSupport()`.
-- `radio:control` enables `ctx.radio.setFrequency()` and `ctx.radio.capabilities.write()`.
-- `radio:power` enables `ctx.radio.power.set('on' | 'off' | 'standby' | 'operate')`.
-- `ctx.radio.mode` is always readable and exposes the current best-known operating mode using ADIF `MODE`/`SUBMODE` semantics, for example `SSB` + `USB` in voice USB.
+Integrations such as remote-control protocol bridges that may submit occasional
+commands but do not autonomously originate calls implement
+`isTransmitControlEnabled()` instead. They receive the same guarded command
+port but are not shown or paused as auto-call plugins.
+
+The Host allocates an operator command epoch and routes the request through the
+operator/frame coordinators. Plugins cannot directly key or unkey the radio.
+
+## Radio Permissions
+
+`ctx.radio` always exposes a small read-only operating snapshot. Additional
+radio capabilities require explicit declarations:
+
+```ts
+permissions: ['radio:read', 'radio:control', 'radio:tuner-control', 'radio:power']
+```
+
+- `radio:read` exposes `ctx.radioCapabilities` and the read-only `ctx.radioPower` view.
+- `radio:control` exposes Host-arbitrated `set-frequency` and `switch-band` commands.
+- `switch-band` can include `autoTune: true` when `radio:tuner-control` is also declared; the Host keeps the complete operation inside one physical-idle fence.
+- `radio:tuner-control` exposes only `set-enabled` and `start-manual-tune` through `ctx.radioTunerCommands`.
+- Radio writes reject while Digital, Voice, CW, Tune or manual PTT owns the physical transmitter; they never interrupt that transmission.
+- `radio:power` exposes `ctx.radioPowerCommands.submit({ type: 'set-power', state })`.
+- `ctx.radio.mode` remains read-only and uses ADIF `MODE`/`SUBMODE` semantics.
 
 These APIs are not exposed directly to iframe pages; custom UI should call a server-side page handler.
+
+## Logbook Permissions
+
+- `logbook:read` exposes only query and worked-status methods on `ctx.logbook`.
+- `logbook:write` exposes durable `addQSO()`/`updateQSO()` mutations in addition to reads.
+- `logbook:sync` exposes `ctx.logbookSync` for registering a Host-managed sync provider.
+
+Write completion means the Host logbook durability contract has completed.
+Logbook APIs never grant PTT or frame lifecycle control.
 
 ## Host Settings Permissions
 
@@ -89,9 +174,10 @@ Server-side plugins can use `ctx.settings` to read or update a safe whitelist of
 | `ctx.settings.ntp` | `settings:ntp` | `get()`, `update({ servers })` |
 
 ```ts
-import type { PluginDefinition } from '@tx5dr/plugin-api';
+import { definePlugin } from '@tx5dr/plugin-api';
 
-const plugin: PluginDefinition = {
+const plugin = definePlugin({
+  apiVersion: 2,
   name: 'station-policy',
   version: '1.0.0',
   type: 'utility',
@@ -102,7 +188,7 @@ const plugin: PluginDefinition = {
       await ctx.settings.station.update({ callsign: 'W1AW' });
     },
   },
-};
+});
 
 export default plugin;
 ```
@@ -163,10 +249,11 @@ Avoid generic names like `update` or `message` — they will collide.
 ### Basic Usage
 
 ```ts
-import type { PluginDefinition } from '@tx5dr/plugin-api';
+import { definePlugin } from '@tx5dr/plugin-api';
 
 // Publisher plugin
-const publisher: PluginDefinition = {
+const publisher = definePlugin({
+  apiVersion: 2,
   name: 'spot-monitor',
   version: '1.0.0',
   type: 'utility',
@@ -174,24 +261,25 @@ const publisher: PluginDefinition = {
   hooks: {
     onDecode(messages, ctx) {
       for (const msg of messages) {
-        ctx.eventBus?.publish('spot-monitor.new-spot', {
+        ctx.eventBus.publish('spot-monitor.new-spot', {
           callsign: msg.callsign,
           frequency: msg.frequencyHz,
         });
       }
     },
   },
-};
+});
 
 // Subscriber plugin
-const subscriber: PluginDefinition = {
+const subscriber = definePlugin({
+  apiVersion: 2,
   name: 'spot-logger',
   version: '1.0.0',
   type: 'utility',
   permissions: ['plugin:event-bus'],
   hooks: {
     onLoad(ctx) {
-      ctx.eventBus?.subscribe('spot-monitor.new-spot', (message) => {
+      ctx.eventBus.subscribe('spot-monitor.new-spot', (message) => {
         ctx.log.info('received spot', {
           from: message.publisher.pluginName,
           callsign: (message.payload as any).callsign,
@@ -199,7 +287,7 @@ const subscriber: PluginDefinition = {
       });
     },
   },
-};
+});
 ```
 
 ### Cross-Operator Communication
@@ -207,7 +295,7 @@ const subscriber: PluginDefinition = {
 Operator-scoped plugins can communicate across operators on the same host. The `publisher` metadata lets subscribers identify which operator sent the message:
 
 ```ts
-ctx.eventBus?.subscribe('qso-monitor.qso-complete', (message) => {
+ctx.eventBus.subscribe('qso-monitor.qso-complete', (message) => {
   const { callsign, band } = message.payload as any;
   ctx.log.info('QSO completed by another operator', {
     operator: message.publisher.operatorId,

--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tx5dr/plugin-api",
-  "version": "1.7.12",
+  "version": "2.0.0",
   "type": "module",
   "description": "Public plugin API for TX-5DR digital radio engine",
   "license": "MIT",

--- a/packages/plugin-api/src/__tests__/capability-context.test.ts
+++ b/packages/plugin-api/src/__tests__/capability-context.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { definePlugin } from '../definition.js';
+
+describe('capability-derived plugin contexts', () => {
+  it('keeps speculative strategy factories free of command capabilities', () => {
+    definePlugin({
+      apiVersion: 2,
+      name: 'safe-strategy',
+      version: '1.0.0',
+      type: 'strategy',
+      permissions: ['operator:transmit-control', 'radio:control'],
+      createStrategyRuntime(ctx) {
+        // @ts-expect-error strategy factories receive only the speculative read context
+        void ctx.operatorCommands;
+        // @ts-expect-error strategy factories cannot capture radio command ports
+        void ctx.radioCommands;
+        throw new Error('type-only fixture');
+      },
+      isAutoCallEnabled: () => true,
+    });
+  });
+
+  it('keeps unload cleanup free of runtime command capabilities', () => {
+    definePlugin({
+      apiVersion: 2,
+      name: 'safe-cleanup',
+      version: '1.0.0',
+      type: 'utility',
+      permissions: ['operator:transmit-control', 'radio:control', 'network'],
+      onUnload(ctx) {
+        void ctx.store.global.flush();
+        ctx.timers.clearAll();
+        void ctx.files;
+        // @ts-expect-error unload cannot submit operator mutations
+        void ctx.operatorCommands;
+        // @ts-expect-error unload cannot control the physical radio
+        void ctx.radioCommands;
+        // @ts-expect-error unload cannot retain network capabilities
+        void ctx.network;
+      },
+      isAutoCallEnabled: () => true,
+    });
+  });
+
+  it('never exposes raw physical transmission primitives, even with command capabilities', () => {
+    definePlugin({
+      apiVersion: 2,
+      name: 'host-arbitrated-transmit-control',
+      version: '1.0.0',
+      type: 'utility',
+      permissions: ['operator:transmit-control', 'radio:read', 'radio:control', 'radio:power'],
+      hooks: {
+        async onUserAction(_actionId, _payload, ctx) {
+          await ctx.operatorCommands.submit({ type: 'stop-automation' });
+          await ctx.radioCommands.submit({ type: 'set-frequency', frequency: 14_074_000 });
+
+          // @ts-expect-error physical PTT ownership is never a plugin capability
+          void ctx.setPTT;
+          // @ts-expect-error audio playback is owned by PhysicalTxCoordinator
+          void ctx.playAudio;
+          // @ts-expect-error frame mixing is an internal coordinator detail
+          void ctx.audioMixer;
+          // @ts-expect-error encoding is submitted through host intents only
+          void ctx.encoder;
+          // @ts-expect-error global emergency stop is reserved for authenticated host commands
+          void ctx.forceStopTransmission;
+        },
+      },
+      isAutoCallEnabled: () => true,
+    });
+  });
+
+  it('requires an explicit tuner capability for tuner RF actions', () => {
+    definePlugin({
+      apiVersion: 2,
+      name: 'frequency-only',
+      version: '1.0.0',
+      type: 'utility',
+      permissions: ['radio:control'],
+      hooks: {
+        onUserAction(_actionId, _payload, ctx) {
+          void ctx.radioCommands.submit({ type: 'set-frequency', frequency: 7_074_000 });
+          // @ts-expect-error tuner RF actions require radio:tuner-control
+          void ctx.radioTunerCommands;
+        },
+      },
+    });
+
+    definePlugin({
+      apiVersion: 2,
+      name: 'tuner-controller',
+      version: '1.0.0',
+      type: 'utility',
+      permissions: ['radio:tuner-control'],
+      hooks: {
+        onUserAction(_actionId, _payload, ctx) {
+          void ctx.radioTunerCommands.submit({ type: 'start-manual-tune' });
+          // @ts-expect-error tuner control does not grant frequency control
+          void ctx.radioCommands;
+        },
+      },
+    });
+  });
+
+});

--- a/packages/plugin-api/src/__tests__/testing-utils.test.ts
+++ b/packages/plugin-api/src/__tests__/testing-utils.test.ts
@@ -7,8 +7,11 @@ import {
   createMockContext,
   createMockSlotInfo,
   createMockParsedMessage,
-  createMockOperatorControl,
-  createMockRadioControl,
+  createMockOperatorSnapshot,
+  createMockOperatorCommandPort,
+  createMockRadioView,
+  createMockRadioCapabilitiesView,
+  createMockRadioPowerView,
   createMockLogbookAccess,
   createMockBandAccess,
   createMockHostSettingsControl,
@@ -74,24 +77,32 @@ describe('plugin-api testing utilities', () => {
   });
 
   describe('createMockContext', () => {
-    it('creates a full context with defaults', () => {
+    it('creates a safe context with defaults', () => {
       const ctx = createMockContext();
       expect(ctx.operator.callsign).toBe('W1AW');
       expect(ctx.operator.grid).toBe('FN31');
       expect(ctx.radio.isConnected).toBe(true);
       expect(ctx.config).toEqual({});
-      expect(typeof ctx.eventBus.publish).toBe('function');
+      expect('eventBus' in ctx).toBe(false);
     });
 
     it('does not expose mock host dependencies without permissions', () => {
       const ctx = createMockContext();
-      expect(ctx.hostDependencies.hamlib).toBeUndefined();
+      expect('hostDependencies' in ctx).toBe(false);
+      expect('operatorCommands' in ctx).toBe(false);
+    });
+
+    it('exposes only the host-arbitrated command port with transmit-control permission', async () => {
+      const ctx = createMockContext({ permissions: ['operator:transmit-control'] });
+      expect(ctx.operatorCommands).toBeDefined();
+      expect('startTransmitting' in ctx.operator).toBe(false);
+      await ctx.operatorCommands?.submit({ type: 'start-automation' });
     });
 
     it('provides mock host dependencies with host permissions', () => {
       const ctx = createMockContext({ permissions: ['host:hamlib'] });
-      expect(ctx.hostDependencies.hamlib?.Rotator.getHamlibVersion()).toBe('mock-hamlib');
-      expect(ctx.hostDependencies.hamlib?.Rotator.getSupportedRotators()).toEqual([]);
+      expect(ctx.hostDependencies?.hamlib?.Rotator.getHamlibVersion()).toBe('mock-hamlib');
+      expect(ctx.hostDependencies?.hamlib?.Rotator.getSupportedRotators()).toEqual([]);
     });
 
     it('accepts overrides', () => {
@@ -117,7 +128,7 @@ describe('plugin-api testing utilities', () => {
     });
 
     it('includes host settings mocks', async () => {
-      const ctx = createMockContext();
+      const ctx = createMockContext({ permissions: ['settings:ft8'] });
       await expect(ctx.settings.ft8.update({ maxSameTransmissionCount: 0 })).resolves.toMatchObject({
         maxSameTransmissionCount: 0,
       });
@@ -125,7 +136,7 @@ describe('plugin-api testing utilities', () => {
 
     it('accepts an event bus override', () => {
       const eventBus = createMockEventBus();
-      const ctx = createMockContext({ eventBus });
+      const ctx = createMockContext({ permissions: ['plugin:event-bus'], eventBus });
       expect(ctx.eventBus).toBe(eventBus);
     });
   });
@@ -221,17 +232,17 @@ describe('plugin-api testing utilities', () => {
     });
   });
 
-  describe('createMockOperatorControl', () => {
+  describe('createMockOperatorSnapshot', () => {
     it('has reasonable defaults', () => {
-      const op = createMockOperatorControl();
+      const op = createMockOperatorSnapshot();
       expect(op.isTransmitting).toBe(false);
       expect(op.mode.name).toBe('FT8');
       expect(op.getOtherOperators()).toEqual([]);
     });
 
     it('supports partial overrides', () => {
-      const otherMode = createMockOperatorControl().mode;
-      const op = createMockOperatorControl({
+      const otherMode = createMockOperatorSnapshot().mode;
+      const op = createMockOperatorSnapshot({
         isTransmitting: true,
         callsign: 'K1ABC',
         getOtherOperators: () => [{
@@ -254,14 +265,22 @@ describe('plugin-api testing utilities', () => {
     });
   });
 
-  describe('createMockRadioControl', () => {
+  describe('createMockOperatorCommandPort', () => {
+    it('records declarative commands', async () => {
+      const port = createMockOperatorCommandPort();
+      await port.submit({ type: 'stop-automation' });
+      expect(port._commands).toEqual([{ type: 'stop-automation' }]);
+    });
+  });
+
+  describe('radio capability mocks', () => {
     it('provides connected radio by default', () => {
-      const radio = createMockRadioControl();
+      const radio = createMockRadioView();
       expect(radio.isConnected).toBe(true);
       expect(radio.frequency).toBe(14074000);
       expect(radio.mode).toMatchObject({ engineMode: 'digital', mode: 'FT8', radioMode: 'USB' });
-      expect(radio.capabilities.getSnapshot()).toEqual({ descriptors: [], capabilities: [] });
-      expect(radio.power.getState()).toMatchObject({ state: 'awake', stage: 'idle' });
+      expect(createMockRadioCapabilitiesView().getSnapshot()).toEqual({ descriptors: [], capabilities: [] });
+      expect(createMockRadioPowerView().getState()).toMatchObject({ state: 'awake', stage: 'idle' });
     });
   });
 

--- a/packages/plugin-api/src/capabilities.ts
+++ b/packages/plugin-api/src/capabilities.ts
@@ -1,0 +1,58 @@
+import type { PluginPermission } from '@tx5dr/contracts';
+
+/**
+ * Top-level context properties granted by each manifest permission.
+ *
+ * The host consumes this registry when it constructs and guards a runtime
+ * context. Keeping the mapping in the public API package prevents the type
+ * contract and runtime capability surface from drifting apart.
+ */
+export const PLUGIN_CONTEXT_CAPABILITY_KEYS = {
+  'operator:transmit-control': ['operatorCommands'],
+  'radio:read': ['radioCapabilities', 'radioPower'],
+  'radio:control': ['radioCommands'],
+  'radio:tuner-control': ['radioTunerCommands'],
+  'radio:power': ['radioPowerCommands'],
+  'logbook:read': ['logbook'],
+  'logbook:write': ['logbook'],
+  'logbook:sync': ['logbookSync'],
+  'settings:ft8': ['settings'],
+  'settings:decode-windows': ['settings'],
+  'settings:realtime': ['settings'],
+  'settings:frequency-presets': ['settings'],
+  'settings:station': ['settings'],
+  'settings:psk-reporter': ['settings'],
+  'settings:ntp': ['settings'],
+  network: ['network', 'fetch'],
+  'plugin:event-bus': ['eventBus'],
+  'host:hamlib': ['hostDependencies'],
+} as const satisfies Partial<Record<PluginPermission, readonly string[]>>;
+
+export type PluginContextCapabilityPermission = keyof typeof PLUGIN_CONTEXT_CAPABILITY_KEYS;
+export type PluginContextCapabilityKey =
+  (typeof PLUGIN_CONTEXT_CAPABILITY_KEYS)[PluginContextCapabilityPermission][number];
+
+/** Permissions that expose host-arbitrated mutation ports and therefore require API v2. */
+export const PLUGIN_COMMAND_CAPABILITY_PERMISSIONS = [
+  'operator:transmit-control',
+  'radio:control',
+  'radio:tuner-control',
+  'radio:power',
+  'logbook:write',
+  'logbook:sync',
+] as const satisfies readonly PluginPermission[];
+
+export function getPluginContextCapabilityKeys(
+  permissions: readonly PluginPermission[] | undefined,
+): PluginContextCapabilityKey[] {
+  const keys = new Set<PluginContextCapabilityKey>();
+  for (const permission of permissions ?? []) {
+    const capabilityKeys = PLUGIN_CONTEXT_CAPABILITY_KEYS[
+      permission as PluginContextCapabilityPermission
+    ];
+    for (const key of capabilityKeys ?? []) {
+      keys.add(key);
+    }
+  }
+  return [...keys];
+}

--- a/packages/plugin-api/src/context.ts
+++ b/packages/plugin-api/src/context.ts
@@ -2,8 +2,15 @@ import type {
   KVStore,
   PluginLogger,
   PluginTimers,
-  OperatorControl,
-  RadioControl,
+  OperatorSnapshot,
+  OperatorCommandPort,
+  RadioView,
+  RadioCapabilitiesView,
+  RadioCommandPort,
+  RadioTunerCommandPort,
+  RadioPowerView,
+  RadioPowerCommandPort,
+  LogbookReadAccess,
   LogbookAccess,
   BandAccess,
   UIBridge,
@@ -11,6 +18,7 @@ import type {
   PluginNetworkControl,
   PluginEventBus,
 } from './helpers.js';
+import type { PluginPermission } from '@tx5dr/contracts';
 import type { LogbookSyncRegistrar } from './sync.js';
 import type { HostSettingsControl } from './settings.js';
 import type { HostDependencies } from './host-dependencies.js';
@@ -28,7 +36,7 @@ import type { HostDependencies } from './host-dependencies.js';
  * here, plugin code should treat it as unavailable rather than reaching into
  * TX-5DR internals.
  */
-export interface PluginContext {
+export interface PluginContextBase {
   /**
    * Resolved plugin configuration values.
    *
@@ -83,26 +91,13 @@ export interface PluginContext {
    */
   readonly timers: PluginTimers;
 
-  /**
-   * Control surface for the current operator.
-   */
-  readonly operator: OperatorControl;
+  /** Read-only snapshot and query surface for the current operator. */
+  readonly operator: OperatorSnapshot;
 
   /**
-   * Access to the physical radio state and tuning controls.
+   * Read-only projection of the physical radio state.
    */
-  readonly radio: RadioControl;
-
-  /**
-   * Full logbook access — read-only queries, record writes and UI notifications.
-   *
-   * Provides the original read-only helpers (`hasWorked`, `hasWorkedDXCC`,
-   * `hasWorkedGrid`) plus advanced query (`queryQSOs`, `countQSOs`), write
-   * (`addQSO`, `updateQSO`) and notification (`notifyUpdated`) capabilities.
-   * Sync providers and other data-oriented plugins use the write methods to
-   * self-orchestrate their flow without host-side special handling.
-   */
-  readonly logbook: LogbookAccess;
+  readonly radio: RadioView;
 
   /**
    * Read-only access to current-band and slot decode data.
@@ -124,53 +119,123 @@ export interface PluginContext {
    */
   readonly files: PluginFileStore;
 
-  /**
-   * Logbook sync registration entry point.
-   *
-   * Utility plugins that implement logbook synchronization call
-   * `ctx.logbookSync.register(provider)` during `onLoad` to register their
-   * sync provider. The host manages the provider lifecycle and UI integration.
-   */
-  readonly logbookSync: LogbookSyncRegistrar;
+}
 
-  /**
-   * Permission-gated host settings control surface.
-   *
-   * Each namespace requires the matching `settings:*` manifest permission.
-   */
-  readonly settings: HostSettingsControl;
+type CapabilityProperty<
+  Permissions extends readonly PluginPermission[],
+  Permission extends PluginPermission,
+  Property extends object,
+> = number extends Permissions['length']
+  ? object
+  : Permission extends Permissions[number] ? Property : object;
 
-  /**
-   * Permission-gated network capabilities.
-   *
-   * UDP sockets are host-managed and automatically closed when the plugin
-   * instance unloads. This is intentionally protocol-agnostic; protocol codecs
-   * such as WSJT-X UDP belong inside plugins.
-   */
-  readonly network?: PluginNetworkControl;
+type SettingsCapability<Permissions extends readonly PluginPermission[]> =
+  number extends Permissions['length']
+    ? object
+    : Extract<Permissions[number], `settings:${string}`> extends never
+      ? object
+      : {
+          readonly settings:
+            CapabilityProperty<Permissions, 'settings:ft8', Pick<HostSettingsControl, 'ft8'>>
+            & CapabilityProperty<Permissions, 'settings:decode-windows', Pick<HostSettingsControl, 'decodeWindows'>>
+            & CapabilityProperty<Permissions, 'settings:realtime', Pick<HostSettingsControl, 'realtime'>>
+            & CapabilityProperty<Permissions, 'settings:frequency-presets', Pick<HostSettingsControl, 'frequencyPresets'>>
+            & CapabilityProperty<Permissions, 'settings:station', Pick<HostSettingsControl, 'station'>>
+            & CapabilityProperty<Permissions, 'settings:psk-reporter', Pick<HostSettingsControl, 'pskReporter'>>
+            & CapabilityProperty<Permissions, 'settings:ntp', Pick<HostSettingsControl, 'ntp'>>;
+        };
 
-  /**
-   * Permission-gated plugin-to-plugin event bus.
-   *
-   * Topics are shared across plugin instances within the same host process.
-   * Treat this capability as optional and feature-detect before use.
-   */
-  readonly eventBus?: PluginEventBus;
+type LogbookCapability<Permissions extends readonly PluginPermission[]> =
+  number extends Permissions['length']
+    ? object
+    : 'logbook:write' extends Permissions[number]
+      ? { readonly logbook: LogbookAccess }
+      : 'logbook:read' extends Permissions[number]
+        ? { readonly logbook: LogbookReadAccess }
+        : object;
 
-  /**
-   * Host-owned runtime dependencies exposed to plugins.
-   *
-   * Native dependencies such as Hamlib are loaded by the host process. Each
-   * dependency is optional and requires its own manifest permission; feature
-   * detect before use.
-   */
-  readonly hostDependencies: HostDependencies;
+/**
+ * Plugin context whose privileged ports are derived from literal manifest
+ * permissions. Capabilities that were not declared do not exist in the type.
+ */
+export type PluginContextFor<Permissions extends readonly PluginPermission[]> =
+  PluginContextBase
+  & CapabilityProperty<Permissions, 'operator:transmit-control', {
+    readonly operatorCommands: OperatorCommandPort;
+  }>
+  & CapabilityProperty<Permissions, 'radio:read', {
+    readonly radioCapabilities: RadioCapabilitiesView;
+    readonly radioPower: RadioPowerView;
+  }>
+  & CapabilityProperty<Permissions, 'radio:control', {
+    readonly radioCommands: RadioCommandPort;
+  }>
+  & CapabilityProperty<Permissions, 'radio:tuner-control', {
+    readonly radioTunerCommands: RadioTunerCommandPort;
+  }>
+  & CapabilityProperty<Permissions, 'radio:power', {
+    readonly radioPowerCommands: RadioPowerCommandPort;
+  }>
+  & LogbookCapability<Permissions>
+  & CapabilityProperty<Permissions, 'logbook:sync', {
+    readonly logbookSync: LogbookSyncRegistrar;
+  }>
+  & SettingsCapability<Permissions>
+  & CapabilityProperty<Permissions, 'network', {
+    readonly network: PluginNetworkControl;
+    readonly fetch: (url: string, init?: RequestInit) => Promise<Response>;
+  }>
+  & CapabilityProperty<Permissions, 'plugin:event-bus', {
+    readonly eventBus: PluginEventBus;
+  }>
+  & CapabilityProperty<Permissions, 'host:hamlib', {
+    readonly hostDependencies: HostDependencies & Required<Pick<HostDependencies, 'hamlib'>>;
+  }>;
 
-  /**
-   * Permission-gated HTTP client.
-   *
-   * This method is only available when the plugin declares the corresponding
-   * network permission. Treat it as optional and feature-detect before calling.
-   */
-  readonly fetch?: (url: string, init?: RequestInit) => Promise<Response>;
+/** Safe default context for code that has not declared literal permissions. */
+export type PluginContext = PluginContextFor<readonly []>;
+
+/**
+ * Teardown-only context passed to `onUnload`.
+ *
+ * Cleanup may flush plugin-owned state and release plugin-owned files, but it
+ * cannot retain or acquire operator, radio, network, UI, event-bus or logbook
+ * command capabilities while the instance is being revoked.
+ */
+export type PluginCleanupContext = Pick<
+  PluginContextBase,
+  'store' | 'log' | 'timers' | 'files'
+>;
+
+/** Host-side erased runtime shape. Public plugin definitions should use `definePlugin()`. */
+export type RuntimePluginContext = PluginContextBase & Partial<{
+  operatorCommands: OperatorCommandPort;
+  radioCapabilities: RadioCapabilitiesView;
+  radioCommands: RadioCommandPort;
+  radioTunerCommands: RadioTunerCommandPort;
+  radioPower: RadioPowerView;
+  radioPowerCommands: RadioPowerCommandPort;
+  logbook: LogbookReadAccess | LogbookAccess;
+  logbookSync: LogbookSyncRegistrar;
+  settings: Partial<HostSettingsControl>;
+  network: PluginNetworkControl;
+  eventBus: PluginEventBus;
+  hostDependencies: HostDependencies;
+  fetch: (url: string, init?: RequestInit) => Promise<Response>;
+}>;
+
+/**
+ * Deliberately narrow context captured by a speculative strategy runtime.
+ * Decisions can inspect operator state and emit a result, but cannot retain a
+ * command, radio, logbook-write, network, timer or UI capability.
+ */
+export interface StrategyPluginContext {
+  readonly config: Readonly<Record<string, unknown>>;
+  readonly log: PluginLogger;
+  readonly operator: OperatorSnapshot;
+}
+
+/** Minimal context used to evaluate a transmit-control eligibility predicate. */
+export interface PluginEligibilityContext {
+  readonly config: Readonly<Record<string, unknown>>;
 }

--- a/packages/plugin-api/src/definition.ts
+++ b/packages/plugin-api/src/definition.ts
@@ -8,7 +8,12 @@ import type {
   PluginInstanceScope,
   PluginUIPageDescriptor,
 } from '@tx5dr/contracts';
-import type { PluginContext } from './context.js';
+import type {
+  PluginCleanupContext,
+  PluginContextFor,
+  PluginEligibilityContext,
+  StrategyPluginContext,
+} from './context.js';
 import type { PluginHooks } from './hooks.js';
 import type { StrategyRuntime } from './runtime.js';
 
@@ -76,7 +81,12 @@ import type { StrategyRuntime } from './runtime.js';
  * export default plugin;
  * ```
  */
-export interface PluginDefinition {
+export interface PluginDefinition<
+  Permissions extends readonly PluginPermission[] = readonly [],
+> {
+  /** Required for strategy and transmit-control plugins. */
+  apiVersion?: 2;
+
   /**
    * Stable machine-readable plugin identifier.
    *
@@ -126,7 +136,7 @@ export interface PluginDefinition {
    * Permissions allow the host to gate sensitive features such as network
    * access. Always declare the smallest set that the plugin truly needs.
    */
-  permissions?: PluginPermission[];
+  permissions?: Permissions;
 
   /**
    * Declarative settings schema for generated configuration forms.
@@ -215,7 +225,7 @@ export interface PluginDefinition {
    * should be omitted for utility plugins. The returned runtime becomes the
    * operator's active automation controller.
    */
-  createStrategyRuntime?(ctx: PluginContext): StrategyRuntime;
+  createStrategyRuntime?(ctx: StrategyPluginContext): StrategyRuntime;
 
   /**
    * Runs after the plugin instance has been loaded and the context is ready.
@@ -224,7 +234,7 @@ export interface PluginDefinition {
    * sending initial panel data. Keep it fast; long-running work should be
    * deferred or done asynchronously.
    */
-  onLoad?(ctx: PluginContext): void | Promise<void>;
+  onLoad?(ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Runs before the plugin instance is unloaded.
@@ -233,7 +243,7 @@ export interface PluginDefinition {
    * handled through the host abstractions. Any timers created via
    * {@link PluginContext.timers} are cleared automatically by the host.
    */
-  onUnload?(ctx: PluginContext): void | Promise<void>;
+  onUnload?(ctx: PluginCleanupContext): void | Promise<void>;
 
   /**
    * Event and pipeline hooks implemented by the plugin.
@@ -241,17 +251,44 @@ export interface PluginDefinition {
    * Hooks let utility plugins observe or transform the message flow, and let the
    * active strategy participate in decision making.
    */
-  hooks?: PluginHooks;
+  hooks?: PluginHooks<Permissions>;
 
   /**
-   * Reports whether this operator-scoped plugin currently has automatic
-   * calling/transmit-control behavior enabled for its operator instance.
+   * Safety gate for the operator command port.
    *
-   * Plugins that declare `operator:transmit-control` must implement this
-   * function. The host uses it both for operator-card status indicators and as
-   * a safety gate before allowing plugin code to call operator transmit-control
-   * APIs such as `startTransmitting`, `call`, `replyToDecode` or
-   * `sendFreeText`.
+   * Plugins that declare `operator:transmit-control` must implement this or
+   * {@link isAutoCallEnabled}. The host evaluates it immediately before each
+   * command so disabled remote-control or integration features cannot retain
+   * command authority.
    */
-  isAutoCallEnabled?(ctx: PluginContext): boolean;
+  isTransmitControlEnabled?(ctx: PluginEligibilityContext): boolean;
+
+  /**
+   * Marks an operator-scoped plugin as an automatic calling controller and
+   * reports whether that behavior is currently enabled.
+   *
+   * The host uses this declaration for the auto-call indicator and pause UI.
+   * It also acts as the command-port safety gate when
+   * {@link isTransmitControlEnabled} is omitted. Integrations that can submit
+   * occasional external commands but are not auto-call controllers should
+   * implement only {@link isTransmitControlEnabled}.
+   */
+  isAutoCallEnabled?(ctx: PluginEligibilityContext): boolean;
+}
+
+/** Type-erased plugin definition used by the host after module loading. */
+// Permission tuples are invariant because callback contexts depend on their
+// exact literals, so the host registry needs a deliberate existential erasure.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyPluginDefinition = PluginDefinition<any>;
+
+/**
+ * Defines a plugin while preserving literal permissions for capability-aware
+ * callback context inference. New plugins should use this helper instead of
+ * widening their definition to `PluginDefinition`.
+ */
+export function definePlugin<
+  const Permissions extends readonly PluginPermission[] = readonly [],
+>(definition: PluginDefinition<Permissions>): PluginDefinition<Permissions> {
+  return definition;
 }

--- a/packages/plugin-api/src/helpers.ts
+++ b/packages/plugin-api/src/helpers.ts
@@ -2,9 +2,7 @@ import type {
   ParsedFT8Message,
   SlotInfo,
   SlotPack,
-  QSORecord,
   FrameMessage,
-  OperatorSlots,
   ModeDescriptor,
   EngineMode,
   PermissionGrant,
@@ -15,7 +13,6 @@ import type {
   RadioPowerStateEvent,
   RadioPowerSupportInfo,
   RadioPowerTarget,
-  WriteCapabilityPayload,
 } from '@tx5dr/contracts';
 import type { StrategyRuntimeSnapshot } from './runtime.js';
 
@@ -228,7 +225,7 @@ export interface OtherOperatorSnapshot {
   readonly automation?: StrategyRuntimeSnapshot | null;
 }
 
-export interface OperatorControl {
+export interface OperatorSnapshot {
   /** Unique operator identifier used by the host. */
   readonly id: string;
   /** Whether this operator is currently transmitting or otherwise armed. */
@@ -249,34 +246,6 @@ export interface OperatorControl {
   /** Returns read-only snapshots for operators other than the current instance. */
   getOtherOperators(): OtherOperatorSnapshot[];
 
-  /** Enables transmission/automation for the current operator. */
-  startTransmitting(): void;
-
-  /** Disables transmission/automation for the current operator. */
-  stopTransmitting(): void;
-
-  /**
-   * Requests that the operator call the specified target station.
-   *
-   * Passing `lastMessage` helps the host preserve the triggering context.
-   */
-  call(callsign: string, lastMessage?: { message: FrameMessage; slotInfo: SlotInfo }): void;
-
-  /**
-   * Requests host-managed reply behavior for a decoded message.
-   *
-   * This is equivalent to an operator selecting a decode in the RX view while
-   * keeping the API independent from any specific UDP/control protocol.
-   */
-  replyToDecode(decode: { callsign: string; lastMessage: { message: FrameMessage; slotInfo: SlotInfo }; modifiers?: number }): void;
-
-  /**
-   * Updates the operator's transmit cycle preference.
-   *
-   * Pass a single value or an array to support alternating or multi-cycle modes.
-   */
-  setTransmitCycles(cycles: number | number[]): void;
-
   /**
    * Checks whether this operator has previously worked the given callsign.
    */
@@ -288,38 +257,59 @@ export interface OperatorControl {
    */
   isTargetBeingWorkedByOthers(targetCallsign: string): boolean;
 
-  /** Clears host-managed decoded-message views when available. */
-  clearDecodes(window?: number): void;
+}
 
-  /** Stops current transmission/automation. */
-  haltTransmission(options?: { autoOnly?: boolean }): void;
+/**
+ * Declarative operator mutations accepted by the host transmission framework.
+ *
+ * The command set deliberately contains no PTT, audio, mixer, encoder, raw
+ * transmit or emergency-stop primitive. Plugins can request product actions;
+ * only the host coordinators may translate them into a physical RF lifecycle.
+ */
+export type PluginOperatorCommand =
+  | { type: 'start-automation' }
+  | { type: 'stop-automation' }
+  | {
+      type: 'request-call';
+      callsign: string;
+      lastMessage?: { message: FrameMessage; slotInfo: SlotInfo };
+    }
+  | {
+      type: 'reply-to-decode';
+      callsign: string;
+      lastMessage: { message: FrameMessage; slotInfo: SlotInfo };
+      modifiers?: number;
+    }
+  | { type: 'set-transmit-cycles'; cycles: number | number[] }
+  | { type: 'remove-contribution' }
+  | { type: 'clear-decodes'; window?: number }
+  | { type: 'set-free-text'; text: string }
+  | { type: 'send-free-text'; text?: string }
+  | { type: 'set-temporary-location'; location: string }
+  | {
+      type: 'highlight-callsign';
+      callsign: string;
+      background?: string | null;
+      foreground?: string | null;
+      lastOnly?: boolean;
+    };
 
-  /** Stores the current free-text message without necessarily transmitting it. */
-  setFreeText(text: string): void;
+export interface PluginOperatorCommandResult {
+  /** Host command epoch allocated before any asynchronous work begins. */
+  epoch: number;
+  /** `superseded` means a newer host command revoked this request. */
+  outcome: 'completed' | 'superseded';
+}
 
-  /** Requests transmission of free text. If text is provided it is stored first. */
-  sendFreeText(text?: string): void;
-
-  /** Applies a temporary session grid/location override when the host supports it. */
-  setTemporaryLocation(location: string): void;
-
-  /** Requests callsign highlighting in host decode views when available. */
-  highlightCallsign(rule: { callsign: string; background?: string | null; foreground?: string | null; lastOnly?: boolean }): void;
-
-  /**
-   * Records a completed QSO through the host logbook pipeline.
-   */
-  recordQSO(record: QSORecord): Promise<QSORecord>;
-
-  /**
-   * Pushes updated slot text content to the frontend operator view.
-   */
-  notifySlotsUpdated(slots: OperatorSlots): void;
-
-  /**
-   * Pushes a strategy state change notification to the frontend operator view.
-   */
-  notifyStateChanged(state: string): void;
+/**
+ * Capability-scoped command port for plugins with
+ * `operator:transmit-control` and API v2.
+ *
+ * The property is omitted from contexts without that capability. Every submit
+ * is invocation-guarded and enters the host's per-operator intent lane.
+ */
+export interface OperatorCommandPort {
+  submit(command: PluginOperatorCommand): Promise<PluginOperatorCommandResult>;
 }
 
 /**
@@ -352,7 +342,7 @@ export interface RadioOperatingMode {
   readonly descriptor: ModeDescriptor;
 }
 
-export interface RadioControl {
+export interface RadioView {
   /** Current tuned radio frequency in Hz. */
   readonly frequency: number;
   /** Human-readable current band label, for example `20m`. */
@@ -362,36 +352,50 @@ export interface RadioControl {
   /** Whether the radio transport is currently connected. */
   readonly isConnected: boolean;
 
-  /** Negotiated radio capability controls. Requires radio plugin permissions. */
-  readonly capabilities: RadioCapabilitiesControl;
-
-  /** Physical radio power controls. Requires radio plugin permissions. */
-  readonly power: RadioPowerControl;
-
-  /**
-   * Requests a frequency change.
-   *
-   * The host remains responsible for serializing hardware access and enforcing
-   * any safety or capability constraints.
-   */
-  setFrequency(freq: number): Promise<void>;
 }
 
 /**
  * Access to the host-managed radio capability negotiation system.
  */
-export interface RadioCapabilitiesControl {
-  /** Returns the current capability descriptor/state snapshot. Requires `radio:read`. */
+export interface RadioCapabilitiesView {
+  /** Returns the current capability descriptor/state snapshot. */
   getSnapshot(): CapabilityList;
 
-  /** Returns a single capability state from the current snapshot, or null. Requires `radio:read`. */
+  /** Returns a single capability state from the current snapshot, or null. */
   getState(id: string): CapabilityState | null;
 
-  /** Refreshes readable capability values and returns the updated snapshot. Requires `radio:read`. */
+  /** Refreshes readable capability values and returns the updated snapshot. */
   refresh(): Promise<CapabilityList>;
+}
 
-  /** Writes a capability value or triggers an action capability. Requires `radio:control`. */
-  write(payload: WriteCapabilityPayload): Promise<void>;
+/** Declarative radio mutations accepted by the host radio coordinator. */
+export type PluginRadioCommand =
+  | { type: 'set-frequency'; frequency: number }
+  | {
+      /** Atomically changes band and optionally starts the radio's tuner while RF is idle. */
+      type: 'switch-band';
+      frequency: number;
+      autoTune?: boolean;
+    };
+
+/**
+ * Capability-scoped radio command port.
+ *
+ * This port exists only for plugins with `radio:control`. It deliberately does
+ * not expose a radio connection, PTT primitive, mode switch, audio output or
+ * any other physical device object.
+ */
+export interface RadioCommandPort {
+  submit(command: PluginRadioCommand): Promise<void>;
+}
+
+/** Explicit tuner operations; no arbitrary capability identifier is accepted. */
+export type PluginRadioTunerCommand =
+  | { type: 'set-enabled'; enabled: boolean }
+  | { type: 'start-manual-tune' };
+
+export interface RadioTunerCommandPort {
+  submit(command: PluginRadioTunerCommand): Promise<void>;
 }
 
 export interface RadioPowerSetOptions {
@@ -404,15 +408,23 @@ export interface RadioPowerSetOptions {
 /**
  * Access to physical radio power management.
  */
-export interface RadioPowerControl {
-  /** Returns power support information for the active or specified profile. Requires `radio:read`. */
+export interface RadioPowerView {
+  /** Returns power support information for the active or specified profile. */
   getSupport(profileId?: string): Promise<RadioPowerSupportInfo>;
 
-  /** Returns the last known power transition state for the active or specified profile. Requires `radio:read`. */
+  /** Returns the last known power transition state for the active or specified profile. */
   getState(profileId?: string): RadioPowerStateEvent | null;
+}
 
-  /** Requests a physical power transition. Requires `radio:power`. */
-  set(state: RadioPowerTarget, options?: RadioPowerSetOptions): Promise<RadioPowerResponse>;
+export type PluginRadioPowerCommand = {
+  type: 'set-power';
+  state: RadioPowerTarget;
+  options?: RadioPowerSetOptions;
+};
+
+/** Capability-scoped physical power command port for `radio:power` plugins. */
+export interface RadioPowerCommandPort {
+  submit(command: PluginRadioPowerCommand): Promise<RadioPowerResponse>;
 }
 
 /**
@@ -454,7 +466,7 @@ export interface QSOQueryFilter {
  * The host resolves an already registered concrete logbook on each operation,
  * which keeps the handle valid across reloads without implicitly creating data.
  */
-export interface CallsignLogbookAccess {
+export interface CallsignLogbookReadAccess {
   /** Normalized callsign that scopes this accessor. */
   readonly callsign: string;
 
@@ -465,6 +477,13 @@ export interface CallsignLogbookAccess {
   queryQSOs(filter: QSOQueryFilter): Promise<import('@tx5dr/contracts').QSORecord[]>;
   /** Counts QSO records matching the given filter. */
   countQSOs(filter?: QSOQueryFilter): Promise<number>;
+  /** Returns current statistics for this callsign's logbook. */
+  getStatistics(): Promise<import('@tx5dr/contracts').LogBookStatistics | null>;
+}
+
+export interface CallsignLogbookCommandPort {
+  /** Normalized callsign that scopes this accessor. */
+  readonly callsign: string;
   /** Adds a QSO and resolves with the final record after durable commit. */
   addQSO(record: import('@tx5dr/contracts').QSORecord): Promise<import('@tx5dr/contracts').QSORecord>;
   /** Updates a QSO and resolves with the final record after durable commit. */
@@ -472,11 +491,12 @@ export interface CallsignLogbookAccess {
     qsoId: string,
     updates: Partial<import('@tx5dr/contracts').QSORecord>,
   ): Promise<import('@tx5dr/contracts').QSORecord>;
-  /** Returns current statistics for this callsign's logbook. */
-  getStatistics(): Promise<import('@tx5dr/contracts').LogBookStatistics | null>;
   /** Notifies the frontend that this callsign's logbook changed. */
   notifyUpdated(operatorId?: string): Promise<void>;
 }
+
+export interface CallsignLogbookAccess
+  extends CallsignLogbookReadAccess, CallsignLogbookCommandPort {}
 
 /**
  * Full logbook access for plugins.
@@ -485,7 +505,7 @@ export interface CallsignLogbookAccess {
  * capabilities so that sync providers can self-orchestrate their entire flow
  * without host-side special handling.
  */
-export interface LogbookAccess {
+export interface LogbookReadAccess {
   // === Read-only helpers (original) ===
 
   /** Checks whether the callsign has already been worked. */
@@ -502,11 +522,11 @@ export interface LogbookAccess {
   /** Counts QSO records matching the given filter. */
   countQSOs(filter?: QSOQueryFilter): Promise<number>;
 
-  /** Returns a callsign-bound accessor suitable for global plugin instances. */
-  forCallsign(callsign: string): CallsignLogbookAccess;
+  /** Returns a read-only callsign-bound accessor suitable for global plugin instances. */
+  forCallsign(callsign: string): CallsignLogbookReadAccess;
+}
 
-  // === Write ===
-
+export interface LogbookCommandPort {
   /** Adds a QSO and resolves with the final record after durable commit. */
   addQSO(record: import('@tx5dr/contracts').QSORecord): Promise<import('@tx5dr/contracts').QSORecord>;
   /** Updates a QSO and resolves with the final record after durable commit. */
@@ -519,6 +539,14 @@ export interface LogbookAccess {
 
   /** Notifies the frontend to refresh logbook data (call after batch writes). */
   notifyUpdated(): Promise<void>;
+
+  /** Returns a callsign-bound durable mutation port for global plugin instances. */
+  forCallsign(callsign: string): CallsignLogbookCommandPort;
+}
+
+/** @deprecated Prefer capability-specific LogbookReadAccess and LogbookCommandPort. */
+export interface LogbookAccess extends LogbookReadAccess, LogbookCommandPort {
+  forCallsign(callsign: string): CallsignLogbookAccess;
 }
 
 /**

--- a/packages/plugin-api/src/hooks.ts
+++ b/packages/plugin-api/src/hooks.ts
@@ -1,5 +1,5 @@
-import type { ParsedFT8Message, SlotInfo, SlotPack, QSORecord, FrameMessage, FrequencyState } from '@tx5dr/contracts';
-import type { PluginContext } from './context.js';
+import type { ParsedFT8Message, SlotInfo, SlotPack, QSORecord, FrameMessage, FrequencyState, PluginPermission } from '@tx5dr/contracts';
+import type { PluginContextFor } from './context.js';
 
 /**
  * Candidate message plus an accumulated ranking score.
@@ -35,13 +35,9 @@ export interface QSOFailureInfo {
  */
 export interface StrategyDecision {
   /**
-   * Requests that the host stop transmitting and leave the active QSO flow.
-   *
-   * During a late re-decision (`meta.isReDecision === true`), the host treats
-   * this as an immediate abort request for the operator's in-flight
-   * transmission. In other words, `stop: true` means both:
-   * - stop the operator's automation/runtime state; and
-   * - interrupt the operator's current audio/PTT contribution right away.
+   * Requests that the host stop this operator's automation and leave the
+   * active QSO flow. This is a policy stop, not a physical RF interrupt: any
+   * committed/on-air frame is allowed to finish.
    */
   stop?: boolean;
   /**
@@ -169,7 +165,7 @@ export type FrequencyChangeState = FrequencyState;
  * Hooks should be quick and defensive. A misbehaving plugin can delay the whole
  * decode pipeline, so expensive work should be throttled, cached or deferred.
  */
-export interface PluginHooks {
+export interface PluginHooks<Permissions extends readonly PluginPermission[] = readonly []> {
   /**
    * Proposes an automatic call target while the operator is idle.
    *
@@ -180,7 +176,7 @@ export interface PluginHooks {
   onAutoCallCandidate?(
     slotInfo: SlotInfo,
     messages: ParsedFT8Message[],
-    ctx: PluginContext,
+    ctx: PluginContextFor<Permissions>,
   ): AutoCallProposal | null | undefined | Promise<AutoCallProposal | null | undefined>;
 
   /**
@@ -194,7 +190,7 @@ export interface PluginHooks {
   onConfigureAutoCallExecution?(
     request: AutoCallExecutionRequest,
     plan: AutoCallExecutionPlan,
-    ctx: PluginContext,
+    ctx: PluginContextFor<Permissions>,
   ): AutoCallExecutionPlan | null | undefined | Promise<AutoCallExecutionPlan | null | undefined>;
 
   /**
@@ -206,7 +202,7 @@ export interface PluginHooks {
    */
   onFilterCandidates?(
     candidates: ParsedFT8Message[],
-    ctx: PluginContext,
+    ctx: PluginContextFor<Permissions>,
   ): ParsedFT8Message[] | Promise<ParsedFT8Message[]>;
 
   /**
@@ -217,14 +213,14 @@ export interface PluginHooks {
    */
   onScoreCandidates?(
     candidates: ScoredCandidate[],
-    ctx: PluginContext,
+    ctx: PluginContextFor<Permissions>,
   ): ScoredCandidate[] | Promise<ScoredCandidate[]>;
 
   /**
    * Broadcast at the start of every slot with the slot metadata and decoded
    * messages already associated with that slot.
    */
-  onSlotStart?(slotInfo: SlotInfo, messages: ParsedFT8Message[], ctx: PluginContext): void;
+  onSlotStart?(slotInfo: SlotInfo, messages: ParsedFT8Message[], ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast with raw slot/frame context plus parsed messages.
@@ -232,7 +228,7 @@ export interface PluginHooks {
    * Prefer this hook when a plugin needs full decoder metadata or wants to
    * preserve a cache suitable for replay/status integrations.
    */
-  onSlotActivity?(event: SlotActivityEvent, ctx: PluginContext): void;
+  onSlotActivity?(event: SlotActivityEvent, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast whenever decoded messages become available.
@@ -240,38 +236,38 @@ export interface PluginHooks {
    * This fires even when the operator is idle, which makes it a good place for
    * monitoring, trigger detection and passive analytics.
    */
-  onDecode?(messages: ParsedFT8Message[], ctx: PluginContext): void;
+  onDecode?(messages: ParsedFT8Message[], ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast when the host operating frequency or band changes.
    */
-  onFrequencyChange?(state: FrequencyChangeState, ctx: PluginContext): void | Promise<void>;
+  onFrequencyChange?(state: FrequencyChangeState, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast when the host locks onto a target and a QSO officially starts.
    */
-  onQSOStart?(info: { targetCallsign: string; grid?: string }, ctx: PluginContext): void;
+  onQSOStart?(info: { targetCallsign: string; grid?: string }, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast after a QSO has been completed and recorded.
    */
-  onQSOComplete?(record: QSORecord, ctx: PluginContext): void;
+  onQSOComplete?(record: QSORecord, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast when an in-progress QSO terminates unsuccessfully.
    */
-  onQSOFail?(info: QSOFailureInfo, ctx: PluginContext): void;
+  onQSOFail?(info: QSOFailureInfo, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast when a named timer created through {@link PluginContext.timers}
    * fires.
    */
-  onTimer?(timerId: string, ctx: PluginContext): void;
+  onTimer?(timerId: string, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast when the user clicks one of the plugin's declared quick actions.
    */
-  onUserAction?(actionId: string, payload: unknown, ctx: PluginContext): void;
+  onUserAction?(actionId: string, payload: unknown, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 
   /**
    * Broadcast after one or more persisted plugin settings have changed.
@@ -279,5 +275,5 @@ export interface PluginHooks {
    * The `changes` object contains only the updated keys and their new resolved
    * values.
    */
-  onConfigChange?(changes: Record<string, unknown>, ctx: PluginContext): void;
+  onConfigChange?(changes: Record<string, unknown>, ctx: PluginContextFor<Permissions>): void | Promise<void>;
 }

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -21,8 +21,26 @@
  */
 
 /** Core plugin definition and lifecycle interfaces. */
-export type { PluginDefinition } from './definition.js';
-export type { PluginContext } from './context.js';
+export { definePlugin } from './definition.js';
+export {
+  PLUGIN_COMMAND_CAPABILITY_PERMISSIONS,
+  PLUGIN_CONTEXT_CAPABILITY_KEYS,
+  getPluginContextCapabilityKeys,
+} from './capabilities.js';
+export type {
+  PluginContextCapabilityKey,
+  PluginContextCapabilityPermission,
+} from './capabilities.js';
+export type { PluginDefinition, AnyPluginDefinition } from './definition.js';
+export type {
+  PluginContext,
+  PluginContextBase,
+  PluginCleanupContext,
+  PluginContextFor,
+  RuntimePluginContext,
+  StrategyPluginContext,
+  PluginEligibilityContext,
+} from './context.js';
 export type {
   HostDependencies,
   HamlibHostDependency,
@@ -57,6 +75,12 @@ export type {
   StrategyRuntimeSnapshot,
   StrategyRuntimeSlot,
   StrategyRuntimeSlotContentUpdate,
+  StrategyRuntimeCheckpoint,
+  StrategyDecisionMetaV2,
+  StrategyDecisionResult,
+  StrategyDecisionSource,
+  StrategyQSOCompletionEffect,
+  StrategyQSOCompletionSettlement,
 } from './runtime.js';
 export type {
   HostSettingsControl,
@@ -75,14 +99,27 @@ export type {
   PluginLogger,
   PluginTimers,
   OtherOperatorSnapshot,
-  OperatorControl,
-  RadioControl,
+  OperatorSnapshot,
+  OperatorCommandPort,
+  PluginOperatorCommand,
+  PluginOperatorCommandResult,
+  RadioView,
   RadioOperatingMode,
-  RadioCapabilitiesControl,
-  RadioPowerControl,
+  RadioCapabilitiesView,
+  RadioCommandPort,
+  PluginRadioCommand,
+  RadioTunerCommandPort,
+  PluginRadioTunerCommand,
+  RadioPowerView,
+  RadioPowerCommandPort,
+  PluginRadioPowerCommand,
   RadioPowerSetOptions,
   LogbookAccess,
+  LogbookReadAccess,
+  LogbookCommandPort,
   CallsignLogbookAccess,
+  CallsignLogbookReadAccess,
+  CallsignLogbookCommandPort,
   QSOQueryFilter,
   BandAccess,
   IdleTransmitFrequencyOptions,

--- a/packages/plugin-api/src/runtime.ts
+++ b/packages/plugin-api/src/runtime.ts
@@ -1,5 +1,5 @@
-import type { ParsedFT8Message, FrameMessage, SlotInfo } from '@tx5dr/contracts';
-import type { StrategyDecision, StrategyDecisionMeta } from './hooks.js';
+import type { ParsedFT8Message, FrameMessage, SlotInfo, QSORecord } from '@tx5dr/contracts';
+import type { StrategyDecision } from './hooks.js';
 
 /**
  * Logical FT8 transmit slot identifiers used by the built-in automation model.
@@ -44,6 +44,8 @@ export interface StrategyRuntimeSnapshot {
   context?: StrategyRuntimeContext;
   /** Optional list of user-visible next states, modes or branch hints. */
   availableSlots?: string[];
+  /** Host correlation token for QSO persistence; it is not an RF decision epoch. */
+  qsoLifecycleEpoch?: number;
 }
 
 /**
@@ -56,6 +58,35 @@ export interface StrategyRuntimeSlotContentUpdate {
   content: string;
 }
 
+export type StrategyDecisionSource = 'slot-auto' | 'late-decode';
+
+export interface StrategyDecisionMetaV2 {
+  epoch: number;
+  source: StrategyDecisionSource;
+  isReDecision: boolean;
+  signal: AbortSignal;
+}
+
+export type StrategyRuntimeCheckpoint = unknown;
+
+export interface StrategyQSOCompletionEffect {
+  record: QSORecord;
+  /** Stable within one strategy runtime generation; distinct from RF decision epochs. */
+  lifecycleEpoch: number;
+}
+
+export interface StrategyQSOCompletionSettlement {
+  lifecycleEpoch: number;
+  recordId: string;
+  status: 'committed' | 'failed';
+}
+
+export interface StrategyDecisionResult extends StrategyDecision {
+  transmission: string | null;
+  snapshot: StrategyRuntimeSnapshot;
+  qsoCompletion?: StrategyQSOCompletionEffect;
+}
+
 /**
  * Active controller for a `strategy` plugin.
  *
@@ -64,19 +95,29 @@ export interface StrategyRuntimeSlotContentUpdate {
  * respect to the incoming slot/decode stream.
  */
 export interface StrategyRuntime {
+  checkpoint(): StrategyRuntimeCheckpoint;
+
+  restore(checkpoint: StrategyRuntimeCheckpoint): void;
+
+  /**
+   * Optional acknowledgement for a declarative QSO effect. Implementations may
+   * use it to prevent a completed contact from leaking into the next lifecycle.
+   */
+  settleQSOCompletion?(settlement: StrategyQSOCompletionSettlement): void;
+
   /**
    * Re-evaluates the current automation state using the latest decoded messages.
    *
-   * Return `{ stop: true }` to ask the host to stop transmitting. During a
-   * late re-decision (`meta.isReDecision === true`), the host also immediately
-   * aborts the operator's current live transmission contribution. Any other
-   * decision fields can be added in future API revisions, so plugins should
-   * return an object rather than a bare boolean.
+   * Return `{ stop: true }` to stop this operator's automation and prevent new
+   * frames. It never grants an RF interrupt: an already committed/on-air frame
+   * is allowed to finish. Explicit operator contribution removal is available
+   * only through the invocation-guarded `operator:transmit-control` command
+   * port outside speculative strategy execution.
    */
   decide(
     messages: ParsedFT8Message[],
-    meta?: StrategyDecisionMeta,
-  ): Promise<StrategyDecision> | StrategyDecision;
+    meta: StrategyDecisionMetaV2,
+  ): Promise<StrategyDecisionResult> | StrategyDecisionResult;
 
   /**
    * Returns the exact text that should be transmitted next, or `null` when no

--- a/packages/plugin-api/src/testing/index.ts
+++ b/packages/plugin-api/src/testing/index.ts
@@ -13,8 +13,15 @@ import type {
   KVStore,
   PluginLogger,
   PluginTimers,
-  OperatorControl,
-  RadioControl,
+  OperatorSnapshot,
+  OperatorCommandPort,
+  PluginOperatorCommand,
+  RadioView,
+  RadioCapabilitiesView,
+  RadioCommandPort,
+  RadioTunerCommandPort,
+  RadioPowerView,
+  RadioPowerCommandPort,
   LogbookAccess,
   BandAccess,
   UIBridge,
@@ -30,7 +37,7 @@ import type {
   HostFrequencyPresetsSettings,
   HostSettingsControl,
 } from '../settings.js';
-import type { PluginContext } from '../context.js';
+import type { PluginContextFor } from '../context.js';
 import type { HostDependencies } from '../host-dependencies.js';
 // Type-only imports from contracts (devDependency — erased at compile time)
 import type {
@@ -72,7 +79,7 @@ export interface MockUIBridge extends UIBridge {
 }
 
 /** Full mock context with typed access to all sub-mocks. */
-export interface MockPluginContext extends PluginContext {
+interface MockPluginContextDecorations {
   readonly store: {
     readonly global: MockKVStore;
     readonly operator: MockKVStore;
@@ -81,9 +88,15 @@ export interface MockPluginContext extends PluginContext {
   readonly timers: MockTimers;
   readonly ui: MockUIBridge;
   readonly settings: HostSettingsControl;
-  readonly hostDependencies: HostDependencies;
-  readonly network: PluginNetworkControl;
-  readonly eventBus: PluginEventBus;
+}
+
+export type MockPluginContextFor<Permissions extends readonly PluginPermission[]> =
+  PluginContextFor<Permissions> & MockPluginContextDecorations;
+
+export type MockPluginContext = MockPluginContextFor<readonly []>;
+
+export interface MockOperatorCommandPort extends OperatorCommandPort {
+  readonly _commands: PluginOperatorCommand[];
 }
 
 export interface MockUdpSocket extends PluginUdpSocket {
@@ -208,7 +221,7 @@ export function createMockTimers(): MockTimers {
   };
 }
 
-// ===== Factory: OperatorControl =====
+// ===== Factory: Operator snapshot and commands =====
 
 const DEFAULT_MODE: ModeDescriptor = {
   name: 'FT8',
@@ -219,9 +232,9 @@ const DEFAULT_MODE: ModeDescriptor = {
   encodeAdvance: 400,
 };
 
-export function createMockOperatorControl(
-  overrides?: Partial<OperatorControl>,
-): OperatorControl {
+export function createMockOperatorSnapshot(
+  overrides?: Partial<OperatorSnapshot>,
+): OperatorSnapshot {
   return {
     id: 'operator-0',
     isTransmitting: false,
@@ -232,33 +245,31 @@ export function createMockOperatorControl(
     transmitCycles: [0],
     automation: null,
     getOtherOperators: () => [],
-    startTransmitting(): void {},
-    stopTransmitting(): void {},
-    call(): void {},
-    replyToDecode(): void {},
-    setTransmitCycles(): void {},
-    clearDecodes(): void {},
-    haltTransmission(): void {},
-    setFreeText(): void {},
-    sendFreeText(): void {},
-    setTemporaryLocation(): void {},
-    highlightCallsign(): void {},
     hasWorkedCallsign: async () => false,
     isTargetBeingWorkedByOthers: () => false,
-    async recordQSO(record: QSORecord): Promise<QSORecord> { return record; },
-    notifySlotsUpdated(): void {},
-    notifyStateChanged(): void {},
     ...overrides,
+  };
+}
+
+export function createMockOperatorCommandPort(
+  submit?: (command: PluginOperatorCommand) => void | Promise<void>,
+): MockOperatorCommandPort {
+  const commands: PluginOperatorCommand[] = [];
+  return {
+    _commands: commands,
+    async submit(command) {
+      commands.push(command);
+      await submit?.(command);
+      return { epoch: commands.length, outcome: 'completed' };
+    },
   };
 }
 
 // ===== Factory: RadioControl =====
 
-export function createMockRadioControl(
-  overrides?: Partial<RadioControl>,
-): RadioControl {
-  const capabilitySnapshot: CapabilityList = { descriptors: [], capabilities: [] };
-  const powerState: RadioPowerStateEvent = { state: 'awake', stage: 'idle' };
+export function createMockRadioView(
+  overrides?: Partial<RadioView>,
+): RadioView {
   return {
     frequency: 14074000,
     band: '20m',
@@ -269,24 +280,47 @@ export function createMockRadioControl(
       descriptor: DEFAULT_MODE,
     },
     isConnected: true,
-    capabilities: {
-      getSnapshot: () => capabilitySnapshot,
-      getState: (id) => capabilitySnapshot.capabilities.find((capability) => capability.id === id) ?? null,
-      refresh: async () => capabilitySnapshot,
-      write: async () => {},
-    },
-    power: {
-      getSupport: async (profileId = 'mock-profile') => ({
-        profileId,
-        canPowerOn: true,
-        canPowerOff: true,
-        supportedStates: ['off', 'standby', 'operate'],
-      }),
-      getState: () => powerState,
-      set: async (state) => ({ success: true, target: state, state: state === 'off' ? 'off' : 'awake' }),
-    },
-    setFrequency: async () => {},
     ...overrides,
+  };
+}
+
+export function createMockRadioCapabilitiesView(): RadioCapabilitiesView {
+  const snapshot: CapabilityList = { descriptors: [], capabilities: [] };
+  return {
+    getSnapshot: () => snapshot,
+    getState: (id: string) => snapshot.capabilities.find((capability) => capability.id === id) ?? null,
+    refresh: async () => snapshot,
+  };
+}
+
+export function createMockRadioCommandPort(): RadioCommandPort {
+  return { submit: async () => {} };
+}
+
+export function createMockRadioTunerCommandPort(): RadioTunerCommandPort {
+  return { submit: async () => {} };
+}
+
+export function createMockRadioPowerView(): RadioPowerView {
+  const state: RadioPowerStateEvent = { state: 'awake', stage: 'idle' };
+  return {
+    getSupport: async (profileId = 'mock-profile') => ({
+      profileId,
+      canPowerOn: true,
+      canPowerOff: true,
+      supportedStates: ['off', 'standby', 'operate'],
+    }),
+    getState: () => state,
+  };
+}
+
+export function createMockRadioPowerCommandPort(): RadioPowerCommandPort {
+  return {
+    submit: async (command) => ({
+      success: true,
+      target: command.state,
+      state: command.state === 'off' ? 'off' : 'awake',
+    }),
   };
 }
 
@@ -614,7 +648,9 @@ export function createMockHostSettingsControl(overrides?: Partial<HostSettingsCo
 
 // ===== Factory: PluginContext =====
 
-export interface MockPluginContextOptions {
+export interface MockPluginContextOptions<
+  Permissions extends readonly PluginPermission[] = readonly [],
+> {
   /** Initial config values (default: empty). */
   config?: Record<string, unknown>;
   /** Operator identifier (default: `'operator-0'`). */
@@ -628,11 +664,18 @@ export interface MockPluginContextOptions {
   /** Partial mode descriptor overrides. */
   mode?: Partial<ModeDescriptor>;
   /** Additional operator control overrides. */
-  operator?: Partial<OperatorControl>;
+  operator?: Partial<OperatorSnapshot>;
+  /** Optional command-port override. Otherwise created only with `operator:transmit-control`. */
+  operatorCommands?: OperatorCommandPort;
   /** Network control override. */
   network?: PluginNetworkControl;
   /** Radio control overrides. */
-  radio?: Partial<RadioControl>;
+  radio?: Partial<RadioView>;
+  radioCapabilities?: RadioCapabilitiesView;
+  radioCommands?: RadioCommandPort;
+  radioTunerCommands?: RadioTunerCommandPort;
+  radioPower?: RadioPowerView;
+  radioPowerCommands?: RadioPowerCommandPort;
   /** Logbook access overrides. */
   logbook?: Partial<LogbookAccess>;
   /** Band access overrides. */
@@ -644,12 +687,14 @@ export interface MockPluginContextOptions {
   /** Host dependency overrides. */
   hostDependencies?: HostDependencies;
   /** Manifest permissions to model permission-gated optional host dependencies. */
-  permissions?: PluginPermission[];
+  permissions?: Permissions;
   /** Pre-constructed stores (uses fresh empty stores when omitted). */
   store?: { global?: MockKVStore; operator?: MockKVStore };
 }
 
-export function createMockContext(options?: MockPluginContextOptions): MockPluginContext {
+export function createMockContext<
+  const Permissions extends readonly PluginPermission[] = readonly [],
+>(options?: MockPluginContextOptions<Permissions>): MockPluginContextFor<Permissions> {
   const opts = options ?? {};
   const log = createMockLogger();
   const timers = createMockTimers();
@@ -661,7 +706,7 @@ export function createMockContext(options?: MockPluginContextOptions): MockPlugi
     ? { ...DEFAULT_MODE, ...opts.mode }
     : DEFAULT_MODE;
 
-  const operator = createMockOperatorControl({
+  const operator = createMockOperatorSnapshot({
     id: opts.operatorId ?? 'operator-0',
     callsign: opts.callsign ?? 'W1AW',
     grid: opts.grid ?? 'FN31',
@@ -670,8 +715,25 @@ export function createMockContext(options?: MockPluginContextOptions): MockPlugi
     ...opts.operator,
   });
 
-  const radio = createMockRadioControl(opts.radio);
+  const radio = createMockRadioView(opts.radio);
   const logbook = createMockLogbookAccess(opts.logbook);
+  const readOnlyLogbook = {
+    hasWorked: logbook.hasWorked,
+    hasWorkedDXCC: logbook.hasWorkedDXCC,
+    hasWorkedGrid: logbook.hasWorkedGrid,
+    queryQSOs: logbook.queryQSOs,
+    countQSOs: logbook.countQSOs,
+    forCallsign(callsign: string) {
+      const access = logbook.forCallsign(callsign);
+      return {
+        callsign: access.callsign,
+        getLogBookId: access.getLogBookId,
+        queryQSOs: access.queryQSOs,
+        countQSOs: access.countQSOs,
+        getStatistics: access.getStatistics,
+      };
+    },
+  };
   const band = createMockBandAccess(opts.band);
 
   const settings = createMockHostSettingsControl(opts.settings);
@@ -692,16 +754,44 @@ export function createMockContext(options?: MockPluginContextOptions): MockPlugi
     timers,
     operator,
     radio,
-    logbook,
     band,
     ui,
-    settings,
-    hostDependencies,
     files,
-    network,
-    eventBus,
-    logbookSync,
-  };
+    ...((opts.permissions?.includes('logbook:read') || opts.permissions?.includes('logbook:write')) ? {
+      logbook: opts.permissions?.includes('logbook:write') ? logbook : readOnlyLogbook,
+    } : {}),
+    ...(opts.permissions?.includes('logbook:sync') ? { logbookSync } : {}),
+    ...((opts.permissions ?? []).some(permission => permission.startsWith('settings:')) ? {
+      settings: {
+        ...(opts.permissions?.includes('settings:ft8') ? { ft8: settings.ft8 } : {}),
+        ...(opts.permissions?.includes('settings:decode-windows') ? { decodeWindows: settings.decodeWindows } : {}),
+        ...(opts.permissions?.includes('settings:realtime') ? { realtime: settings.realtime } : {}),
+        ...(opts.permissions?.includes('settings:frequency-presets') ? { frequencyPresets: settings.frequencyPresets } : {}),
+        ...(opts.permissions?.includes('settings:station') ? { station: settings.station } : {}),
+        ...(opts.permissions?.includes('settings:psk-reporter') ? { pskReporter: settings.pskReporter } : {}),
+        ...(opts.permissions?.includes('settings:ntp') ? { ntp: settings.ntp } : {}),
+      },
+    } : {}),
+    ...(opts.permissions?.includes('operator:transmit-control') ? {
+      operatorCommands: opts.operatorCommands ?? createMockOperatorCommandPort(),
+    } : {}),
+    ...(opts.permissions?.includes('radio:read') ? {
+      radioCapabilities: opts.radioCapabilities ?? createMockRadioCapabilitiesView(),
+      radioPower: opts.radioPower ?? createMockRadioPowerView(),
+    } : {}),
+    ...(opts.permissions?.includes('radio:control') ? {
+      radioCommands: opts.radioCommands ?? createMockRadioCommandPort(),
+    } : {}),
+    ...(opts.permissions?.includes('radio:tuner-control') ? {
+      radioTunerCommands: opts.radioTunerCommands ?? createMockRadioTunerCommandPort(),
+    } : {}),
+    ...(opts.permissions?.includes('radio:power') ? {
+      radioPowerCommands: opts.radioPowerCommands ?? createMockRadioPowerCommandPort(),
+    } : {}),
+    ...(opts.permissions?.includes('host:hamlib') ? { hostDependencies } : {}),
+    ...(opts.permissions?.includes('network') ? { network, fetch: globalThis.fetch } : {}),
+    ...(opts.permissions?.includes('plugin:event-bus') ? { eventBus } : {}),
+  } as MockPluginContextFor<Permissions>;
 }
 
 // ===== Data factories =====

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -13,7 +13,9 @@ TX-5DR 数字电台核心后端：Fastify + 数字电台引擎 + 音频处理 + 
 
 | 子系统 | 文件 | 职责 |
 |--------|------|------|
-| `TransmissionPipeline` | `subsystems/TransmissionPipeline.ts` | encode→mix→PTT→play 全流程、编码跟踪 |
+| `TransmissionPipeline` | `subsystems/TransmissionPipeline.ts` | 数字帧事件适配、编码/混音结果路由、终态事件 |
+| `DigitalFrameCoordinator` | `transmission/DigitalFrameCoordinator.ts` | FT8/FT4 intent、epoch、整帧替换与时隙预算 |
+| `PhysicalTxCoordinator` | `transmission/PhysicalTxCoordinator.ts` | 唯一物理 PTT/audio lease、drain、硬中断与迟到操作 fence |
 | `RadioBridge` | `subsystems/RadioBridge.ts` | 电台事件转发、频率同步、断线恢复、健康检查 |
 | `ClockCoordinator` | `subsystems/ClockCoordinator.ts` | 时钟/解码/频谱/SlotPack 事件桥接、PSKReporter 转发 |
 | `AudioVolumeController` | `subsystems/AudioVolumeController.ts` | 音量读写 + ConfigManager 持久化 + 事件广播 |
@@ -29,7 +31,8 @@ TX-5DR 数字电台核心后端：Fastify + 数字电台引擎 + 音频处理 + 
 
 #### 添加新功能指南
 
-- 发射相关逻辑 → `TransmissionPipeline`
+- 数字帧生命周期 → `DigitalFrameCoordinator`；物理 PTT/播放生命周期 → `PhysicalTxCoordinator`
+- encode/mix 事件适配 → `TransmissionPipeline`；插件只提交高层 intent
 - 电台连接/断线处理 → `RadioBridge`
 - 新的时钟/解码事件 → `ClockCoordinator`
 - 音量控制 → `AudioVolumeController`
@@ -80,216 +83,65 @@ routes/
   └─ profiles.ts               ← Profile REST API
 ```
 
-### 发射时序系统 ⭐
+### 发射时序系统
 
-**核心原则**:
-1. **WSJT-X 标准对齐**: 通过 `transmitTiming` 让信号在时隙边界后 ~0.5s 起始（FT8/FT4 都按 500ms）
-2. **提前编码**: 通过 `encodeAdvance` 提前触发编码，补偿编码+混音时间（FT8=0；FT4=300，FT4 时隙短必须提前）
-3. **周期判断**: RadioOperator 在 `encodeStart` 事件中判断周期并加入队列
-4. **子系统编排**: ClockCoordinator 桥接时钟事件，TransmissionPipeline 编排发射管线
-5. **智能调度**: AudioMixer 根据目标播放时间动态调整混音窗口
-
-#### 时间线图解
+发射控制分成数字帧与物理发射两层。`DigitalFrameCoordinator` 管理 intent、frame epoch、不可变混音快照和晚到纠正；`PhysicalTxCoordinator` 是唯一可操作共享 PTT 和播放生命周期的 owner。日志写入、同步和插件 completion 不得控制物理 lease。
 
 ```mermaid
 sequenceDiagram
     participant Clock as SlotClock
-    participant Coord as ClockCoordinator
-    participant Pipeline as TransmissionPipeline
-    participant Operator as RadioOperator
     participant Manager as RadioOperatorManager
-    participant EncQueue as WSJTXEncodeWorkQueue
+    participant Frame as DigitalFrameCoordinator
+    participant Encode as EncodeQueue
     participant Mixer as AudioMixer
-    participant PTT as PhysicalRadioManager
+    participant Pipeline as TransmissionPipeline
+    participant Physical as PhysicalTxCoordinator
+    participant Radio as PhysicalRadioManager
     participant Audio as AudioStreamManager
 
-    Note over Clock,Audio: ═══ 时隙开始 (T0) ═══
-    Clock->>Coord: slotStart 事件
-    Coord->>Pipeline: forceStopPTT() + onSlotStart()
-    Pipeline->>Mixer: clearSlotCache()
-    Coord->>Manager: broadcastAllOperatorStatusUpdates()
-    Coord->>Coord: engineEmitter.emit('slotStart', slotInfo, slotPack)
-
-    Note over Clock,Audio: ═══ 编码时机 (T0 + transmitTiming - encodeAdvance) ═══
-    Clock->>Coord: encodeStart(slotInfo)
-    Coord->>Coord: engineEmitter.emit('encodeStart', slotInfo)
-    Coord->>Pipeline: onEncodeStart(slotInfo)
-
-    Note over Operator,Manager: RadioOperator 监听 engineEmitter 的 encodeStart
-    Operator->>Operator: isTransmitSlot(slotInfo) via CycleUtils
-
-    alt 在发射周期
-        Operator->>Operator: transmissionStrategy.handleTransmitSlot()
-        Operator->>Manager: emit('requestTransmit', {operatorId, transmission})
-        Note right of Manager: pendingTransmissions.push()
-    else 非发射周期
-        Operator->>Operator: isTransmitSlot() ✗ → 跳过
+    Clock->>Manager: encodeStart(slotInfo)
+    Manager->>Frame: prepareFrame(intents, slot budget)
+    Frame-->>Manager: frameId + decisionEpoch + revision
+    Manager->>Encode: encode(frame identity)
+    Encode-->>Pipeline: encodeComplete(frame identity)
+    Pipeline->>Frame: acceptEncodeResult()
+    Pipeline->>Mixer: addOperatorAudio(frame identity)
+    Mixer-->>Pipeline: mixedAudioReady(immutable frame)
+    Pipeline->>Frame: validate budget + commitFrame()
+    Pipeline->>Physical: transmitAudio(frame lease)
+    Physical->>Radio: setTxDialOffset + setPTT(true)
+    Physical->>Physical: validate budget again after each delayed start stage
+    Physical->>Audio: playAudio(playbackId)
+    Physical-->>Pipeline: phase=active only after PTT and audio start
+    alt late correction or one participant removed
+        Pipeline->>Mixer: mix complete replacement snapshot
+        Mixer-->>Pipeline: prepared replacement waveform
+        Pipeline->>Physical: commitAudioReplacement(prepared waveform)
+        Physical->>Audio: stop old playback generation + wait for drain
+        Physical->>Audio: slice at current slot cursor + play new generation
+        Note over Physical,Radio: PTT remains asserted
+    else final playback or last participant removed
+        Audio-->>Physical: playback drained
+        Physical->>Radio: setPTT(false) + clearTxDialOffset
+        Physical-->>Pipeline: exactly-once physical terminal
     end
-
-    Pipeline->>Manager: processPendingTransmissions(slotInfo)
-    Manager->>Manager: 去重 + 使用 slotInfo.startMs 计算时间戳
-
-    loop 处理队列中的每个请求
-        Manager->>EncQueue: push({message, frequency, slotStartMs, requestId})
-    end
-
-    Note over Clock,Audio: ═══ 音频编码 (100-200ms) ═══
-    EncQueue->>EncQueue: wsjtx-lib 生成 FT8 音频 + 重采样到 12kHz
-    EncQueue->>Pipeline: encodeComplete 事件
-    Pipeline->>Pipeline: transmissionTracker 记录编码完成
-    Pipeline->>Mixer: addOperatorAudio(operatorId, audioData, sampleRate, slotStartMs)
-    Pipeline->>Mixer: scheduleMixing(targetPlaybackTime = T0 + transmitTiming)
-
-    Note over Clock,Audio: ═══ 目标播放时机 (T0 + transmitTiming) ═══
-    Clock->>Coord: transmitStart(slotInfo)
-    Coord->>Pipeline: onTransmitStart(slotInfo)
-    Pipeline->>Pipeline: 检查编码是否超时（未完成则发出 timingWarning）
-
-    Note over Clock,Audio: ═══ 混音器智能调度 (动态窗口) ═══
-    Mixer->>Mixer: 定时器触发 triggerMixing()
-    Mixer->>Mixer: mixAllOperatorAudios() → 重采样/裁剪/合并/归一化
-    Mixer->>Pipeline: emit('mixedAudioReady', {audioData, sampleRate, duration, operatorIds})
-
-    Note over Clock,Audio: ═══ 并行启动发射 ═══
-    par PTT 激活
-        Pipeline->>PTT: setPTT(true)
-        Pipeline->>Pipeline: spectrumScheduler.setPTTActive(true)
-        Pipeline->>Pipeline: emit('pttStatusChanged', {isTransmitting: true})
-        PTT-->>Pipeline: PTT 激活完成
-    and 音频播放
-        Pipeline->>Audio: playAudio(mixedAudio)
-        Audio-->>Audio: 分块写入 RtAudio/ICOM（FT8≈12.64s，FT4≈6.0s）
-    end
-    Pipeline->>Pipeline: schedulePTTStop(duration + 200ms)
-
-    Note over Clock,Audio: ═══ 发射完成 ═══
-    Audio-->>Pipeline: playAudio() Promise 完成
-    Pipeline->>PTT: setPTT(false) (定时器延迟停止)
-    Pipeline->>Pipeline: spectrumScheduler.setPTTActive(false)
-    Pipeline->>Pipeline: emit('pttStatusChanged', {isTransmitting: false})
-    Pipeline->>Pipeline: emit('transmissionComplete', {operatorId, success, duration})
 ```
 
-#### 时序配置参数 (mode.schema.ts)
+生命周期固定为 `requested -> encoding -> ready -> committed -> on_air -> draining -> terminal`。普通策略停止、日志失败和插件异常只能取消 commit 前的 frame 或阻止下一次自动化；只有人工强停、设备断连和 shutdown 可以调用 `forceInterrupt()`。
 
-**FT8 模式** (WSJT-X 标准):
-- `slotMs: 15000` - 时隙长度 15 秒
-- `transmitTiming: 500` - 信号在 T+0.5s 起，12.64s 长，T+13.14s 结束
-- `encodeAdvance: 0` - encodeStart 与 transmitStart 同时触发；编码 100-200ms 完成后由 AudioMixer 智能调度
-- `windowTiming: [-3200, -1500, -300]` - 三轮解码（balanced 预设）
-- **时间线**: T0 → T0+500ms(编码开始 + 目标播放) → T0+13140ms(播放结束) → T0+11800/13500/14700ms(三轮解码) → T0+15000ms(时隙结束)
+晚到解码或人工编辑在 commit 前替换并 tombstone 旧 encode callback；已 on-air 时，重新编码完成后在同一个物理 PTT lease 内停止旧音频 generation、等待输出收敛，再按当前时隙位置播放新 generation，不能通过 `setPTT(false/true)` 实现内容替换。若剩余预算不足以容纳完整剩余波形和 tail hold，intent 延期到下一合法 TX cycle。
 
-**FT4 模式** (WSJT-X 标准 + 双 pass 解码):
-- `slotMs: 7500` - 时隙长度 7.5 秒
-- `transmitTiming: 500` - 信号在 T+0.5s 起，6.0s 长，T+6.5s 结束（与 WSJT-X/JTDX 对齐）
-- `encodeAdvance: 300` - encodeStart 在 T+200ms 触发，给编码 ~300ms 完成；FT4 时隙短，必须提前编码避免错过 transmitStart
-- `windowTiming: [-1500, 0]` - 双 pass 解码：T+6000ms 早 pass + T+7500ms 末 pass。早 pass 让下一周期 encodeStart 之前能拿到对端消息（自动 QSO 必需）
-- **时间线**: T0 → T0+200ms(编码开始) → T0+500ms(目标播放) → T0+6000ms(早 pass 解码) → T0+6500ms(播放结束) → T0+7500ms(末 pass 解码 + 时隙结束)
+多操作员始终生成新的不可变 mixed frame：显式移除一个操作员时复用其他操作员的原始编码音频并重混，PTT 保持开启；只有参与者集合变空时才释放 PTT。连续纠正和连续移除通过 playback generation fence 串行切换，旧播放 Promise 只能结束旧 frame，不能释放当前 lease。
 
-**调优建议**:
-- 如果经常出现编码超时告警，增大 `encodeAdvance`
-- 如果音频播放偏早/偏晚，微调 `transmitTiming` (±50ms)
-- 自动 QSO 在 FT4 上不响应：检查 `windowTiming` 是否包含早 pass（如 -1500）
-- TransmissionTracker 会记录详细时序统计，用于性能分析
+所有启动阶段都可能迟到：pre-start cleanup、dial offset、PTT ACK 后都必须重新检查完整帧预算。超时的 PTT stop、音频 cleanup 或 CAT cleanup 会留下 operation fence；底层 Promise 真正 settlement 前不得建立新 lease，防止旧 `PTT(false)` 或旧播放收尾关闭新发射。
 
-#### 关键事件流
+模式切换先进入 transmission maintenance gate，撤销所有未提交 candidate 和旧 decision，再硬中断当前物理 lease；只有 Coordinator 明确回到 `idle` 后才允许修改模式、频率和 SlotClock，`unknown` 必须拒绝切换。
 
-**1. 正常周期发射** (偶数周期操作员在偶数时隙发射)
-
-```
-SlotClock.encodeStart (T0 + 780ms)
-    ↓
-DigitalRadioEngine.emit('encodeStart', slotInfo)
-    ↓
-RadioOperator.onEncodeStart(slotInfo)
-    ├─ 计算周期: isTransmitCycle(slotInfo.utcSeconds)
-    ├─ ✓ 是发射周期
-    └─ emit('requestTransmit', { operatorId, transmission })
-        ↓
-RadioOperatorManager.pendingTransmissions.push(request)
-    ↓
-RadioOperatorManager.processPendingTransmissions(slotInfo)
-    ├─ 使用 slotInfo.startMs (准确时间戳)
-    ├─ 计算 targetTime = slotInfo.startMs + mode.transmitTiming
-    ├─ 处理队列中所有请求
-    └─ encodeQueue.push() → 开始编码
-        ↓
-编码完成 (通常100-200ms后)
-    ↓
-AudioMixer.addAudio(audioData, targetPlaybackTime)
-    ├─ 计算到目标时间的延迟
-    ├─ 如果距离目标>100ms: 等待到目标时间-50ms
-    └─ 如果距离目标<100ms: 立即混音
-        ↓
-混音完成 → 在目标时间 (T0 + mode.transmitTiming) 准确播放
-```
-
-**2. 非发射周期** (奇数周期操作员在偶数时隙)
-
-```
-SlotClock.encodeStart (T0 + 780ms)
-    ↓
-RadioOperator.onEncodeStart(slotInfo)
-    ├─ 计算周期: isTransmitCycle(slotInfo.utcSeconds)
-    ├─ ✗ 不是发射周期
-    └─ 输出日志，不发射 requestTransmit
-        ↓
-RadioOperatorManager.processPendingTransmissions(slotInfo)
-    └─ 队列为空，无操作
-```
-
-**3. 多操作员同周期发射** (2个操作员都在偶数周期)
-
-```
-encodeStart 事件 (T0 + 780ms)
-    ↓
-RadioOperator A → requestTransmit → 加入队列
-RadioOperator B → requestTransmit → 加入队列
-    ↓
-processPendingTransmissions()
-    ├─ 处理 Operator A 请求 → encodeQueue (目标时间: T0 + mode.transmitTiming)
-    ├─ 处理 Operator B 请求 → encodeQueue (目标时间: T0 + mode.transmitTiming)
-    └─ 两个编码并行进行
-        ↓
-AudioMixer 智能调度
-    ├─ 第一个编码完成 → addAudio(A, targetTime)
-    ├─ 等待第二个或超时 (基于targetTime计算)
-    ├─ 第二个编码完成 → addAudio(B, targetTime)
-    ├─ 触发混音窗口结束
-    └─ 合并两路音频 → 单次 PTT 发射混音结果
-```
-
-**4. 时隙中间切换** (用户手动切换发射内容)
-
-```
-用户操作 (切换槽位/修改内容/改变周期)
-    ↓
-operatorSlotChanged / operatorSlotContentChanged / operatorTransmitCyclesChanged
-    ↓
-RadioOperatorManager.checkAndTriggerTransmission(operatorId)
-    ├─ 检查当前是否在发射周期
-    ├─ ✓ 是 → 立即生成发射内容
-    └─ processPendingTransmissions(基于当前时隙startMs)
-        └─ 统一入队并消费，正确计算 timeSinceSlotStartMs（标记中途发射/重新混音）
-```
-
-#### 时间戳一致性保证
-
-**核心要点**: 所有时间计算使用同一个 `slotInfo.startMs`（中途触发时由管理器基于当前时隙计算得到），避免跨时隙边界错误；队列在消费层统一清空，防止请求残留导致下一个非发射周期误发。
-
-```
-    transmitStart(slotInfo) 触发 → processPendingTransmissions(slotInfo)
-        ↓
-    使用 slotInfo.startMs (事件产生时的准确时间)
-        ↓
-    所有操作基于同一时间戳
-        ↓
-    周期判断准确无误
-```
+UI 的 `on_air` 只来自 `PhysicalTxCoordinator` 的 `active` phase；`starting`、`committed` 不能显示为正在发射，`unknown` 不能显示为 RX。`transmissionComplete` 每个 frame/operator 只发一次，并携带 `frameId`、`physicalConfirmed` 与 terminal reason。
 
 ### 音频链路
 - **AudioStreamManager**: Audify (RtAudio) 低延迟 I/O，多设备动态切换，实时状态监控
-- **AudioMixer**: 多操作员混音，独立音量控制，PTT 逻辑
+- **AudioMixer**: 按不可变 frame identity 进行多操作员混音，不控制 PTT 或播放停止
 - **SpectrumAnalyzer**: WebWorker 并行 FFT，瀑布图数据，自适应调度
 
 ### 解码链路

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "node ../../scripts/clean-paths.mjs dist && tsc",
-    "dev": "node ../../scripts/run-with-env.mjs --node-env=development tsx watch --watch-path=src src/index.ts",
+    "dev": "node ../../scripts/run-with-env.mjs --node-env=development tsx watch --watch-path=src --include='../builtin-plugins/dist/**/*.js' src/index.ts",
     "dev:prof": "node ../../scripts/run-with-env.mjs --node-env=development tsx --prof src/index.ts",
     "clinic:doctor": "yarn build && clinic doctor -- node dist/index.js",
     "clinic:flame": "yarn build && clinic flame -- node dist/index.js",

--- a/packages/server/src/DigitalRadioEngine.ts
+++ b/packages/server/src/DigitalRadioEngine.ts
@@ -57,6 +57,10 @@ import {
   resolveFrequencyRadioMode,
 } from './radio/frequencyRadioMode.js';
 import { TransmissionTracker } from './transmission/TransmissionTracker.js';
+import { DigitalFrameCoordinator } from './transmission/DigitalFrameCoordinator.js';
+import { PhysicalTxCoordinator } from './transmission/PhysicalTxCoordinator.js';
+import { OperatorIntentCoordinator } from './transmission/OperatorIntentCoordinator.js';
+import type { PhysicalTxSnapshot } from './transmission/TransmissionIntent.js';
 import type { OpenWebRXAudioAdapter } from './openwebrx/OpenWebRXAudioAdapter.js';
 import { MemoryLeakDetector } from './utils/MemoryLeakDetector.js';
 import { ResourceManager } from './utils/ResourceManager.js';
@@ -74,6 +78,13 @@ type DecodeWorkerEngineEmitter = EventEmitter<{
   decodeWorkerUnavailable: (status: DecodeWorkerPoolHealthSnapshot) => void;
   decodeWorkerRecovered: (status: DecodeWorkerPoolHealthSnapshot) => void;
 }>;
+
+type OperatingStateSyncStatus = 'applied' | 'skipped-offline' | 'partially-applied' | 'failed';
+
+interface OperatingStateSyncResult {
+  status: OperatingStateSyncStatus;
+  detail?: string;
+}
 
 // 子系统
 import { AudioVolumeController } from './subsystems/AudioVolumeController.js';
@@ -100,6 +111,7 @@ import { RadioPowerController } from './radio/RadioPowerController.js';
 import { TuneToneController } from './radio/TuneToneController.js';
 import { buildRadioStatusPayload } from './radio/buildRadioStatusPayload.js';
 import type { RealtimeRxAudioRouter } from './realtime/RealtimeRxAudioRouter.js';
+import type { PluginRadioCommand, PluginRadioTunerCommand } from '@tx5dr/plugin-api';
 import path from 'node:path';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -221,6 +233,9 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
   private frequencyManager: FrequencyManager;
   private _operatorManager: RadioOperatorManager;
   private transmissionTracker: TransmissionTracker;
+  private digitalFrameCoordinator: DigitalFrameCoordinator;
+  private physicalTxCoordinator: PhysicalTxCoordinator;
+  private operatorIntentCoordinator: OperatorIntentCoordinator;
   private resourceManager: ResourceManager;
 
   // 语音模式
@@ -234,6 +249,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
   private cwDecoderManager: CWDecoderManager | null = null;
   private cwDecoderStartedEngine = false;
   private modeSwitchTail: Promise<void> = Promise.resolve();
+  private operatingStateWarningActive = false;
 
   // 子系统
   private audioVolumeController: AudioVolumeController;
@@ -296,6 +312,22 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     });
     this.audioMixer = new AudioMixer(100);
     this.radioManager = new PhysicalRadioManager();
+    this.digitalFrameCoordinator = new DigitalFrameCoordinator({ now: () => this.clockSource.now() });
+    this.operatorIntentCoordinator = new OperatorIntentCoordinator();
+    this.physicalTxCoordinator = new PhysicalTxCoordinator({
+      isRadioConnected: () => this.radioManager.isConnected(),
+      setPTT: (active) => this.radioManager.setPTT(active),
+      playAudio: (audioData, sampleRate, options) => this.audioStreamManager.playAudio(audioData, sampleRate, options),
+      stopCurrentPlayback: (options) => this.audioStreamManager.stopCurrentPlayback(options),
+      prepareAudioPlayback: () => this.audioStreamManager.waitForOutputDrain(),
+      isAudioPlaying: (kind) => this.audioStreamManager.isPlaying(kind),
+      setTxDialOffset: (shiftHz) => this.radioManager.setTxDialOffset(shiftHz),
+      clearTxDialOffset: () => this.radioManager.clearTxDialOffset(),
+      now: () => this.clockSource.now(),
+    });
+    this.physicalTxCoordinator.on('phaseChanged', (snapshot) => {
+      this.handleCoordinatedPhysicalTxChanged(snapshot);
+    });
     this.frequencyManager = new FrequencyManager(ConfigManager.getInstance().getCustomFrequencyPresets());
     this.transmissionTracker = new TransmissionTracker();
     this.resourceManager = new ResourceManager();
@@ -348,6 +380,9 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       },
       transmissionTracker: this.transmissionTracker,
       callsignTracker: this._callsignTracker,
+      digitalFrameCoordinator: this.digitalFrameCoordinator,
+      getTransmitCompensationMs: () => this.slotClock?.getCompensation() ?? 0,
+      intentCoordinator: this.operatorIntentCoordinator,
     });
 
     // 初始化插件管理器（在操作员管理器之后）
@@ -382,6 +417,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
           return false;
         }
       },
+      submitRadioMaintenanceCommand: (command) => this.submitPluginRadioMaintenanceCommand(command),
       getRadioBand: () => ConfigManager.getInstance().getLastSelectedFrequency()?.band ?? '',
       getRadioConnected: () => this.radioManager.isConnected(),
       getRadioCapabilitySnapshot: () => this.radioManager.getCapabilitySnapshot(),
@@ -407,12 +443,34 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
           additionalOccupiedFrequenciesHz,
         )
       ),
-      setOperatorAudioFrequency: async (operatorId, frequency) => {
-        await this._operatorManager.updateOperatorContext(operatorId, { frequency });
+      setOperatorAudioFrequency: async (operatorId, frequency, commandToken) => {
+        await this._operatorManager.updateOperatorContext(operatorId, { frequency }, {
+          commandEpoch: commandToken?.epoch,
+          source: commandToken?.source,
+          reason: 'auto-call execution plan changed audio frequency',
+        });
       },
       interruptOperatorTransmission: async (operatorId) => {
-        await this.removeOperatorFromTransmission(operatorId);
+        this._operatorManager.getOperatorById(operatorId)?.stop();
+        await this.physicalTxCoordinator.forceInterrupt(`manual plugin halt: ${operatorId}`);
       },
+      requestOperatorStrategyStop: (operatorId, reason) => {
+        this._operatorManager.requestStrategyStop(operatorId, reason);
+      },
+      transitionTargetReservation: (operatorId, epoch, targetCallsign) => (
+        this._operatorManager.transitionTargetReservation(operatorId, epoch, targetCallsign)
+      ),
+      releaseTargetReservation: (operatorId, epoch) => {
+        this._operatorManager.releaseTargetReservation(operatorId, epoch);
+      },
+      removeOperatorContribution: (operatorId, options) => this.transmissionPipeline.removeOperatorFromTransmission(
+        operatorId,
+        {
+          commandAlreadyAllocated: true,
+          signal: options.signal,
+          commandToken: options.commandToken,
+        },
+      ),
       hasWorkedCallsign: async (operatorId, callsign, options) => {
         return this._operatorManager.hasWorkedCallsign(operatorId, callsign, options);
       },
@@ -493,9 +551,10 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       resetOperatorRuntime: (operatorId, reason) => {
         this._operatorManager.resetPluginRuntime(operatorId, reason);
       },
-      triggerReEncode: (operatorId) => {
-        this._operatorManager.triggerPostDecisionReEncode(operatorId);
+      triggerReEncode: (operatorId, options) => {
+        this._operatorManager.triggerPostDecisionReEncode(operatorId, options);
       },
+      intentCoordinator: this.operatorIntentCoordinator,
       dataDir: '', // 将在 initialize() 中更新
     });
 
@@ -532,11 +591,13 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       engineEmitter: this,
       audioMixer: this.audioMixer,
       audioStreamManager: this.audioStreamManager,
-      radioManager: this.radioManager,
       spectrumScheduler: this.spectrumScheduler,
       transmissionTracker: this.transmissionTracker,
       encodeQueue: this.realEncodeQueue,
       operatorManager: this._operatorManager,
+      digitalFrameCoordinator: this.digitalFrameCoordinator,
+      physicalTxCoordinator: this.physicalTxCoordinator,
+      intentCoordinator: this.operatorIntentCoordinator,
       clockSource: this.clockSource,
       getCurrentMode: () => this.currentMode,
       getCompensationMs: () => this.slotClock?.getCompensation() ?? 0,
@@ -549,6 +610,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       frequencyManager: this.frequencyManager,
       slotPackManager: this.slotPackManager,
       operatorManager: this._operatorManager,
+      physicalTxCoordinator: this.physicalTxCoordinator,
       getTransmissionPipeline: () => this.transmissionPipeline,
       getEngineLifecycle: () => this.engineLifecycle,
       getEngineMode: () => this.engineMode,
@@ -567,15 +629,16 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       // CAT PTT reads report the radio's TX/RX state, not who caused TX.
       // Keep polling paused while tx5dr or the keyer is holding PTT so our own
       // keyer transmission is not misclassified as a physical manual override.
-      isSoftwarePttActive: () => this.voiceManualPttActive || this.voiceKeyerPttActive,
+      isSoftwarePttActive: () => this.physicalTxCoordinator.getSnapshot().phase !== 'idle'
+        || this.voiceManualPttActive
+        || this.voiceKeyerPttActive,
       emitStatus: (active) => this.handlePhysicalPttChanged(active),
     });
     this.tuneToneController = new TuneToneController({
       radioManager: this.radioManager,
-      audioStreamManager: this.audioStreamManager,
+      physicalTxCoordinator: this.physicalTxCoordinator,
       isTransmitBusy: () => this.isTransmitBusyForTuneTone(),
       getOperatorToneHz: (operatorId) => this.resolveTuneToneFrequency(operatorId),
-      setSoftwarePttActive: (active) => this.setTuneTonePttActive(active),
       emitStatus: (status) => this.emit('tuneToneStatusChanged', status),
     });
     this.on('radioStatusChanged', () => {
@@ -591,7 +654,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       }
     });
 
-    this.rigctldBridge = new RigctldBridge(this.radioManager);
+    this.rigctldBridge = new RigctldBridge(this.radioManager, this.physicalTxCoordinator);
     this.rigctldBridge.on('statusChanged', (status) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this.emit('rigctldStatus' as any, status);
@@ -834,7 +897,10 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
   public getCWKeyerManager(): CWKeyerManager {
     if (!this.cwKeyerManager) {
-      this.cwKeyerManager = new CWKeyerManager(() => this.radioManager);
+      this.cwKeyerManager = new CWKeyerManager(
+        () => this.radioManager,
+        this.physicalTxCoordinator,
+      );
       this.cwKeyerManager.on('cwKeyerStatusChanged', (status) => {
         this.handleCWKeyerStatusChanged(status);
         this.emit('cwKeyerStatusChanged', status);
@@ -1140,6 +1206,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     this.voiceSessionManager = new VoiceSessionManager({
       radioManager: this.radioManager,
       audioStreamManager: this.audioStreamManager,
+      physicalTxCoordinator: this.physicalTxCoordinator,
       onBeforeStartPTT: () => this.stopTuneTone('voice transmission started'),
     });
     this.voiceKeyerManager = new VoiceKeyerManager({
@@ -1159,6 +1226,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       spectrumScheduler: this.spectrumScheduler,
       decodeQueue: this.realDecodeQueue,
       operatorManager: this._operatorManager,
+      physicalTxCoordinator: this.physicalTxCoordinator,
       audioMixer: this.audioMixer,
       clockSource: this.clockSource,
       subsystems: {
@@ -1207,9 +1275,8 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     this.voiceSessionManager.on('voicePttLockChanged', (lock) => {
       this.emit('voicePttLockChanged', lock);
     });
-    this.voiceSessionManager.on('pttStatusChanged', (data) => {
-      this.handleVoiceSoftwarePttChanged(data);
-    });
+    // Physical PTT state is projected exclusively from PhysicalTxCoordinator.
+    // Voice session events remain session-local and are not a second RF truth.
     this.voiceSessionManager.on('voiceRadioModeChanged', (data) => {
       this.emit('voiceRadioModeChanged', data);
     });
@@ -1292,6 +1359,9 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
   }
 
   async stop(): Promise<void> {
+    // Profile/power/shutdown stops are full session boundaries. Let an
+    // already-serialized mode transaction settle before disconnecting CAT.
+    await this.modeSwitchTail.catch(() => undefined);
     await this.stopTuneTone('engine stopped');
     return this.engineLifecycle.stop();
   }
@@ -1333,7 +1403,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
     // 清理音频混音器
     if (this.audioMixer) {
-      this.audioMixer.clear();
+      this.audioMixer.clearSlotCache();
       this.audioMixer.removeAllListeners();
       logger.info('Audio mixer cleaned up');
     }
@@ -1408,6 +1478,18 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     return this.transmissionPipeline.forceStopTransmission();
   }
 
+  public async testPhysicalPTT(durationMs = 500): Promise<void> {
+    const leaseId = await this.physicalTxCoordinator.acquireLease({
+      source: 'test',
+      reason: 'authenticated PTT test',
+    });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, durationMs));
+    } finally {
+      await this.physicalTxCoordinator.releaseLease(leaseId, 'PTT test complete');
+    }
+  }
+
   public async removeOperatorFromTransmission(operatorId: string): Promise<void> {
     return this.transmissionPipeline.removeOperatorFromTransmission(operatorId);
   }
@@ -1435,26 +1517,27 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
   async setMode(mode: ModeDescriptor | string): Promise<void> {
     const runSwitch = async () => {
-      await this.stopTuneTone('mode changed');
       // Handle CW mode
       if (typeof mode === 'object' && mode.name === 'CW') {
         if (this.engineMode === 'cw') {
+          await this.stopTuneTone('mode unchanged');
           logger.info('Already in CW mode');
           this.emitStatusSnapshot();
           return;
         }
-        await this.switchEngineMode('cw', MODES.CW);
+        await this.runWithModeChangeGate(() => this.switchEngineMode('cw', MODES.CW));
         return;
       }
 
       // Handle voice mode (string 'VOICE')
       if (mode === 'VOICE' || (typeof mode === 'object' && mode.name === 'VOICE')) {
         if (this.engineMode === 'voice') {
+          await this.stopTuneTone('mode unchanged');
           logger.info('Already in voice mode');
           this.emitStatusSnapshot();
           return;
         }
-        await this.switchEngineMode('voice', MODES.VOICE);
+        await this.runWithModeChangeGate(() => this.switchEngineMode('voice', MODES.VOICE));
         return;
       }
 
@@ -1462,38 +1545,132 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
       // If switching from voice to digital
       if (this.engineMode === 'voice') {
-        await this.switchEngineMode('digital', digitalMode);
+        await this.runWithModeChangeGate(() => this.switchEngineMode('digital', digitalMode));
         return;
       }
 
       // If switching from CW to digital
       if (this.engineMode === 'cw') {
-        await this.switchEngineMode('digital', digitalMode);
+        await this.runWithModeChangeGate(() => this.switchEngineMode('digital', digitalMode));
         return;
       }
 
       // Normal digital mode switch (FT8 <-> FT4)
       if (this.currentMode.name === digitalMode.name) {
+        await this.stopTuneTone('mode unchanged');
         logger.info(`Already in mode: ${digitalMode.name}`);
         this.syncCurrentModeToRuntimeComponents('already-in-mode');
         this.emitStatusSnapshot();
         return;
       }
 
-      logger.info(`Switching mode: ${this.currentMode.name} -> ${digitalMode.name}`);
-      await this.applyNearestPresetForDigitalMode(digitalMode);
+      await this.runWithModeChangeGate(async () => {
+        logger.info(`Switching mode: ${this.currentMode.name} -> ${digitalMode.name}`);
+        await this.applyNearestPresetForDigitalMode(digitalMode);
 
-      this.currentMode = digitalMode;
-      this.applyDecodeWindowOverrides();
-      this.syncCurrentModeToRuntimeComponents('digital-mode-switch');
+        this.currentMode = digitalMode;
+        this.applyDecodeWindowOverrides();
+        this.syncCurrentModeToRuntimeComponents('digital-mode-switch');
 
-      await ConfigManager.getInstance().setLastDigitalModeName(digitalMode.name);
-      this.emitModeAndStatusSnapshot();
+        await ConfigManager.getInstance().setLastDigitalModeName(digitalMode.name);
+        this.emitModeAndStatusSnapshot();
+      });
     };
 
     const queuedSwitch = this.modeSwitchTail.then(runSwitch, runSwitch);
     this.modeSwitchTail = queuedSwitch.catch(() => undefined);
     await queuedSwitch;
+  }
+
+  private async runWithModeChangeGate(operation: () => Promise<void>): Promise<void> {
+    this._operatorManager.enterTransmissionMaintenance('mode change');
+    try {
+      await this.stopTuneTone('mode changed');
+      const snapshot = this.physicalTxCoordinator.getSnapshot();
+      if (snapshot.phase === 'unknown') {
+        await this.physicalTxCoordinator.retryUnknownStop('mode change PTT recovery');
+      } else if (snapshot.phase !== 'idle') {
+        await this.physicalTxCoordinator.forceInterrupt('mode change');
+      }
+
+      const stopped = this.physicalTxCoordinator.getSnapshot();
+      if (stopped.phase !== 'idle') {
+        throw new Error(`Cannot switch mode while physical PTT is ${stopped.phase}`);
+      }
+      await operation();
+    } finally {
+      this._operatorManager.exitTransmissionMaintenance();
+    }
+  }
+
+  /**
+   * Serializes plugin-originated CAT/tuner mutations with every physical TX
+   * source. This is deliberately narrower than mode switching: background
+   * plugins reject a busy radio and never interrupt an existing lease.
+   */
+  private async submitPluginRadioMaintenanceCommand(
+    command: PluginRadioCommand | PluginRadioTunerCommand,
+  ): Promise<void> {
+    const reason = command.type === 'switch-band'
+      ? 'plugin scheduled band switch'
+      : command.type === 'set-frequency'
+        ? 'plugin frequency change'
+        : 'plugin tuner command';
+
+    await this.physicalTxCoordinator.runIdleMaintenance({ reason, busyPolicy: 'reject' }, async () => {
+      this._operatorManager.enterTransmissionMaintenance(reason);
+      try {
+        if (!this.radioManager.isConnected()) {
+          throw new Error('Radio is not connected');
+        }
+
+        if (command.type === 'set-frequency' || command.type === 'switch-band') {
+          if (!Number.isFinite(command.frequency) || command.frequency <= 0) {
+            throw new Error('Radio frequency must be a positive finite number');
+          }
+          let tunerSwitchEnabled = false;
+          if (command.type === 'switch-band' && command.autoTune === true) {
+            this.assertWritableRadioCapability('tuner_switch');
+            this.assertWritableRadioCapability('tuner_tune');
+            tunerSwitchEnabled = this.radioManager.getCapabilitySnapshot().capabilities
+              .find((capability) => capability.id === 'tuner_switch')?.value === true;
+          }
+
+          const success = await this.radioManager.setFrequency(command.frequency);
+          if (!success) throw new Error('Failed to set radio frequency');
+          this.radioManager.emit('radioFrequencyChanged', command.frequency);
+          if (command.type === 'set-frequency' || command.autoTune !== true) return;
+
+          if (!tunerSwitchEnabled) {
+            await this.radioManager.writeCapability('tuner_switch', true, undefined);
+          }
+          await this.radioManager.writeCapability('tuner_tune', undefined, true);
+          return;
+        }
+
+        if (command.type === 'set-enabled') {
+          this.assertWritableRadioCapability('tuner_switch');
+          await this.radioManager.writeCapability('tuner_switch', command.enabled, undefined);
+          return;
+        }
+
+        this.assertWritableRadioCapability('tuner_tune');
+        await this.radioManager.writeCapability('tuner_tune', undefined, true);
+      } finally {
+        this._operatorManager.exitTransmissionMaintenance();
+      }
+    });
+  }
+
+  private assertWritableRadioCapability(capabilityId: 'tuner_switch' | 'tuner_tune'): void {
+    const snapshot = this.radioManager.getCapabilitySnapshot();
+    const descriptor = snapshot.descriptors.find((item) => item.id === capabilityId);
+    const state = snapshot.capabilities.find((item) => item.id === capabilityId);
+    if (descriptor?.writable !== true
+        || state?.supported !== true
+        || state.availability === 'unavailable') {
+      throw new Error(`Radio capability ${capabilityId} is unavailable`);
+    }
   }
 
   private async applyNearestPresetForDigitalMode(targetMode: ModeDescriptor): Promise<void> {
@@ -1554,7 +1731,10 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     return nearestPreset;
   }
 
-  private async applyDigitalPresetFrequency(preset: PresetFrequency): Promise<void> {
+  private async applyDigitalPresetFrequency(
+    preset: PresetFrequency,
+    expectedConnectionGeneration?: number,
+  ): Promise<OperatingStateSyncResult> {
     const configManager = ConfigManager.getInstance();
     const description = preset.description
       || `${(preset.frequency / 1000000).toFixed(3)} MHz${preset.band ? ` ${preset.band}` : ''}`;
@@ -1568,21 +1748,31 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     });
     const effectiveRadioMode = radioModeResolution.displayRadioMode;
 
+    let syncResult: OperatingStateSyncResult = { status: 'skipped-offline' };
     if (radioConnected) {
-      const applyResult = await this.radioManager.applyOperatingState(buildFrequencyOperatingStateRequest({
+      const request = buildFrequencyOperatingStateRequest({
         frequency: preset.frequency,
         radioMode: preset.radioMode,
         effectiveMode: preset.mode,
         engineMode: 'digital',
         digitalModeRadioMode: activeRadioConfig.digitalModeRadioMode,
-      }));
+      });
+      const applyResult = await this.applyModeOperatingState(request, expectedConnectionGeneration);
 
       if (!applyResult.frequencyApplied) {
         throw new Error(`Failed to switch radio frequency to ${description}`);
       }
 
-      if (applyResult.modeError) {
-        logger.warn(`Switched digital frequency but failed to set radio mode: ${applyResult.modeError.message}`);
+      if (request.mode && (!applyResult.modeApplied || applyResult.modeError)) {
+        logger.warn(
+          `Switched digital frequency but failed to set radio mode: ${applyResult.modeError?.message || 'not confirmed'}`,
+        );
+        syncResult = {
+          status: 'partially-applied',
+          detail: applyResult.modeError?.message || 'radio mode write was not confirmed',
+        };
+      } else {
+        syncResult = { status: 'applied' };
       }
 
       await this.applyRepeaterDuplexConfigWithWarning(
@@ -1627,12 +1817,17 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       radioConnected,
       source: 'program',
     });
+    return syncResult;
   }
 
-  private async restoreLastDigitalOperatingState(configManager: ConfigManager, targetMode: ModeDescriptor): Promise<void> {
+  private async restoreLastDigitalOperatingState(
+    configManager: ConfigManager,
+    targetMode: ModeDescriptor,
+    expectedConnectionGeneration?: number,
+  ): Promise<OperatingStateSyncResult | null> {
     const lastDigital = configManager.getLastSelectedFrequency();
     if (!lastDigital?.frequency) {
-      return;
+      return null;
     }
 
     let targetFrequency: PresetFrequency = {
@@ -1655,10 +1850,16 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     }
 
     try {
-      await this.applyDigitalPresetFrequency(targetFrequency);
-      logger.info(`Restored digital operating state: ${(targetFrequency.frequency / 1000000).toFixed(3)} MHz (${targetFrequency.mode})`);
+      const result = await this.applyDigitalPresetFrequency(targetFrequency, expectedConnectionGeneration);
+      logger.info(`Digital operating state ${result.status}`, {
+        frequencyHz: targetFrequency.frequency,
+        mode: targetFrequency.mode,
+        detail: result.detail,
+      });
+      return result;
     } catch (error) {
       logger.warn(`Failed to restore digital operating state: ${(error as Error).message}`);
+      return { status: 'failed', detail: (error as Error).message };
     }
   }
 
@@ -1750,12 +1951,24 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
   }
 
   private async switchEngineMode(targetEngineMode: EngineMode, targetMode: ModeDescriptor): Promise<void> {
+    const previousEngineMode = this.engineMode;
+    const previousMode = this.currentMode;
+    const configManager = ConfigManager.getInstance();
+    const expectedProfileId = configManager.getActiveProfileId?.();
+    const radioWasConnected = this.radioManager.isConnected();
+    const expectedConnectionGeneration = this.radioManager.getConnectionGeneration?.();
+    const previousCWDecoderRuntime = previousEngineMode === 'cw'
+      && this.cwDecoderManager?.getStatus().state === 'running'
+      ? {
+          config: configManager.getCWDecoderConfig(),
+          startedEngine: this.cwDecoderStartedEngine,
+        }
+      : null;
     let engineState = this.engineLifecycle?.getEngineState() ?? EngineState.IDLE;
     let shouldResumeAfterSwitch = engineState === EngineState.RUNNING || engineState === EngineState.STARTING;
     // CW keying can lazy-init its own manager, but RX monitor/decoder still
     // need the engine audio chain. Preserve the user's running/idle intent.
     const comingFromCW = this.engineMode === 'cw';
-    const goingToCW = targetEngineMode === 'cw';
     logger.info(`Switching engine mode: ${this.engineMode}/${this.currentMode.name} -> ${targetEngineMode}/${targetMode.name}`);
 
     if (this.engineMode === 'voice' && targetEngineMode !== 'voice') {
@@ -1786,79 +1999,250 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
 
     if (engineState === EngineState.RUNNING) {
       this.radioBridge.wasRunningBeforeDisconnect = false;
-      if (goingToCW && this.engineLifecycle) {
-        // Digital→CW: stop engine but keep radio connected (CW has its own serial port).
-        this.engineLifecycle.preserveRadioConnection = true;
+      await this.stopTuneTone('mode runtime stopped');
+      await this.engineLifecycle.stopModeRuntime();
+    }
+
+    let targetModeStaged = false;
+    try {
+      this.assertModeSwitchProfile(configManager, expectedProfileId);
+      this.engineMode = targetEngineMode;
+      this.currentMode = targetMode;
+      targetModeStaged = true;
+      this.configureAudioProcessingForCurrentMode?.('mode-switch');
+
+      if (targetEngineMode === 'digital') {
+        this.applyDecodeWindowOverrides();
       }
-      try {
-        await this.stop();
-      } finally {
-        if (this.engineLifecycle) {
-          this.engineLifecycle.preserveRadioConnection = false;
-        }
+
+      this.syncCurrentModeToRuntimeComponents('engine-mode-switch');
+      await this.engineLifecycle.rebuildResourcePlan();
+      const operatingStateResult = await this.restoreOperatingStateForEngineMode(
+        configManager,
+        targetEngineMode,
+        targetMode,
+        radioWasConnected ? expectedConnectionGeneration : undefined,
+      );
+      this.reportOperatingStateSync(targetEngineMode, targetMode, operatingStateResult);
+      this.assertModeSwitchProfile(configManager, expectedProfileId);
+      this.assertModeSwitchRadioSession(
+        targetEngineMode,
+        radioWasConnected,
+        expectedConnectionGeneration,
+      );
+
+      if (shouldResumeAfterSwitch) {
+        await this.engineLifecycle.startAndWaitForRunning();
       }
+
+      this.assertModeSwitchProfile(configManager, expectedProfileId);
+      this.assertModeSwitchRadioSession(
+        targetEngineMode,
+        radioWasConnected,
+        expectedConnectionGeneration,
+      );
+
+      await configManager.setLastEngineMode(targetEngineMode);
+      if (targetEngineMode === 'digital') {
+        await configManager.setLastDigitalModeName(targetMode.name);
+      }
+
+      this.emitModeAndStatusSnapshot();
+      if (shouldResumeAfterSwitch) {
+        this.emitStatusSnapshot();
+      }
+
+      // Refresh split capability after mode switch (some radios support split only in certain modes)
+      void this.radioManager?.refreshSplitCapability?.();
+
+      this.resetVoicePttState();
+      this.squelchStatusMonitor.reevaluate();
+      this.physicalPttMonitor.reevaluate();
+      logger.info(`Engine mode switched to ${targetEngineMode}/${targetMode.name}`);
+    } catch (error) {
+      const profileChanged = expectedProfileId !== undefined
+        && configManager.getActiveProfileId() !== expectedProfileId;
+      if (targetModeStaged && !profileChanged) {
+        await this.rollbackEngineModeSwitch(
+          previousEngineMode,
+          previousMode,
+          shouldResumeAfterSwitch,
+          configManager,
+          error,
+          previousCWDecoderRuntime,
+        );
+      }
+      throw error;
     }
-
-    this.engineMode = targetEngineMode;
-    this.currentMode = targetMode;
-    this.configureAudioProcessingForCurrentMode?.('mode-switch');
-
-    if (targetEngineMode === 'digital') {
-      this.applyDecodeWindowOverrides();
-    }
-
-    this.syncCurrentModeToRuntimeComponents('engine-mode-switch');
-    await this.engineLifecycle.rebuildResourcePlan();
-
-    const configManager = ConfigManager.getInstance();
-    await configManager.setLastEngineMode(targetEngineMode);
-    if (targetEngineMode === 'digital') {
-      await configManager.setLastDigitalModeName(targetMode.name);
-    }
-
-    if (targetEngineMode === 'voice') {
-      await this.restoreLastVoiceOperatingState(configManager);
-    } else if (goingToCW) {
-      await this.restoreLastCWOperatingState(configManager);
-    } else if (targetEngineMode === 'digital') {
-      await this.restoreLastDigitalOperatingState(configManager, targetMode);
-    }
-    this.emitModeAndStatusSnapshot();
-
-    // Refresh split capability after mode switch (some radios support split only in certain modes)
-    void this.radioManager?.refreshSplitCapability?.();
-
-    this.resetVoicePttState();
-    this.squelchStatusMonitor.reevaluate();
-    this.physicalPttMonitor.reevaluate();
-
-    // Keep the engine running across mode switches only if it was running before.
-    if (shouldResumeAfterSwitch) {
-      await this.engineLifecycle.startAndWaitForRunning();
-      this.emitStatusSnapshot();
-    }
-
-    logger.info(`Engine mode switched to ${targetEngineMode}/${targetMode.name}`);
   }
 
-  private async restoreLastVoiceOperatingState(configManager: ConfigManager): Promise<void> {
-    const lastVoice = configManager.getLastVoiceFrequency();
-    if (!lastVoice?.frequency || !this.radioManager.isConnected()) {
+  private assertModeSwitchProfile(
+    configManager: ConfigManager,
+    expectedProfileId: string | null | undefined,
+  ): void {
+    if (
+      expectedProfileId !== undefined
+      && configManager.getActiveProfileId() !== expectedProfileId
+    ) {
+      throw new Error('Active radio profile changed during mode switch');
+    }
+  }
+
+  private assertModeSwitchRadioSession(
+    targetEngineMode: EngineMode,
+    radioWasConnected: boolean,
+    expectedConnectionGeneration: number | undefined,
+  ): void {
+    if (!radioWasConnected || expectedConnectionGeneration === undefined) {
       return;
     }
 
+    const sessionUnchanged = this.radioManager.isConnected()
+      && this.radioManager.getConnectionGeneration() === expectedConnectionGeneration;
+    if (sessionUnchanged) {
+      return;
+    }
+
+    if (targetEngineMode === 'cw') {
+      this.reportOperatingStateSync(targetEngineMode, MODES.CW, {
+        status: 'skipped-offline',
+        detail: 'CAT session changed during mode switch',
+      });
+      return;
+    }
+
+    throw new Error('Physical radio connection changed during mode switch');
+  }
+
+  private reportOperatingStateSync(
+    engineMode: EngineMode,
+    mode: ModeDescriptor,
+    result: OperatingStateSyncResult | null,
+  ): void {
+    if (!result) {
+      return;
+    }
+
+    if (result.status === 'applied') {
+      if (this.operatingStateWarningActive) {
+        logger.info('Radio operating-state warning cleared after confirmed synchronization');
+      }
+      this.operatingStateWarningActive = false;
+      return;
+    }
+
+    this.operatingStateWarningActive = true;
+    const detail = result.detail || (
+      result.status === 'skipped-offline'
+        ? 'The physical radio is offline.'
+        : 'The radio did not confirm every requested CAT setting.'
+    );
+    this.emit('textMessage', {
+      title: 'Radio mode not confirmed',
+      text: `${mode.name} is active in TX-5DR, but the physical radio operating state was ${result.status}. ${detail} Please verify the radio manually.`,
+      color: 'warning',
+      timeout: null,
+      key: 'radioOperatingStateNotConfirmed',
+      params: {
+        engineMode,
+        mode: mode.name,
+        status: result.status,
+        reason: detail,
+      },
+    });
+  }
+
+  private async restoreOperatingStateForEngineMode(
+    configManager: ConfigManager,
+    engineMode: EngineMode,
+    mode: ModeDescriptor,
+    expectedConnectionGeneration?: number,
+  ): Promise<OperatingStateSyncResult | null> {
+    if (engineMode === 'voice') {
+      return this.restoreLastVoiceOperatingState(configManager, expectedConnectionGeneration);
+    } else if (engineMode === 'cw') {
+      return this.restoreLastCWOperatingState(configManager, expectedConnectionGeneration);
+    }
+    return this.restoreLastDigitalOperatingState(configManager, mode, expectedConnectionGeneration);
+  }
+
+  private applyModeOperatingState(
+    request: Parameters<PhysicalRadioManager['applyOperatingState']>[0],
+    expectedConnectionGeneration?: number,
+  ): ReturnType<PhysicalRadioManager['applyOperatingState']> {
+    return expectedConnectionGeneration === undefined
+      ? this.radioManager.applyOperatingState(request)
+      : this.radioManager.applyOperatingState(request, { expectedConnectionGeneration });
+  }
+
+  private async rollbackEngineModeSwitch(
+    previousEngineMode: EngineMode,
+    previousMode: ModeDescriptor,
+    shouldResume: boolean,
+    configManager: ConfigManager,
+    cause: unknown,
+    previousCWDecoderRuntime: { config: CWDecoderConfig; startedEngine: boolean } | null,
+  ): Promise<void> {
+    logger.error('Mode runtime switch failed; restoring previous runtime', {
+      previousEngineMode,
+      previousMode: previousMode.name,
+      error: cause instanceof Error ? cause.message : String(cause),
+    });
+
     try {
-      const applyResult = await this.radioManager.applyOperatingState({
+      if (this.engineLifecycle.getEngineState() !== EngineState.IDLE) {
+        await this.engineLifecycle.stopModeRuntime();
+      }
+      this.engineMode = previousEngineMode;
+      this.currentMode = previousMode;
+      this.configureAudioProcessingForCurrentMode?.('mode-switch-rollback');
+      if (previousEngineMode === 'digital') {
+        this.applyDecodeWindowOverrides();
+      }
+      this.syncCurrentModeToRuntimeComponents('engine-mode-switch-rollback');
+      await this.engineLifecycle.rebuildResourcePlan();
+      await this.restoreOperatingStateForEngineMode(configManager, previousEngineMode, previousMode);
+      if (shouldResume) {
+        await this.engineLifecycle.startAndWaitForRunning();
+      }
+      if (previousEngineMode === 'cw' && previousCWDecoderRuntime) {
+        await this.getCWDecoderManager().start(this.toServerCWDecoderConfig({
+          ...previousCWDecoderRuntime.config,
+          enabled: true,
+        }));
+        this.cwDecoderStartedEngine = previousCWDecoderRuntime.startedEngine;
+      }
+      this.emitModeAndStatusSnapshot();
+    } catch (rollbackError) {
+      logger.error('Failed to restore previous mode runtime', rollbackError);
+    }
+  }
+
+  private async restoreLastVoiceOperatingState(
+    configManager: ConfigManager,
+    expectedConnectionGeneration?: number,
+  ): Promise<OperatingStateSyncResult | null> {
+    const lastVoice = configManager.getLastVoiceFrequency();
+    if (!lastVoice?.frequency) {
+      return null;
+    }
+    if (!this.radioManager.isConnected()) {
+      logger.info('Voice operating state skipped-offline', { frequencyHz: lastVoice.frequency });
+      return { status: 'skipped-offline' };
+    }
+
+    try {
+      const applyResult = await this.applyModeOperatingState({
         frequency: lastVoice.frequency,
         mode: lastVoice.radioMode,
         bandwidth: lastVoice.radioMode ? 'nochange' : undefined,
         options: lastVoice.radioMode ? { intent: 'voice' } : undefined,
         tolerateModeFailure: true,
-      });
+      }, expectedConnectionGeneration);
 
       if (!applyResult.frequencyApplied) {
         logger.warn(`Failed to restore last voice frequency: ${(lastVoice.frequency / 1000000).toFixed(3)} MHz`);
-        return;
+        return { status: 'failed', detail: 'frequency write was not confirmed' };
       }
 
       if (applyResult.modeError) {
@@ -1888,14 +2272,22 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
         source: 'program',
       });
       logger.info(`Restored last voice operating state: ${description}${lastVoice.radioMode ? ` (${lastVoice.radioMode})` : ''}`);
+      return applyResult.modeError
+        ? { status: 'partially-applied', detail: applyResult.modeError.message }
+        : { status: 'applied' };
     } catch (error) {
       logger.warn(`Failed to restore last voice operating state: ${(error as Error).message}`);
+      return { status: 'failed', detail: (error as Error).message };
     }
   }
 
-  private async restoreLastCWOperatingState(configManager: ConfigManager): Promise<void> {
+  private async restoreLastCWOperatingState(
+    configManager: ConfigManager,
+    expectedConnectionGeneration?: number,
+  ): Promise<OperatingStateSyncResult | null> {
     if (!this.radioManager.isConnected()) {
-      return;
+      logger.info('CW operating state skipped-offline');
+      return { status: 'skipped-offline' };
     }
 
     const lastCW = configManager.getLastCWFrequency();
@@ -1910,7 +2302,7 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       const currentFreq = await this.radioManager.getFrequency();
       if (!currentFreq || currentFreq <= 0) {
         logger.warn('Cannot restore CW operating state: no saved frequency and failed to read current frequency');
-        return;
+        return { status: 'failed', detail: 'current radio frequency is unavailable' };
       }
       targetFrequency = currentFreq;
       targetRadioMode = 'CW';
@@ -1918,17 +2310,17 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
     }
 
     try {
-      const applyResult = await this.radioManager.applyOperatingState({
+      const applyResult = await this.applyModeOperatingState({
         frequency: targetFrequency,
         mode: targetRadioMode,
         bandwidth: targetRadioMode ? 'nochange' : undefined,
         options: targetRadioMode ? { intent: 'cw' } : undefined,
         tolerateModeFailure: true,
-      });
+      }, expectedConnectionGeneration);
 
       if (!applyResult.frequencyApplied) {
         logger.warn(`Failed to restore CW frequency: ${(targetFrequency / 1000000).toFixed(3)} MHz`);
-        return;
+        return { status: 'failed', detail: 'frequency write was not confirmed' };
       }
 
       if (applyResult.modeError) {
@@ -1947,8 +2339,12 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
         source: 'program',
       });
       logger.info(`Restored CW operating state: ${description}${targetRadioMode ? ` (${targetRadioMode})` : ''}`);
+      return applyResult.modeError
+        ? { status: 'partially-applied', detail: applyResult.modeError.message }
+        : { status: 'applied' };
     } catch (error) {
       logger.warn(`Failed to restore CW operating state: ${(error as Error).message}`);
+      return { status: 'failed', detail: (error as Error).message };
     }
   }
 
@@ -1977,32 +2373,47 @@ export class DigitalRadioEngine extends EventEmitter<DigitalRadioEngineEvents> {
       || this.physicalPttActive;
   }
 
-  private setTuneTonePttActive(active: boolean): void {
-    this.radioManager.setPTTActive(active);
-    this.spectrumScheduler.setPTTActive(active);
-    this.squelchStatusMonitor.setPTTActive(active);
-    this.physicalPttMonitor.setSoftwarePttActive(active || this.voiceManualPttActive || this.voiceKeyerPttActive);
-    this.emit('pttStatusChanged', {
-      isTransmitting: active,
-      operatorIds: [],
-    });
-  }
-
-  private handleVoiceSoftwarePttChanged(data: { isTransmitting: boolean; operatorIds: string[]; source?: 'manual' | 'voice-keyer' }): void {
-    if (data.source === 'voice-keyer') {
-      this.voiceKeyerPttActive = data.isTransmitting;
-    } else {
-      this.voiceManualPttActive = data.isTransmitting;
-    }
-
-    this.physicalPttMonitor.setSoftwarePttActive(this.voiceManualPttActive || this.voiceKeyerPttActive);
-    this.applyUnifiedVoicePttState(data.operatorIds ?? []);
-  }
-
   private handlePhysicalPttChanged(active: boolean): void {
     this.physicalPttActive = active;
     this.voiceKeyerManager?.setManualPttActive(this.voiceManualPttActive || this.physicalPttActive);
     this.applyUnifiedVoicePttState([]);
+  }
+
+  private handleCoordinatedPhysicalTxChanged(snapshot: PhysicalTxSnapshot): void {
+    const uncertain = snapshot.phase === 'unknown';
+    const pttConfirmed = snapshot.pttConfirmed || uncertain;
+    const operatorIds = pttConfirmed && snapshot.source === 'digital'
+      ? snapshot.operatorIds
+      : [];
+
+    this.radioManager.setPTTActive(pttConfirmed);
+    this.spectrumScheduler.setPTTActive(pttConfirmed);
+    this.squelchStatusMonitor?.setPTTActive(pttConfirmed);
+    this.physicalPttMonitor?.setSoftwarePttActive(snapshot.phase !== 'idle');
+
+    if (snapshot.source === 'voice') {
+      this.voiceManualPttActive = snapshot.phase !== 'idle';
+    } else if (snapshot.source === 'voice-keyer') {
+      this.voiceKeyerPttActive = snapshot.phase !== 'idle';
+    } else if (snapshot.phase === 'idle') {
+      this.voiceManualPttActive = false;
+      this.voiceKeyerPttActive = false;
+    }
+    this.voiceKeyerManager?.setManualPttActive(
+      this.voiceManualPttActive || this.physicalPttActive,
+    );
+    this.unifiedVoicePttActive = this.voiceManualPttActive
+      || this.voiceKeyerPttActive
+      || this.physicalPttActive;
+
+    this._operatorManager.updateActiveTransmissionOperators(operatorIds);
+    this.emit('pttStatusChanged', {
+      isTransmitting: pttConfirmed,
+      operatorIds,
+      phase: snapshot.phase === 'active' ? 'on_air' : snapshot.phase,
+      frameId: snapshot.frameId,
+      source: snapshot.source,
+    });
   }
 
   private handleCWKeyerStatusChanged(status: CWKeyerStatus): void {

--- a/packages/server/src/__tests__/DigitalRadioEngine.mode-switch.test.ts
+++ b/packages/server/src/__tests__/DigitalRadioEngine.mode-switch.test.ts
@@ -32,6 +32,17 @@ describe('DigitalRadioEngine mode switching', () => {
     const emit = vi.fn();
     const clearInMemory = vi.fn();
     const operatorSetMode = vi.fn();
+    const enterTransmissionMaintenance = vi.fn();
+    const exitTransmissionMaintenance = vi.fn();
+    let physicalPhase: 'idle' | 'active' | 'unknown' = 'idle';
+    const forceInterrupt = vi.fn(async () => {
+      physicalPhase = 'idle';
+      return null;
+    });
+    const retryUnknownStop = vi.fn(async () => {
+      physicalPhase = 'idle';
+      return null;
+    });
 
     vi.spyOn(ConfigManager, 'getInstance').mockReturnValue({
       getCustomFrequencyPresets: vi.fn(() => options.customFrequencyPresets ?? null),
@@ -67,6 +78,13 @@ describe('DigitalRadioEngine mode switching', () => {
       },
       _operatorManager: {
         getAllOperators: vi.fn(() => [{ setMode: operatorSetMode }]),
+        enterTransmissionMaintenance,
+        exitTransmissionMaintenance,
+      },
+      physicalTxCoordinator: {
+        getSnapshot: vi.fn(() => ({ phase: physicalPhase })),
+        forceInterrupt,
+        retryUnknownStop,
       },
       emit,
       emitModeAndStatusSnapshot: vi.fn(() => undefined),
@@ -81,6 +99,13 @@ describe('DigitalRadioEngine mode switching', () => {
       emit,
       clearInMemory,
       operatorSetMode,
+      enterTransmissionMaintenance,
+      exitTransmissionMaintenance,
+      forceInterrupt,
+      retryUnknownStop,
+      setPhysicalPhase: (phase: 'idle' | 'active' | 'unknown') => {
+        physicalPhase = phase;
+      },
     };
   }
 
@@ -100,6 +125,7 @@ describe('DigitalRadioEngine mode switching', () => {
     const fakeEngine = Object.assign(Object.create(DigitalRadioEngine.prototype), {
       engineMode: 'digital',
       currentMode: MODES.FT8,
+      stopTuneTone: vi.fn(async () => undefined),
       radioBridge: { wasRunningBeforeDisconnect: true },
       engineLifecycle: {
         getEngineState: vi.fn(() => engineState),
@@ -110,6 +136,10 @@ describe('DigitalRadioEngine mode switching', () => {
         }),
         stop: vi.fn(async () => {
           sequence.push('engineLifecycle.stop');
+        }),
+        stopModeRuntime: vi.fn(async () => {
+          sequence.push('stopModeRuntime');
+          engineState = EngineState.IDLE;
         }),
         rebuildResourcePlan: vi.fn(() => {
           sequence.push('rebuildResourcePlan');
@@ -126,6 +156,8 @@ describe('DigitalRadioEngine mode switching', () => {
       applyDecodeWindowOverrides: vi.fn(() => {
         sequence.push('applyDecodeWindowOverrides');
       }),
+      syncCurrentModeToRuntimeComponents: vi.fn(() => undefined),
+      radioManager: { isConnected: vi.fn(() => true) },
       slotClock: {
         setMode: vi.fn(() => {
           sequence.push('slotClock.setMode');
@@ -170,11 +202,12 @@ describe('DigitalRadioEngine mode switching', () => {
     }).switchEngineMode.call(fakeEngine, 'voice', MODES.VOICE);
 
     expect(fakeEngine.engineLifecycle.waitForStartupToSettle).toHaveBeenCalledOnce();
-    expect(fakeEngine.stop).toHaveBeenCalledOnce();
+    expect(fakeEngine.stop).not.toHaveBeenCalled();
+    expect(fakeEngine.engineLifecycle.stopModeRuntime).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.rebuildResourcePlan).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.startAndWaitForRunning).toHaveBeenCalledOnce();
     expect(sequence.indexOf('waitForStartupToSettle')).toBeLessThan(sequence.indexOf('rebuildResourcePlan'));
-    expect(sequence.indexOf('stop')).toBeLessThan(sequence.indexOf('rebuildResourcePlan'));
+    expect(sequence.indexOf('stopModeRuntime')).toBeLessThan(sequence.indexOf('rebuildResourcePlan'));
   });
 
   it('skips restart when startup settles back to idle', async () => {
@@ -188,6 +221,7 @@ describe('DigitalRadioEngine mode switching', () => {
     const fakeEngine = Object.assign(Object.create(DigitalRadioEngine.prototype), {
       engineMode: 'digital',
       currentMode: MODES.FT8,
+      stopTuneTone: vi.fn(async () => undefined),
       radioBridge: { wasRunningBeforeDisconnect: true },
       engineLifecycle: {
         getEngineState: vi.fn(() => engineState),
@@ -196,11 +230,14 @@ describe('DigitalRadioEngine mode switching', () => {
           return EngineState.IDLE;
         }),
         stop: vi.fn(async () => undefined),
+        stopModeRuntime: vi.fn(async () => undefined),
         rebuildResourcePlan: vi.fn(() => undefined),
         startAndWaitForRunning: vi.fn(async () => undefined),
       },
       stop: vi.fn(async () => undefined),
       applyDecodeWindowOverrides: vi.fn(() => undefined),
+      syncCurrentModeToRuntimeComponents: vi.fn(() => undefined),
+      radioManager: { isConnected: vi.fn(() => true) },
       slotClock: null,
       slotPackManager: {
         setMode: vi.fn(() => undefined),
@@ -237,6 +274,8 @@ describe('DigitalRadioEngine mode switching', () => {
     const sequence: string[] = [];
     const setLastEngineMode = vi.fn(async () => undefined);
     const setLastDigitalModeName = vi.fn(async () => undefined);
+    const disconnect = vi.fn(async () => undefined);
+    const connectionGeneration = 17;
 
     vi.spyOn(ConfigManager, 'getInstance').mockReturnValue({
       setLastEngineMode,
@@ -246,12 +285,16 @@ describe('DigitalRadioEngine mode switching', () => {
     const fakeEngine = Object.assign(Object.create(DigitalRadioEngine.prototype), {
       engineMode: options.initialEngineMode,
       currentMode: options.initialMode,
+      stopTuneTone: vi.fn(async () => undefined),
       radioBridge: { wasRunningBeforeDisconnect: true },
       engineLifecycle: {
-        preserveRadioConnection: false,
         getEngineState: vi.fn(() => engineState),
         waitForStartupToSettle: vi.fn(async () => engineState),
         stop: vi.fn(async () => undefined),
+        stopModeRuntime: vi.fn(async () => {
+          sequence.push('stopModeRuntime');
+          engineState = EngineState.IDLE;
+        }),
         rebuildResourcePlan: vi.fn(async () => {
           sequence.push('rebuildResourcePlan');
         }),
@@ -268,6 +311,12 @@ describe('DigitalRadioEngine mode switching', () => {
         sequence.push(`stopCWDecoderRuntime:${reason}`);
       }),
       applyDecodeWindowOverrides: vi.fn(() => undefined),
+      syncCurrentModeToRuntimeComponents: vi.fn(() => undefined),
+      radioManager: {
+        isConnected: vi.fn(() => true),
+        getConnectionGeneration: vi.fn(() => connectionGeneration),
+        disconnect,
+      },
       slotClock: {
         setMode: vi.fn(() => undefined),
       },
@@ -280,6 +329,7 @@ describe('DigitalRadioEngine mode switching', () => {
       _operatorManager: {
         getAllOperators: vi.fn(() => []),
       },
+      emit: vi.fn(),
       emitModeAndStatusSnapshot: vi.fn(() => undefined),
       emitStatusSnapshot: vi.fn(() => undefined),
       restoreLastVoiceOperatingState: vi.fn(async () => undefined),
@@ -294,7 +344,14 @@ describe('DigitalRadioEngine mode switching', () => {
       },
     });
 
-    return { fakeEngine, sequence, setLastEngineMode, setLastDigitalModeName };
+    return {
+      fakeEngine,
+      sequence,
+      setLastEngineMode,
+      setLastDigitalModeName,
+      disconnect,
+      connectionGeneration,
+    };
   }
 
   it('keeps the engine running when switching from running FT8 to CW', async () => {
@@ -308,14 +365,15 @@ describe('DigitalRadioEngine mode switching', () => {
       switchEngineMode: (targetEngineMode: 'cw', targetMode: typeof MODES.CW) => Promise<void>;
     }).switchEngineMode.call(fakeEngine, 'cw', MODES.CW);
 
-    expect(fakeEngine.stop).toHaveBeenCalledOnce();
+    expect(fakeEngine.stop).not.toHaveBeenCalled();
+    expect(fakeEngine.engineLifecycle.stopModeRuntime).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.rebuildResourcePlan).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.startAndWaitForRunning).toHaveBeenCalledOnce();
     expect(fakeEngine.emitStatusSnapshot).toHaveBeenCalledOnce();
     expect(fakeEngine.restoreLastCWOperatingState).toHaveBeenCalledOnce();
     expect(setLastEngineMode).toHaveBeenCalledWith('cw');
     expect(fakeEngine.stopCWDecoderRuntime).not.toHaveBeenCalled();
-    expect(sequence).toEqual(['stop', 'rebuildResourcePlan', 'startAndWaitForRunning']);
+    expect(sequence).toEqual(['stopModeRuntime', 'rebuildResourcePlan', 'startAndWaitForRunning']);
   });
 
   it('does not start the engine when switching from idle FT8 to CW', async () => {
@@ -349,7 +407,8 @@ describe('DigitalRadioEngine mode switching', () => {
     }).switchEngineMode.call(fakeEngine, 'digital', MODES.FT8);
 
     expect(fakeEngine.stopCWDecoderRuntime).toHaveBeenCalledWith('leaving-cw-mode');
-    expect(fakeEngine.stop).toHaveBeenCalledOnce();
+    expect(fakeEngine.stop).not.toHaveBeenCalled();
+    expect(fakeEngine.engineLifecycle.stopModeRuntime).toHaveBeenCalledOnce();
     expect(fakeEngine.applyDecodeWindowOverrides).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.rebuildResourcePlan).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.startAndWaitForRunning).toHaveBeenCalledOnce();
@@ -368,7 +427,8 @@ describe('DigitalRadioEngine mode switching', () => {
     }).switchEngineMode.call(fakeEngine, 'voice', MODES.VOICE);
 
     expect(fakeEngine.stopCWDecoderRuntime).toHaveBeenCalledWith('leaving-cw-mode');
-    expect(fakeEngine.stop).toHaveBeenCalledOnce();
+    expect(fakeEngine.stop).not.toHaveBeenCalled();
+    expect(fakeEngine.engineLifecycle.stopModeRuntime).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.rebuildResourcePlan).toHaveBeenCalledOnce();
     expect(fakeEngine.engineLifecycle.startAndWaitForRunning).toHaveBeenCalledOnce();
     expect(fakeEngine.restoreLastVoiceOperatingState).toHaveBeenCalledOnce();
@@ -395,6 +455,56 @@ describe('DigitalRadioEngine mode switching', () => {
       expect(fakeEngine.engineLifecycle.rebuildResourcePlan).toHaveBeenCalledOnce();
       expect(fakeEngine.engineLifecycle.startAndWaitForRunning).not.toHaveBeenCalled();
     }
+  });
+
+  it('reuses one physical CAT session across CW, FT8, voice, and FT4 runtimes', async () => {
+    const { fakeEngine, disconnect, connectionGeneration } = createEngineModeSwitchHarness({
+      initialEngineMode: 'cw',
+      initialMode: MODES.CW,
+      engineState: EngineState.RUNNING,
+    });
+
+    const switchMode = (targetEngineMode: 'digital' | 'voice', targetMode: typeof MODES.FT8 | typeof MODES.FT4 | typeof MODES.VOICE) => (
+      (DigitalRadioEngine.prototype as unknown as {
+        switchEngineMode: (
+          engineMode: 'digital' | 'voice',
+          mode: typeof MODES.FT8 | typeof MODES.FT4 | typeof MODES.VOICE,
+        ) => Promise<void>;
+      }).switchEngineMode.call(fakeEngine, targetEngineMode, targetMode)
+    );
+
+    await switchMode('digital', MODES.FT8);
+    await switchMode('voice', MODES.VOICE);
+    await switchMode('digital', MODES.FT4);
+
+    expect(fakeEngine.engineLifecycle.stopModeRuntime).toHaveBeenCalledTimes(3);
+    expect(fakeEngine.engineLifecycle.stop).not.toHaveBeenCalled();
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(fakeEngine.radioManager.getConnectionGeneration()).toBe(connectionGeneration);
+  });
+
+  it('commits the application mode but emits a persistent warning when CAT mode sync is partial', async () => {
+    const { fakeEngine, setLastEngineMode } = createEngineModeSwitchHarness({
+      initialEngineMode: 'digital',
+      initialMode: MODES.FT8,
+      engineState: EngineState.RUNNING,
+    });
+    fakeEngine.restoreLastVoiceOperatingState.mockResolvedValue({
+      status: 'partially-applied',
+      detail: 'mode write rejected',
+    });
+
+    await (DigitalRadioEngine.prototype as unknown as {
+      switchEngineMode: (targetEngineMode: 'voice', targetMode: typeof MODES.VOICE) => Promise<void>;
+    }).switchEngineMode.call(fakeEngine, 'voice', MODES.VOICE);
+
+    expect(fakeEngine.engineMode).toBe('voice');
+    expect(setLastEngineMode).toHaveBeenCalledWith('voice');
+    expect(fakeEngine.emit).toHaveBeenCalledWith('textMessage', expect.objectContaining({
+      color: 'warning',
+      timeout: null,
+      key: 'radioOperatingStateNotConfirmed',
+    }));
   });
 
   it('routes startCWDecoder through the CW decoder runtime reconciler', async () => {
@@ -629,9 +739,10 @@ describe('DigitalRadioEngine mode switching', () => {
 
     expect(applyOperatingState).toHaveBeenCalledWith(expect.objectContaining({
       frequency: 14074000,
+      mode: 'USB',
+      options: { intent: 'voice' },
       tolerateModeFailure: true,
     }));
-    expect((applyOperatingState.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty('mode');
     expect(updateLastSelectedFrequency).toHaveBeenCalledWith(expect.objectContaining({
       frequency: 14074000,
       mode: 'FT8',
@@ -678,9 +789,10 @@ describe('DigitalRadioEngine mode switching', () => {
 
     expect(applyOperatingState).toHaveBeenCalledWith(expect.objectContaining({
       frequency: 14080000,
+      mode: 'USB',
+      options: { intent: 'voice' },
       tolerateModeFailure: true,
     }));
-    expect((applyOperatingState.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty('mode');
   });
 
   it('syncs restored FT4 mode to operators during startup restore', () => {
@@ -735,11 +847,21 @@ describe('DigitalRadioEngine mode switching', () => {
   });
 
   it('switches from FT8 to the nearest FT4 preset frequency', async () => {
-    const { fakeEngine, applyOperatingState, updateLastSelectedFrequency, emit } = createDigitalSwitchHarness({
+    const {
+      fakeEngine,
+      applyOperatingState,
+      updateLastSelectedFrequency,
+      emit,
+      enterTransmissionMaintenance,
+      exitTransmissionMaintenance,
+      forceInterrupt,
+      setPhysicalPhase,
+    } = createDigitalSwitchHarness({
       initialMode: MODES.FT8,
       knownFrequency: 14_074_000,
       radioConnected: true,
     });
+    setPhysicalPhase('active');
 
     await (DigitalRadioEngine.prototype as unknown as {
       setMode: (mode: typeof MODES.FT4) => Promise<void>;
@@ -747,6 +869,9 @@ describe('DigitalRadioEngine mode switching', () => {
 
     expect(applyOperatingState).toHaveBeenCalledWith({
       frequency: 14_080_000,
+      mode: 'USB',
+      bandwidth: 'nochange',
+      options: { intent: 'voice' },
       tolerateModeFailure: true,
     });
     const savedFrequency = (updateLastSelectedFrequency.mock.calls[0] as unknown[] | undefined)?.[0];
@@ -754,17 +879,47 @@ describe('DigitalRadioEngine mode switching', () => {
       frequency: 14_080_000,
       mode: 'FT4',
       band: '20m',
+      radioMode: 'USB',
     });
-    expect(savedFrequency).not.toHaveProperty('radioMode');
     expect(emit).toHaveBeenCalledWith('frequencyChanged', expect.objectContaining({
       frequency: 14_080_000,
+      radioMode: 'USB',
       mode: 'FT4',
       source: 'program',
       radioConnected: true,
     }));
+    expect(enterTransmissionMaintenance).toHaveBeenCalledWith('mode change');
+    expect(forceInterrupt).toHaveBeenCalledWith('mode change');
+    expect(exitTransmissionMaintenance).toHaveBeenCalledOnce();
   });
 
-  it('switches from FT4 to the nearest FT8 preset frequency', async () => {
+  it('does not change mode when PTT stop remains unknown', async () => {
+    const {
+      fakeEngine,
+      applyOperatingState,
+      retryUnknownStop,
+      setPhysicalPhase,
+      exitTransmissionMaintenance,
+    } = createDigitalSwitchHarness({
+      initialMode: MODES.FT8,
+      knownFrequency: 14_074_000,
+      radioConnected: true,
+    });
+    setPhysicalPhase('unknown');
+    retryUnknownStop.mockImplementationOnce(async () => null);
+
+    await expect((DigitalRadioEngine.prototype as unknown as {
+      setMode: (mode: typeof MODES.FT4) => Promise<void>;
+    }).setMode.call(fakeEngine, MODES.FT4)).rejects.toThrow(
+      'Cannot switch mode while physical PTT is unknown',
+    );
+
+    expect(applyOperatingState).not.toHaveBeenCalled();
+    expect(fakeEngine.currentMode).toBe(MODES.FT8);
+    expect(exitTransmissionMaintenance).toHaveBeenCalledOnce();
+  });
+
+  it('migrates a missing digital radio mode preference to USB when switching presets', async () => {
     const { fakeEngine, applyOperatingState } = createDigitalSwitchHarness({
       initialMode: MODES.FT4,
       knownFrequency: 14_080_000,
@@ -775,11 +930,31 @@ describe('DigitalRadioEngine mode switching', () => {
       setMode: (mode: typeof MODES.FT8) => Promise<void>;
     }).setMode.call(fakeEngine, MODES.FT8);
 
-    expect(applyOperatingState).toHaveBeenCalledWith(expect.objectContaining({
+    expect(applyOperatingState).toHaveBeenCalledWith({
+      frequency: 14_074_000,
+      mode: 'USB',
+      bandwidth: 'nochange',
+      options: { intent: 'voice' },
+      tolerateModeFailure: true,
+    });
+  });
+
+  it('preserves an explicit none preference when switching digital presets', async () => {
+    const { fakeEngine, applyOperatingState } = createDigitalSwitchHarness({
+      initialMode: MODES.FT4,
+      knownFrequency: 14_080_000,
+      radioConnected: true,
+      digitalModeRadioMode: 'none',
+    });
+
+    await (DigitalRadioEngine.prototype as unknown as {
+      setMode: (mode: typeof MODES.FT8) => Promise<void>;
+    }).setMode.call(fakeEngine, MODES.FT8);
+
+    expect(applyOperatingState).toHaveBeenCalledWith({
       frequency: 14_074_000,
       tolerateModeFailure: true,
-    }));
-    expect((applyOperatingState.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty('mode');
+    });
   });
 
   it('uses the active profile USB preference when switching digital preset frequency', async () => {
@@ -852,26 +1027,6 @@ describe('DigitalRadioEngine mode switching', () => {
     }));
   });
 
-  it('chooses the lower frequency when nearest presets are tied', async () => {
-    const { fakeEngine, applyOperatingState } = createDigitalSwitchHarness({
-      initialMode: MODES.FT8,
-      knownFrequency: 14_075_000,
-      radioConnected: true,
-      customFrequencyPresets: [
-        { frequency: 14_074_000, mode: 'FT4', band: '20m', radioMode: 'USB', description: 'low tie' },
-        { frequency: 14_076_000, mode: 'FT4', band: '20m', radioMode: 'USB', description: 'high tie' },
-      ],
-    });
-
-    await (DigitalRadioEngine.prototype as unknown as {
-      setMode: (mode: typeof MODES.FT4) => Promise<void>;
-    }).setMode.call(fakeEngine, MODES.FT4);
-
-    expect(applyOperatingState).toHaveBeenCalledWith(expect.objectContaining({
-      frequency: 14_074_000,
-    }));
-  });
-
   it('records and broadcasts the nearest preset when radio is disconnected', async () => {
     const { fakeEngine, applyOperatingState, updateLastSelectedFrequency, emit } = createDigitalSwitchHarness({
       initialMode: MODES.FT8,
@@ -916,4 +1071,103 @@ describe('DigitalRadioEngine mode switching', () => {
     expect(emit).not.toHaveBeenCalledWith('frequencyChanged', expect.anything());
     expect(fakeEngine.currentMode.name).toBe('FT4');
   });
+});
+
+describe('DigitalRadioEngine plugin radio maintenance', () => {
+  function createMaintenanceHarness(options: {
+    setFrequencyResult?: boolean;
+  } = {}) {
+    const enterTransmissionMaintenance = vi.fn();
+    const exitTransmissionMaintenance = vi.fn();
+    const setFrequency = vi.fn(async () => options.setFrequencyResult ?? true);
+    const writeCapability = vi.fn(async () => undefined);
+    const emit = vi.fn();
+    const runIdleMaintenance = vi.fn(async (_request, operation: () => Promise<void>) => operation());
+    const capabilitySnapshot = {
+      descriptors: [
+        { id: 'tuner_switch', writable: true },
+        { id: 'tuner_tune', writable: true },
+      ],
+      capabilities: [
+        { id: 'tuner_switch', supported: true, availability: 'available', value: false },
+        { id: 'tuner_tune', supported: true, availability: 'available', value: null },
+      ],
+    };
+    const fakeEngine = Object.assign(Object.create(DigitalRadioEngine.prototype), {
+      physicalTxCoordinator: { runIdleMaintenance },
+      _operatorManager: { enterTransmissionMaintenance, exitTransmissionMaintenance },
+      radioManager: {
+        isConnected: vi.fn(() => true),
+        setFrequency,
+        emit,
+        getCapabilitySnapshot: vi.fn(() => capabilitySnapshot),
+        writeCapability,
+      },
+    });
+    return {
+      fakeEngine,
+      enterTransmissionMaintenance,
+      exitTransmissionMaintenance,
+      setFrequency,
+      writeCapability,
+      emit,
+      runIdleMaintenance,
+    };
+  }
+
+  async function submitMaintenanceCommand(engine: DigitalRadioEngine, command: unknown): Promise<void> {
+    await (DigitalRadioEngine.prototype as any).submitPluginRadioMaintenanceCommand.call(engine, command);
+  }
+
+  it('performs a scheduled band switch and tuner start inside one physical idle fence', async () => {
+    const harness = createMaintenanceHarness();
+
+    await submitMaintenanceCommand(harness.fakeEngine, {
+      type: 'switch-band',
+      frequency: 14_074_000,
+      autoTune: true,
+    });
+
+    expect(harness.runIdleMaintenance).toHaveBeenCalledWith(
+      { reason: 'plugin scheduled band switch', busyPolicy: 'reject' },
+      expect.any(Function),
+    );
+    expect(harness.enterTransmissionMaintenance).toHaveBeenCalledWith('plugin scheduled band switch');
+    expect(harness.setFrequency).toHaveBeenCalledWith(14_074_000);
+    expect(harness.writeCapability.mock.calls).toEqual([
+      ['tuner_switch', true, undefined],
+      ['tuner_tune', undefined, true],
+    ]);
+    expect(harness.exitTransmissionMaintenance).toHaveBeenCalledOnce();
+  });
+
+  it('does not touch CAT or operator state when the physical coordinator reports busy', async () => {
+    const harness = createMaintenanceHarness();
+    harness.runIdleMaintenance.mockRejectedValueOnce(new Error('physical transmitter is draining'));
+
+    await expect(submitMaintenanceCommand(harness.fakeEngine, {
+      type: 'switch-band',
+      frequency: 14_074_000,
+      autoTune: true,
+    })).rejects.toThrow('physical transmitter is draining');
+
+    expect(harness.enterTransmissionMaintenance).not.toHaveBeenCalled();
+    expect(harness.setFrequency).not.toHaveBeenCalled();
+    expect(harness.writeCapability).not.toHaveBeenCalled();
+  });
+
+  it('does not tune or report success when the frequency change fails', async () => {
+    const harness = createMaintenanceHarness({ setFrequencyResult: false });
+
+    await expect(submitMaintenanceCommand(harness.fakeEngine, {
+      type: 'switch-band',
+      frequency: 7_074_000,
+      autoTune: true,
+    })).rejects.toThrow('Failed to set radio frequency');
+
+    expect(harness.writeCapability).not.toHaveBeenCalled();
+    expect(harness.emit).not.toHaveBeenCalled();
+    expect(harness.exitTransmissionMaintenance).toHaveBeenCalledOnce();
+  });
+
 });

--- a/packages/server/src/audio/AudioMixer.ts
+++ b/packages/server/src/audio/AudioMixer.ts
@@ -1,6 +1,11 @@
 import { EventEmitter } from 'eventemitter3';
 import { resampleAudioProfessional } from '../utils/audioUtils.js';
 import { createLogger } from '../utils/logger.js';
+import {
+  FrameAudioRepository,
+  type FrameAudioIdentity,
+  type FrameAudioSnapshot,
+} from './FrameAudioRepository.js';
 
 const logger = createLogger('AudioMixer');
 
@@ -9,464 +14,224 @@ export interface MixedAudio {
   sampleRate: number;
   duration: number;
   operatorIds: string[];
-  /**
-   * 虚拟频率：本时隙冻结的 dial 平移量（Hz）。
-   * 与音频载波同源（音频按 origFreq - shift 编码），随负载流转到 PTT 时点，
-   * 保证施加到电台的 dial 平移量恒等于编码所用 shift。0 表示不平移。
-   */
   txDialShiftHz: number;
+  frameId: string;
+  frameRevision: number;
+  slotId: string;
 }
 
-/**
- * 操作员时隙音频 - 保存每个操作员在当前时隙的原始编码音频
- */
-export interface OperatorSlotAudio {
-  operatorId: string;
-  audioData: Float32Array;    // 原始编码音频
-  sampleRate: number;
-  duration: number;           // 音频总时长（秒）
-  encodedAt: number;          // 编码完成时间戳
-  slotStartMs: number;        // 所属时隙开始时间
-  requestId?: string;         // 编码请求ID（用于去重）
+export interface AudioFrameMeta {
+  frameId: string;
+  frameRevision: number;
+  slotId: string;
 }
 
-/**
- * 音频混音器 - 用于将多个操作员的音频混合成一个音频流
- *
- * 新架构：保存每个操作员的原始编码音频，支持中途更新和重新混音
- */
+/** Mixes immutable, explicitly selected frame snapshots. */
 export class AudioMixer extends EventEmitter {
-  // 时隙音频缓存：按操作员ID存储原始编码音频
-  private slotAudioCache: Map<string, OperatorSlotAudio> = new Map();
-
-  // 当前时隙信息
-  private currentSlotStartMs: number = 0;
-
-  // 虚拟频率：本时隙冻结的 dial 平移量（Hz），由 addOperatorAudio 写入、随每个 MixedAudio 流转
-  private currentSlotTxDialShiftHz: number = 0;
-
-  // 播放状态跟踪
-  private playbackStartTimeMs: number = 0;
-  private isPlaying: boolean = false;
-
-  // 累计裁剪偏移量 - 用于中途更新时正确计算已播放时间
-  private cumulativeOffsetMs: number = 0;
-
-  // 混音窗口配置
+  private readonly repository = new FrameAudioRepository();
   private mixingTimeout: NodeJS.Timeout | null = null;
-  private readonly mixingWindowMs: number;
+  private scheduledPlaybackStartMs: number | null = null;
+  private scheduledFrame: FrameAudioIdentity | null = null;
 
-  constructor(mixingWindowMs: number = 100) {
+  constructor(private readonly mixingWindowMs = 100) {
     super();
-    this.mixingWindowMs = mixingWindowMs;
   }
 
-  /**
-   * 添加/更新操作员的编码音频
-   * 如果该操作员已有音频，则替换（支持中途更新）
-   */
   addOperatorAudio(
     operatorId: string,
     audioData: Float32Array,
     sampleRate: number,
     slotStartMs: number,
-    requestId?: string,
-    txDialShiftHz: number = 0
+    requestId: string | undefined,
+    txDialShiftHz: number,
+    frameMeta: AudioFrameMeta,
   ): void {
-    const existing = this.slotAudioCache.get(operatorId);
-    const duration = audioData.length / sampleRate;
+    const added = this.repository.putTrack(
+      {
+        frameId: frameMeta.frameId,
+        revision: frameMeta.frameRevision,
+        slotId: frameMeta.slotId,
+      },
+      {
+        operatorId,
+        audioData,
+        sampleRate,
+        slotStartMs,
+        requestId,
+        encodedAt: Date.now(),
+      },
+      txDialShiftHz,
+    );
+    if (!added) {
+      logger.debug('Ignored duplicate encoded frame track', {
+        operatorId,
+        frameId: frameMeta.frameId,
+        frameRevision: frameMeta.frameRevision,
+        requestId,
+      });
+    }
+  }
 
-    // 检查是否是旧的编码结果（通过 requestId 判断）
-    if (existing && requestId && existing.requestId === requestId) {
-      logger.debug(`Ignoring duplicate encode result: ${operatorId}, requestId=${requestId}`);
+  getFrameSnapshot(frameId: string, frameRevision: number): FrameAudioSnapshot | null {
+    return this.repository.getSnapshot({ frameId, revision: frameRevision });
+  }
+
+  retainFrame(frameId: string, frameRevision: number): void {
+    this.repository.retain({ frameId, revision: frameRevision });
+  }
+
+  releaseFrame(frameId: string, frameRevision: number): void {
+    this.repository.release({ frameId, revision: frameRevision });
+  }
+
+  cloneFrameTracks(
+    source: { frameId: string; frameRevision: number },
+    target: AudioFrameMeta,
+    retainedOperatorIds: readonly string[],
+  ): FrameAudioSnapshot | null {
+    return this.repository.cloneFrame(
+      { frameId: source.frameId, revision: source.frameRevision },
+      { frameId: target.frameId, revision: target.frameRevision, slotId: target.slotId },
+      retainedOperatorIds,
+    );
+  }
+
+  scheduleFrameMixing(
+    frame: FrameAudioIdentity,
+    targetPlaybackTime?: number,
+    playbackStartTime?: number,
+  ): void {
+    if (this.mixingTimeout) clearTimeout(this.mixingTimeout);
+    this.scheduledFrame = { ...frame };
+    this.scheduledPlaybackStartMs = playbackStartTime ?? null;
+    let delay = this.mixingWindowMs;
+    if (targetPlaybackTime !== undefined) {
+      const remaining = targetPlaybackTime - Date.now();
+      delay = remaining > this.mixingWindowMs
+        ? Math.max(0, remaining - 50)
+        : Math.max(0, remaining);
+    }
+    if (delay === 0) {
+      void this.triggerScheduledMix();
       return;
     }
-
-    // 时隙切换检测：如果是新时隙，清空缓存
-    if (slotStartMs !== this.currentSlotStartMs && this.currentSlotStartMs !== 0) {
-      logger.debug(`Slot switch detected: ${this.currentSlotStartMs} -> ${slotStartMs}`);
-      this.clearSlotCache();
-    }
-    this.currentSlotStartMs = slotStartMs;
-    // 在 clearSlotCache 之后赋值（否则会被重置为 0）。同一时隙所有操作员共享同一冻结 shift。
-    this.currentSlotTxDialShiftHz = txDialShiftHz;
-
-    // 存储/替换该操作员的音频
-    const operatorAudio: OperatorSlotAudio = {
-      operatorId,
-      audioData,
-      sampleRate,
-      duration,
-      encodedAt: Date.now(),
-      slotStartMs,
-      requestId
-    };
-
-    this.slotAudioCache.set(operatorId, operatorAudio);
-
-    logger.debug(`${existing ? 'Updated' : 'Added'} operator audio: ${operatorId}, ` +
-      `duration=${duration.toFixed(2)}s, sampleRate=${sampleRate}Hz, ` +
-      `requestId=${requestId || 'N/A'}, cacheSize=${this.slotAudioCache.size}`);
-  }
-
-  /**
-   * 调度混音（设置混音窗口定时器）
-   * @param targetPlaybackTime 目标播放时间（可选），用于智能调度
-   */
-  scheduleMixing(targetPlaybackTime?: number): void {
-    // 清除之前的定时器
-    if (this.mixingTimeout) {
-      clearTimeout(this.mixingTimeout);
+    this.mixingTimeout = setTimeout(() => {
       this.mixingTimeout = null;
-    }
-
-    // 计算混音延迟
-    let mixingDelay = this.mixingWindowMs;
-
-    if (targetPlaybackTime) {
-      const now = Date.now();
-      const timeUntilTarget = targetPlaybackTime - now;
-
-      if (timeUntilTarget > this.mixingWindowMs) {
-        mixingDelay = Math.max(0, timeUntilTarget - 50); // mix 50ms before target
-        logger.debug(`Smart schedule: ${timeUntilTarget}ms to target, will mix in ${mixingDelay}ms`);
-      } else if (timeUntilTarget > 0) {
-        mixingDelay = Math.max(0, timeUntilTarget);
-        logger.debug(`Smart schedule: target time approaching (${timeUntilTarget}ms)`);
-      } else {
-        mixingDelay = 0;
-        logger.warn(`Target playback time already passed by ${Math.abs(timeUntilTarget)}ms, mixing immediately`);
-      }
-    }
-
-    // 设置混音定时器
-    if (mixingDelay > 0) {
-      this.mixingTimeout = setTimeout(async () => {
-        this.mixingTimeout = null;
-        await this.triggerMixing();
-      }, mixingDelay);
-      logger.debug(`Mix timer set: will execute in ${mixingDelay}ms`);
-    } else {
-      // 立即混音
-      this.triggerMixing();
-    }
+      void this.triggerScheduledMix();
+    }, delay);
   }
 
-  /**
-   * 触发混音并发射事件
-   */
-  private async triggerMixing(): Promise<void> {
-    const mixedAudio = await this.mixAllOperatorAudios(0);
-    if (mixedAudio) {
-      this.emit('mixedAudioReady', mixedAudio);
-    }
-  }
-
-  /**
-   * 混合所有操作员的音频
-   * @param elapsedTimeMs 已播放时间（用于裁剪，0表示从头开始）
-   */
-  async mixAllOperatorAudios(elapsedTimeMs: number = 0): Promise<MixedAudio | null> {
-    const mixStartTime = Date.now();
-
-    if (this.slotAudioCache.size === 0) {
-      logger.debug('No audio pending for mix');
-      return null;
-    }
-
-    const audioList = Array.from(this.slotAudioCache.values());
-    const operatorIds = audioList.map(a => a.operatorId);
-
-    logger.debug(`Starting mix: ${audioList.length} tracks, operators=[${operatorIds.join(', ')}], skip=${elapsedTimeMs}ms`);
-
-    try {
-      // 1. 确定目标采样率（使用最高的采样率）
-      const targetSampleRate = Math.max(...audioList.map(a => a.sampleRate));
-
-      // 2. 计算需要跳过的采样点数
-      const skipSamples = Math.floor((elapsedTimeMs / 1000) * targetSampleRate);
-
-      // 3. 处理每个操作员的音频：重采样 + 裁剪
-      const processedAudios = await Promise.all(audioList.map(async (audio) => {
-        let samples = audio.audioData;
-
-        // 重采样（如需要）
-        if (audio.sampleRate !== targetSampleRate) {
-          logger.debug(`Operator ${audio.operatorId}: resampling ${audio.sampleRate}Hz -> ${targetSampleRate}Hz`);
-          try {
-            samples = await resampleAudioProfessional(
-              samples,
-              audio.sampleRate,
-              targetSampleRate,
-              1 // mono
-            );
-          } catch (error) {
-            logger.error(`Operator ${audio.operatorId}: resample failed, using fallback`, error);
-            samples = this.linearResample(samples, audio.sampleRate, targetSampleRate);
-          }
-        }
-
-        // 裁剪已播放部分
-        if (skipSamples > 0) {
-          if (skipSamples < samples.length) {
-            const originalLength = samples.length;
-            samples = samples.slice(skipSamples);
-            logger.debug(`Operator ${audio.operatorId}: trimmed ${originalLength} -> ${samples.length} samples (skipped ${skipSamples})`);
-          } else {
-            logger.debug(`Operator ${audio.operatorId}: audio fully played, skipping`);
-            samples = new Float32Array(0);
-          }
-        }
-
-        return { operatorId: audio.operatorId, samples };
-      }));
-
-      // 4. 过滤掉空音频
-      const validAudios = processedAudios.filter(a => a.samples.length > 0);
-      if (validAudios.length === 0) {
-        logger.warn('All audio tracks fully played, nothing to mix');
-        return null;
-      }
-
-      // 5. 单一音频快速路径
-      if (validAudios.length === 1) {
-        const single = validAudios[0];
-        logger.debug(`Single track fast path: ${single.operatorId}`);
-        return {
-          audioData: single.samples,
-          sampleRate: targetSampleRate,
-          duration: single.samples.length / targetSampleRate,
-          operatorIds: [single.operatorId],
-          txDialShiftHz: this.currentSlotTxDialShiftHz
-        };
-      }
-
-      // 6. 混合多个音频
-      const maxLength = Math.max(...validAudios.map(a => a.samples.length));
-      const mixedSamples = new Float32Array(maxLength);
-
-      for (const audio of validAudios) {
-        logger.debug(`Mixing operator ${audio.operatorId}: ${audio.samples.length} samples`);
-        for (let i = 0; i < audio.samples.length; i++) {
-          mixedSamples[i] += audio.samples[i];
+  async mixFrame(snapshot: FrameAudioSnapshot, elapsedTimeMs = 0): Promise<MixedAudio | null> {
+    const tracks = Array.from(snapshot.tracks.values());
+    if (tracks.length === 0) return null;
+    const targetSampleRate = Math.max(...tracks.map((track) => track.sampleRate));
+    const skipSamples = Math.floor((elapsedTimeMs / 1_000) * targetSampleRate);
+    const processed = await Promise.all(tracks.map(async (track) => {
+      let samples = track.audioData;
+      if (track.sampleRate !== targetSampleRate) {
+        try {
+          samples = await resampleAudioProfessional(samples, track.sampleRate, targetSampleRate, 1);
+        } catch (error) {
+          logger.warn('Professional resample failed; using linear fallback', {
+            operatorId: track.operatorId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          samples = this.linearResample(samples, track.sampleRate, targetSampleRate);
         }
       }
-
-      // 7. 归一化
-      const peakLevel = this.findPeakLevel(mixedSamples);
-      if (peakLevel > 1.0) {
-        const normalizeRatio = 0.95 / peakLevel;
-        logger.debug(`Normalizing: peak=${peakLevel.toFixed(3)}, ratio=${normalizeRatio.toFixed(3)}`);
-        for (let i = 0; i < mixedSamples.length; i++) {
-          mixedSamples[i] *= normalizeRatio;
-        }
-      }
-
-      const finalDuration = maxLength / targetSampleRate;
-      const mixEndTime = Date.now();
-
-      logger.debug(`Mix complete: ${validAudios.length} tracks -> duration=${finalDuration.toFixed(2)}s, elapsed=${mixEndTime - mixStartTime}ms`);
-
       return {
-        audioData: mixedSamples,
-        sampleRate: targetSampleRate,
-        duration: finalDuration,
-        operatorIds: validAudios.map(a => a.operatorId),
-        txDialShiftHz: this.currentSlotTxDialShiftHz
+        operatorId: track.operatorId,
+        samples: skipSamples < samples.length
+          ? samples.subarray(skipSamples)
+          : new Float32Array(0),
       };
+    }));
+    const audible = processed.filter((track) => track.samples.length > 0);
+    if (audible.length === 0) return null;
 
-    } catch (error) {
-      logger.error('Mix failed', error);
-      throw error;
+    const maxLength = Math.max(...audible.map((track) => track.samples.length));
+    let audioData: Float32Array;
+    if (audible.length === 1) {
+      audioData = audible[0].samples;
+    } else {
+      audioData = new Float32Array(maxLength);
+      for (const track of audible) {
+        for (let index = 0; index < track.samples.length; index += 1) {
+          audioData[index] += track.samples[index];
+        }
+      }
+      const peak = this.findPeakLevel(audioData);
+      if (peak > 1) {
+        const ratio = 0.95 / peak;
+        for (let index = 0; index < audioData.length; index += 1) audioData[index] *= ratio;
+      }
     }
+
+    return {
+      audioData,
+      sampleRate: targetSampleRate,
+      duration: audioData.length / targetSampleRate,
+      operatorIds: audible.map((track) => track.operatorId),
+      txDialShiftHz: snapshot.txDialShiftHz,
+      frameId: snapshot.frameId,
+      frameRevision: snapshot.revision,
+      slotId: snapshot.slotId,
+    };
   }
 
-  /**
-   * 重新混音（某操作员更新后调用）
-   * @param newElapsedTimeMs 自上次播放开始到现在经过的时间
-   */
-  async remixAfterUpdate(newElapsedTimeMs: number): Promise<MixedAudio | null> {
-    // 累加新的偏移量到总偏移
-    this.cumulativeOffsetMs += newElapsedTimeMs;
-
-    logger.debug(`Remix: offset=${newElapsedTimeMs}ms, totalOffset=${this.cumulativeOffsetMs}ms, operators=${this.slotAudioCache.size}`);
-
-    // 使用累计偏移量进行裁剪
-    return this.mixAllOperatorAudios(this.cumulativeOffsetMs);
+  async mixFrameById(
+    frameId: string,
+    frameRevision: number,
+    elapsedTimeMs = 0,
+  ): Promise<MixedAudio | null> {
+    const snapshot = this.getFrameSnapshot(frameId, frameRevision);
+    return snapshot ? this.mixFrame(snapshot, elapsedTimeMs) : null;
   }
 
-  /**
-   * 线性插值重采样（备用方案）
-   */
+  clearFrame(frameId: string, frameRevision: number): number {
+    return this.repository.removeFrame({ frameId, revision: frameRevision });
+  }
+
+  clearSlotCache(): void {
+    this.cancelScheduledMix();
+    this.repository.clearUnretained();
+  }
+
+  private async triggerScheduledMix(): Promise<void> {
+    const frame = this.scheduledFrame;
+    const playbackStart = this.scheduledPlaybackStartMs;
+    this.scheduledFrame = null;
+    this.scheduledPlaybackStartMs = null;
+    if (!frame) return;
+    const elapsedTimeMs = playbackStart === null ? 0 : Math.max(0, Date.now() - playbackStart);
+    const mixed = await this.mixFrameById(frame.frameId, frame.revision, elapsedTimeMs);
+    if (mixed) this.emit('mixedAudioReady', mixed);
+  }
+
+  private cancelScheduledMix(): void {
+    if (this.mixingTimeout) clearTimeout(this.mixingTimeout);
+    this.mixingTimeout = null;
+    this.scheduledFrame = null;
+    this.scheduledPlaybackStartMs = null;
+  }
+
   private linearResample(samples: Float32Array, fromRate: number, toRate: number): Float32Array {
     const ratio = toRate / fromRate;
-    const newLength = Math.floor(samples.length * ratio);
-    const resampled = new Float32Array(newLength);
-
-    for (let i = 0; i < newLength; i++) {
-      const sourceIndex = i / ratio;
-      const index = Math.floor(sourceIndex);
-      const fraction = sourceIndex - index;
-
-      if (index + 1 < samples.length) {
-        resampled[i] = samples[index] * (1 - fraction) + samples[index + 1] * fraction;
-      } else {
-        resampled[i] = samples[index] || 0;
-      }
+    const output = new Float32Array(Math.floor(samples.length * ratio));
+    for (let index = 0; index < output.length; index += 1) {
+      const sourceIndex = index / ratio;
+      const base = Math.floor(sourceIndex);
+      const fraction = sourceIndex - base;
+      output[index] = base + 1 < samples.length
+        ? samples[base] * (1 - fraction) + samples[base + 1] * fraction
+        : samples[base] ?? 0;
     }
-
-    return resampled;
+    return output;
   }
 
-  /**
-   * 查找音频的峰值
-   */
   private findPeakLevel(samples: Float32Array): number {
     let peak = 0;
-    for (let i = 0; i < samples.length; i++) {
-      const abs = Math.abs(samples[i]);
-      if (abs > peak) {
-        peak = abs;
-      }
-    }
+    for (const sample of samples) peak = Math.max(peak, Math.abs(sample));
     return peak;
-  }
-
-  /**
-   * 清空当前时隙的音频缓存（时隙切换时调用）
-   */
-  clearSlotCache(): void {
-    const count = this.slotAudioCache.size;
-    this.slotAudioCache.clear();
-    this.isPlaying = false;
-    this.playbackStartTimeMs = 0;
-    this.cumulativeOffsetMs = 0;  // 重置累计偏移量
-    this.currentSlotTxDialShiftHz = 0;  // 重置虚拟频率平移量
-
-    if (this.mixingTimeout) {
-      clearTimeout(this.mixingTimeout);
-      this.mixingTimeout = null;
-    }
-
-    logger.debug(`Slot audio cache cleared: removed ${count} operator tracks`);
-  }
-
-  /**
-   * 记录播放开始
-   */
-  markPlaybackStart(): void {
-    this.playbackStartTimeMs = Date.now();
-    this.isPlaying = true;
-    logger.debug(`Playback start marked: ${new Date(this.playbackStartTimeMs).toISOString()}`);
-  }
-
-  /**
-   * 记录播放停止
-   */
-  markPlaybackStop(): void {
-    this.isPlaying = false;
-    logger.debug('Playback stop marked');
-  }
-
-  /**
-   * 获取已播放时间
-   */
-  getElapsedPlaybackTime(): number {
-    if (!this.isPlaying || this.playbackStartTimeMs === 0) {
-      return 0;
-    }
-    return Date.now() - this.playbackStartTimeMs;
-  }
-
-  /**
-   * 检查是否正在播放
-   */
-  getIsPlaying(): boolean {
-    return this.isPlaying;
-  }
-
-  /**
-   * 强制立即混音
-   */
-  async forceMix(): Promise<MixedAudio | null> {
-    if (this.mixingTimeout) {
-      clearTimeout(this.mixingTimeout);
-      this.mixingTimeout = null;
-    }
-    return this.mixAllOperatorAudios(0);
-  }
-
-  /**
-   * 清除特定操作员的音频
-   */
-  clearOperatorAudio(operatorId: string): boolean {
-    if (this.slotAudioCache.has(operatorId)) {
-      this.slotAudioCache.delete(operatorId);
-      logger.debug(`Cleared audio for operator ${operatorId}`);
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * 获取当前状态
-   */
-  getStatus() {
-    return {
-      cacheCount: this.slotAudioCache.size,
-      operatorIds: Array.from(this.slotAudioCache.keys()),
-      currentSlotStartMs: this.currentSlotStartMs,
-      isPlaying: this.isPlaying,
-      hasPendingMix: this.mixingTimeout !== null,
-      mixingWindowMs: this.mixingWindowMs
-    };
-  }
-
-  /**
-   * 获取缓存中的操作员音频
-   */
-  getOperatorAudio(operatorId: string): OperatorSlotAudio | undefined {
-    return this.slotAudioCache.get(operatorId);
-  }
-
-  /**
-   * 获取所有缓存的操作员音频
-   */
-  getAllOperatorAudios(): OperatorSlotAudio[] {
-    return Array.from(this.slotAudioCache.values());
-  }
-
-  // ===== 兼容旧接口（将逐步废弃） =====
-
-  /**
-   * @deprecated 使用 addOperatorAudio + scheduleMixing 替代
-   */
-  addAudio(operatorId: string, audioData: Float32Array, sampleRate: number, scheduledTime: number, targetPlaybackTime?: number): void {
-    // 从 scheduledTime 推断 slotStartMs
-    const slotStartMs = scheduledTime;
-    this.addOperatorAudio(operatorId, audioData, sampleRate, slotStartMs);
-    this.scheduleMixing(targetPlaybackTime);
-  }
-
-  /**
-   * @deprecated 使用 clearSlotCache 替代
-   */
-  clear(): void {
-    this.clearSlotCache();
-  }
-
-  /**
-   * @deprecated 使用 remixAfterUpdate 替代
-   */
-  async remixWithNewAudio(elapsedTimeMs: number): Promise<MixedAudio | null> {
-    return this.remixAfterUpdate(elapsedTimeMs);
-  }
-
-  /**
-   * @deprecated 使用 getStatus().cacheCount 替代
-   */
-  getCurrentMixedAudio(): MixedAudio | null {
-    // 这个方法在新架构中不再有意义，返回 null
-    return null;
   }
 }

--- a/packages/server/src/audio/AudioStreamManager.ts
+++ b/packages/server/src/audio/AudioStreamManager.ts
@@ -35,7 +35,9 @@ const ICOM_WLAN_TX_MAX_WAIT_SLICE_MS = 20;
 const TCI_AUDIO_DEVICE_NAME = 'TCI Audio';
 const RTAUDIO_TX_CONSUME_WATCHDOG_MS = 750;
 const RTAUDIO_TX_DRAIN_TIMEOUT_FLOOR_MS = 1000;
+const RTAUDIO_TX_START_ACK_TIMEOUT_MS = 2000;
 const RTAUDIO_TX_WATCHDOG_MIN_SUBMITTED_CHUNKS = 3;
+const RTAUDIO_TX_MAX_CONSECUTIVE_WRITE_FAILURES = 20;
 const RTAUDIO_OUTPUT_WARNING_LOG_WINDOW_MS = 5000;
 const MAX_SERIALIZED_INPUT_INGEST_DEPTH = 3;
 
@@ -119,6 +121,24 @@ interface RtAudioIssueLogState {
   suppressedCount: number;
 }
 
+interface RtAudioPlaybackStartWaiter {
+  playbackId: number;
+  submittedChunks: number;
+  consumedChunks: number;
+  finishedSubmitting: boolean;
+  started: boolean;
+  onStarted: () => void;
+}
+
+interface RtAudioOutputDrainWaiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export interface WaitForOutputDrainOptions {
+  timeoutMs?: number;
+}
+
 export type RtAudioRuntimeIssueDirection = 'input' | 'output';
 export type RtAudioRuntimeIssuePhase = 'start' | 'runtime';
 
@@ -190,6 +210,8 @@ export interface PlayAudioOptions {
   injectIntoMonitor?: boolean;
   playbackKind?: PlaybackKind;
   diagnosticContext?: Record<string, unknown>;
+  /** Called once the first output frame has been consumed by the active sink. */
+  onPlaybackStarted?: () => void;
 }
 
 export type PlaybackKind = 'digital' | 'voice-keyer' | 'tune-tone';
@@ -265,7 +287,12 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
   private playbackStartTime: number = 0;        // 播放开始时间戳
   private currentPlaybackPromise: Promise<void> | null = null;  // 当前播放的Promise
   private currentPlaybackKind: PlaybackKind | null = null;
-  private shouldStopPlayback: boolean = false;  // 停止播放标志
+  /**
+   * Playback is allowed to overlap briefly while a timed-out cleanup settles.
+   * Keep cancellation scoped to the playback that requested it; a global flag
+   * lets an old stop cancel a newer frame after the coordinator has advanced.
+   */
+  private readonly stopRequestedPlaybackIds = new Set<number>();
   private voiceOutputObserver: VoiceTxOutputObserver | null = null;
   private voiceTxOutputPipeline: VoiceTxOutputPipeline;
   private nativeAudioInputSequence = 0;
@@ -283,6 +310,13 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
   private readonly inputIngestQueues = new Map<NativeAudioInputSourceKind, SerializedInputIngestQueue>();
   private outputWatchdogGeneration = 0;
   private playbackSequence = 0;
+  /**
+   * RtAudio's output callback has no playback id. Keep submitted playback
+   * chunks in FIFO order so a late callback from an older clip cannot confirm
+   * a newer lease before the older queued audio has drained.
+   */
+  private readonly rtAudioPlaybackStartWaiters: RtAudioPlaybackStartWaiter[] = [];
+  private readonly rtAudioOutputDrainWaiters = new Set<RtAudioOutputDrainWaiter>();
   private readonly now: AudioClock;
   private inputSignalType: AudioInputSignalType = 'af';
   private ifCenterHz = 12000;
@@ -1240,6 +1274,10 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         this.cleanupRtAudioStream('output', this.rtAudioOutput, 'stop-request');
         this.rtAudioOutput = null;
       }
+      this.rtAudioPlaybackStartWaiters.length = 0;
+      this.rejectRtAudioOutputDrainWaiters(
+        new Error('RtAudio output stopped before previous playback drained'),
+      );
 
       AudioDeviceManager.getInstance().clearActiveDevice('output', this.activeOutputDeviceName, this.outputDeviceId);
       this.isOutputting = false;
@@ -1592,6 +1630,85 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       this.outputFirstFrameConsumedAt = now;
     }
     this.outputLastFrameConsumedAt = now;
+
+    const waiter = this.rtAudioPlaybackStartWaiters.find((candidate) =>
+      candidate.consumedChunks < candidate.submittedChunks,
+    );
+    if (!waiter) return;
+
+    waiter.consumedChunks++;
+    if (!waiter.started) {
+      waiter.started = true;
+      try {
+        waiter.onStarted();
+      } catch (error) {
+        logger.warn('RtAudio playback start observer failed', {
+          playbackId: waiter.playbackId,
+          error: this.describeError(error),
+        });
+      }
+    }
+    this.pruneRtAudioPlaybackStartWaiters();
+  }
+
+  private beginRtAudioPlaybackStartWaiter(
+    playbackId: number,
+    onStarted: () => void,
+  ): RtAudioPlaybackStartWaiter {
+    const waiter: RtAudioPlaybackStartWaiter = {
+      playbackId,
+      submittedChunks: 0,
+      consumedChunks: 0,
+      finishedSubmitting: false,
+      started: false,
+      onStarted,
+    };
+    this.rtAudioPlaybackStartWaiters.push(waiter);
+    return waiter;
+  }
+
+  private noteRtAudioChunkPending(waiter: RtAudioPlaybackStartWaiter): void {
+    waiter.submittedChunks++;
+  }
+
+  private rollbackRtAudioChunkPending(waiter: RtAudioPlaybackStartWaiter): void {
+    waiter.submittedChunks = Math.max(waiter.consumedChunks, waiter.submittedChunks - 1);
+    this.pruneRtAudioPlaybackStartWaiters();
+  }
+
+  private finishRtAudioPlaybackStartWaiter(waiter: RtAudioPlaybackStartWaiter): void {
+    waiter.finishedSubmitting = true;
+    this.pruneRtAudioPlaybackStartWaiters();
+  }
+
+  private pruneRtAudioPlaybackStartWaiters(): void {
+    while (this.rtAudioPlaybackStartWaiters.length > 0) {
+      const first = this.rtAudioPlaybackStartWaiters[0]!;
+      if (!first.finishedSubmitting || first.consumedChunks < first.submittedChunks) {
+        return;
+      }
+      this.rtAudioPlaybackStartWaiters.shift();
+    }
+    this.notifyRtAudioOutputDrained();
+  }
+
+  private hasPendingRtAudioPlayback(): boolean {
+    return this.rtAudioPlaybackStartWaiters.some((waiter) =>
+      !waiter.finishedSubmitting || waiter.consumedChunks < waiter.submittedChunks,
+    );
+  }
+
+  private notifyRtAudioOutputDrained(): void {
+    if (this.hasPendingRtAudioPlayback()) return;
+    const waiters = [...this.rtAudioOutputDrainWaiters];
+    this.rtAudioOutputDrainWaiters.clear();
+    for (const waiter of waiters) waiter.resolve();
+  }
+
+  private rejectRtAudioOutputDrainWaiters(error: Error): void {
+    const waiters = [...this.rtAudioOutputDrainWaiters];
+    this.rtAudioOutputDrainWaiters.clear();
+    for (const waiter of waiters) waiter.reject(error);
   }
 
   private recordOutputRtAudioIssue(type: number, message: string): void {
@@ -1977,30 +2094,86 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
 
     const now = Date.now();
     const elapsedTime = now - this.playbackStartTime;
+    const playbackId = this.playbackSequence;
+    const playbackPromise = this.currentPlaybackPromise;
 
     logger.debug(`stopping current playback, elapsed: ${elapsedTime}ms`);
 
     // 设置停止标志,让播放循环自动退出
-    this.shouldStopPlayback = true;
+    this.stopRequestedPlaybackIds.add(playbackId);
 
     // 等待当前播放完全停止
-    if (this.currentPlaybackPromise) {
+    if (playbackPromise) {
       try {
-        await this.currentPlaybackPromise;
+        await playbackPromise;
       } catch (error) {
         // 播放被中断是预期的行为
         logger.debug('playback interrupted');
       }
     }
 
-    this.playing = false;
-    this.shouldStopPlayback = false;
-    this.currentPlaybackPromise = null;
-    this.currentPlaybackKind = null;
+    this.stopRequestedPlaybackIds.delete(playbackId);
+    if (this.playbackSequence === playbackId && this.currentPlaybackPromise === playbackPromise) {
+      this.playing = false;
+      this.currentPlaybackPromise = null;
+      this.currentPlaybackKind = null;
+    }
 
     logger.debug(`playback stopped, elapsed: ${elapsedTime}ms`);
 
     return elapsedTime;
+  }
+
+  /** Wait until the local RtAudio FIFO no longer contains an older playback. */
+  public async waitForOutputDrain(options: WaitForOutputDrainOptions = {}): Promise<boolean> {
+    if (this.usingIcomWlanOutput || this.usingTciOutput || this.usingAndroidOutput) {
+      return false;
+    }
+    if (!this.hasPendingRtAudioPlayback()) {
+      return false;
+    }
+
+    const requestedTimeoutMs = options.timeoutMs ?? 2_000;
+    const timeoutMs = Number.isFinite(requestedTimeoutMs)
+      ? Math.max(1, requestedTimeoutMs)
+      : 2_000;
+    const startedAt = this.now();
+    logger.info('waiting for previous RtAudio playback to drain', {
+      pendingPlaybacks: this.rtAudioPlaybackStartWaiters.length,
+      timeoutMs,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const waiter = {} as RtAudioOutputDrainWaiter;
+      const finish = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        this.rtAudioOutputDrainWaiters.delete(waiter);
+        clearTimeout(timer);
+        if (error) reject(error);
+        else resolve();
+      };
+      waiter.resolve = () => finish();
+      waiter.reject = (error) => finish(error);
+      const timer = setTimeout(() => {
+        finish(new Error(`RtAudio output drain timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.rtAudioOutputDrainWaiters.add(waiter);
+
+      // The callback may have drained the final chunk between the initial
+      // check and waiter registration.
+      if (!this.hasPendingRtAudioPlayback()) waiter.resolve();
+    });
+
+    logger.info('previous RtAudio playback drained', {
+      elapsedMs: Math.max(0, this.now() - startedAt),
+    });
+    return true;
+  }
+
+  private isPlaybackStopRequested(playbackId: number): boolean {
+    return this.stopRequestedPlaybackIds.has(playbackId);
   }
 
   /**
@@ -2033,7 +2206,6 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       this.playing = true;
       this.playbackStartTime = playStartTime;
       this.currentPlaybackKind = playbackKind;
-      this.shouldStopPlayback = false;
 
       const playbackPromise = (async () => {
         const chunkSize = ICOM_WLAN_TX_CHUNK_SIZE;
@@ -2044,9 +2216,19 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         const hrStart = performance.now();
         let samplesWritten = 0;
         let tciTransmissionStarted = false;
+        let playbackStarted = false;
+        const signalPlaybackStarted = () => {
+          if (playbackStarted) return;
+          playbackStarted = true;
+          try {
+            options.onPlaybackStarted?.();
+          } catch (error) {
+            logger.warn(`${radioAudioOutput.label} playback start observer failed`, error);
+          }
+        };
 
         const assertNotStopped = () => {
-          if (this.shouldStopPlayback) {
+          if (this.isPlaybackStopRequested(playbackId)) {
             throw new Error('playback interrupted');
           }
         };
@@ -2098,6 +2280,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
             }
 
             await radioAudioAdapter.sendAudio(chunk);
+            signalPlaybackStarted();
             if (options.injectIntoMonitor) {
               this.emit('txMonitorAudioData', { samples: chunk, sampleRate: targetSampleRate });
             }
@@ -2131,7 +2314,8 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         }
         throw error;
       } finally {
-        if (this.currentPlaybackPromise === playbackPromise) {
+        this.stopRequestedPlaybackIds.delete(playbackId);
+        if (this.playbackSequence === playbackId && this.currentPlaybackPromise === playbackPromise) {
           this.playing = false;
           this.currentPlaybackPromise = null;
           this.currentPlaybackKind = null;
@@ -2149,7 +2333,6 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       this.playing = true;
       this.playbackStartTime = playStartTime;
       this.currentPlaybackKind = playbackKind;
-      this.shouldStopPlayback = false;
       const playbackPromise = (async () => {
         const playbackData = targetSampleRate === this.outputSampleRate
           ? audioData
@@ -2157,12 +2340,21 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         const chunkSize = Math.max(64, this.outputBufferSize || 1024);
         const hrStart = performance.now();
         let samplesWritten = 0;
+        let playbackStarted = false;
         for (let offset = 0; offset < playbackData.length; offset += chunkSize) {
-          if (this.shouldStopPlayback) throw new Error('playback interrupted');
+          if (this.isPlaybackStopRequested(playbackId)) throw new Error('playback interrupted');
           const chunk = playbackData.subarray(offset, Math.min(offset + chunkSize, playbackData.length));
           const wrote = await this.androidAudioOutput?.write(chunk, this.volumeGain);
           if (!wrote) {
             throw new Error('Android audio output write failed');
+          }
+          if (!playbackStarted) {
+            playbackStarted = true;
+            try {
+              options.onPlaybackStarted?.();
+            } catch (error) {
+              logger.warn('Android playback start observer failed', error);
+            }
           }
           if (options.injectIntoMonitor) {
             this.emit('txMonitorAudioData', { samples: chunk, sampleRate: this.outputSampleRate });
@@ -2177,7 +2369,8 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       try {
         await playbackPromise;
       } finally {
-        if (this.currentPlaybackPromise === playbackPromise) {
+        this.stopRequestedPlaybackIds.delete(playbackId);
+        if (this.playbackSequence === playbackId && this.currentPlaybackPromise === playbackPromise) {
           this.playing = false;
           this.currentPlaybackPromise = null;
           this.currentPlaybackKind = null;
@@ -2191,12 +2384,14 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
     if (!this.isOutputting || !this.rtAudioOutput) {
       throw new Error('audio output stream not started');
     }
+    if (this.hasPendingRtAudioPlayback()) {
+      throw new Error('RtAudio output has undrained audio from a previous playback');
+    }
 
     // 保存播放状态
     this.playing = true;
     this.playbackStartTime = playStartTime;
     this.currentPlaybackKind = playbackKind;
-    this.shouldStopPlayback = false;
 
     logger.info('starting audio playback', {
       playbackId,
@@ -2214,6 +2409,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
 
     // 保存当前播放的Promise
     let playbackPromise: Promise<void> | null = null;
+    let playbackStartWaiter: RtAudioPlaybackStartWaiter | null = null;
     playbackPromise = (async () => {
       try {
       let playbackData: Float32Array;
@@ -2272,6 +2468,21 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
       let submittedChunks = 0;
       let submittedSamples = 0;
       let writeFailCount = 0;
+      let consecutiveWriteFailCount = 0;
+      let resolvePlaybackStarted!: () => void;
+      const playbackStartedPromise = new Promise<void>((resolve) => {
+        resolvePlaybackStarted = resolve;
+      });
+      playbackStartWaiter = this.beginRtAudioPlaybackStartWaiter(
+        playbackId,
+        () => {
+          try {
+            options.onPlaybackStarted?.();
+          } finally {
+            resolvePlaybackStarted();
+          }
+        },
+      );
       let postGainPeak = 0;
       let postGainSumSquares = 0;
       let postGainSampleCount = 0;
@@ -2344,7 +2555,18 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
               this.volumeGain,
               Boolean(options.injectIntoMonitor),
             );
-            this.rtAudioOutput.write(encoded.buffer);
+            // The RtAudio callback is the first reliable indication that the
+            // device consumed a frame. Count the in-flight write before
+            // entering native code because some backends invoke the callback
+            // synchronously from write().
+            this.noteRtAudioChunkPending(playbackStartWaiter!);
+            try {
+              this.rtAudioOutput.write(encoded.buffer);
+            } catch (error) {
+              this.rollbackRtAudioChunkPending(playbackStartWaiter!);
+              throw error;
+            }
+            consecutiveWriteFailCount = 0;
             if (encoded.monitorChunk && encoded.monitorChunk.length > 0) {
               this.emit('txMonitorAudioData', { samples: encoded.monitorChunk, sampleRate: this.outputSampleRate });
             }
@@ -2359,6 +2581,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
             return true;
           } catch (error) {
             writeFailCount++;
+            consecutiveWriteFailCount++;
             if (writeFailCount <= 3 || writeFailCount % 100 === 0) {
               logger.warn('audio output write failed', {
                 playbackId,
@@ -2371,6 +2594,11 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
                 error: this.describeError(error),
               });
             }
+            if (consecutiveWriteFailCount >= RTAUDIO_TX_MAX_CONSECUTIVE_WRITE_FAILURES) {
+              throw new Error(
+                `audio output write failed ${consecutiveWriteFailCount} consecutive times: ${this.describeError(error)}`,
+              );
+            }
             return false;
           }
         };
@@ -2378,7 +2606,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         const interval = setInterval(() => {
           try {
             // Check stop signal
-            if (this.shouldStopPlayback) {
+            if (this.isPlaybackStopRequested(playbackId)) {
               clearInterval(interval);
               logger.debug(`stop signal received, aborting playback (submitted ${cursor}/${totalChunks} chunks)`);
               reject(new Error('playback interrupted'));
@@ -2422,7 +2650,7 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
 
             // Catch-up write: write multiple chunks in one tick if behind schedule
             while (cursor < totalChunks && samplesWritten < targetSamples) {
-              if (this.shouldStopPlayback) break;
+              if (this.isPlaybackStopRequested(playbackId)) break;
               if (!writeChunk(cursor)) break;
               cursor++;
             }
@@ -2458,11 +2686,27 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         }, TICK_MS);
       });
 
+      if (options.onPlaybackStarted) {
+        let timer: NodeJS.Timeout | undefined;
+        try {
+          await Promise.race([
+            playbackStartedPromise,
+            new Promise<void>((_, reject) => {
+              timer = setTimeout(() => {
+                reject(new Error('RtAudio playback did not reach device consumption in time'));
+              }, RTAUDIO_TX_START_ACK_TIMEOUT_MS);
+            }),
+          ]);
+        } finally {
+          if (timer) clearTimeout(timer);
+        }
+      }
+
       if (consumeDiagnosticsEnabled) {
         const drainTimeoutMs = Math.max(RTAUDIO_TX_DRAIN_TIMEOUT_FLOOR_MS, prebufferMs + 500);
         const drainDeadline = Date.now() + drainTimeoutMs;
         while (
-          !this.shouldStopPlayback &&
+          !this.isPlaybackStopRequested(playbackId) &&
           this.outputFramesConsumed < submittedChunks &&
           Date.now() < drainDeadline
         ) {
@@ -2519,10 +2763,14 @@ export class AudioStreamManager extends EventEmitter<AudioStreamEvents> {
         }
         throw error;
       } finally {
+        this.stopRequestedPlaybackIds.delete(playbackId);
+        if (playbackStartWaiter) {
+          this.finishRtAudioPlaybackStartWaiter(playbackStartWaiter);
+        }
         // Safe if the playback failed before the watchdog was created.
         this.outputWatchdogGeneration++;
         // 清理播放状态
-        if (this.currentPlaybackPromise === playbackPromise) {
+        if (this.playbackSequence === playbackId && this.currentPlaybackPromise === playbackPromise) {
           this.playing = false;
           this.currentAudioData = null;
           this.currentPlaybackPromise = null;

--- a/packages/server/src/audio/FrameAudioRepository.ts
+++ b/packages/server/src/audio/FrameAudioRepository.ts
@@ -1,0 +1,135 @@
+export interface FrameAudioIdentity {
+  frameId: string;
+  revision: number;
+}
+
+export interface EncodedTrack {
+  operatorId: string;
+  audioData: Float32Array;
+  sampleRate: number;
+  slotStartMs: number;
+  requestId?: string;
+  encodedAt: number;
+}
+
+export interface FrameAudioSnapshot extends FrameAudioIdentity {
+  slotId: string;
+  txDialShiftHz: number;
+  tracks: ReadonlyMap<string, EncodedTrack>;
+}
+
+interface MutableFrameAudio extends FrameAudioIdentity {
+  slotId: string;
+  txDialShiftHz: number;
+  tracks: Map<string, EncodedTrack>;
+}
+
+function frameKey(identity: FrameAudioIdentity): string {
+  return `${identity.frameId}:${identity.revision}`;
+}
+
+export class FrameAudioRepository {
+  private readonly frames = new Map<string, MutableFrameAudio>();
+  private readonly retainedKeys = new Set<string>();
+
+  constructor(private readonly maxFrames = 256) {}
+
+  putTrack(
+    identity: FrameAudioIdentity & { slotId: string },
+    track: EncodedTrack,
+    txDialShiftHz: number,
+  ): boolean {
+    const key = frameKey(identity);
+    let frame = this.frames.get(key);
+    if (!frame) {
+      frame = {
+        frameId: identity.frameId,
+        revision: identity.revision,
+        slotId: identity.slotId,
+        txDialShiftHz,
+        tracks: new Map(),
+      };
+      this.frames.set(key, frame);
+    }
+    const existing = frame.tracks.get(track.operatorId);
+    if (existing?.requestId && track.requestId === existing.requestId) return false;
+    frame.slotId = identity.slotId;
+    frame.txDialShiftHz = txDialShiftHz;
+    frame.tracks.set(track.operatorId, track);
+    this.prune();
+    return true;
+  }
+
+  getSnapshot(identity: FrameAudioIdentity): FrameAudioSnapshot | null {
+    const frame = this.frames.get(frameKey(identity));
+    if (!frame) return null;
+    return {
+      frameId: frame.frameId,
+      revision: frame.revision,
+      slotId: frame.slotId,
+      txDialShiftHz: frame.txDialShiftHz,
+      tracks: new Map(frame.tracks),
+    };
+  }
+
+  cloneFrame(
+    source: FrameAudioIdentity,
+    target: FrameAudioIdentity & { slotId: string },
+    retainedOperatorIds: readonly string[],
+  ): FrameAudioSnapshot | null {
+    const sourceFrame = this.frames.get(frameKey(source));
+    if (!sourceFrame) return null;
+    const tracks = new Map<string, EncodedTrack>();
+    for (const operatorId of retainedOperatorIds) {
+      const track = sourceFrame.tracks.get(operatorId);
+      if (track) tracks.set(operatorId, track);
+    }
+    const cloned: MutableFrameAudio = {
+      frameId: target.frameId,
+      revision: target.revision,
+      slotId: target.slotId,
+      txDialShiftHz: sourceFrame.txDialShiftHz,
+      tracks,
+    };
+    this.frames.set(frameKey(target), cloned);
+    this.prune();
+    return this.getSnapshot(target);
+  }
+
+  removeFrame(identity: FrameAudioIdentity): number {
+    const key = frameKey(identity);
+    const frame = this.frames.get(key);
+    if (!frame) return 0;
+    this.frames.delete(key);
+    this.retainedKeys.delete(key);
+    return frame.tracks.size;
+  }
+
+  retain(identity: FrameAudioIdentity): void {
+    this.retainedKeys.add(frameKey(identity));
+  }
+
+  release(identity: FrameAudioIdentity): void {
+    this.retainedKeys.delete(frameKey(identity));
+    this.prune();
+  }
+
+  clearUnretained(): number {
+    let removed = 0;
+    for (const [key, frame] of this.frames) {
+      if (this.retainedKeys.has(key)) continue;
+      removed += frame.tracks.size;
+      this.frames.delete(key);
+    }
+    return removed;
+  }
+
+  private prune(): void {
+    if (this.frames.size <= this.maxFrames) return;
+    for (const key of this.frames.keys()) {
+      if (this.frames.size <= this.maxFrames) break;
+      if (this.retainedKeys.has(key)) continue;
+      this.frames.delete(key);
+    }
+  }
+}

--- a/packages/server/src/audio/__tests__/AudioMixer.frame-identity.test.ts
+++ b/packages/server/src/audio/__tests__/AudioMixer.frame-identity.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AudioMixer } from '../AudioMixer.js';
+
+const resampleDeferred = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/audioUtils.js', () => ({
+  resampleAudioProfessional: resampleDeferred,
+}));
+
+describe('AudioMixer frame identity', () => {
+  async function mix(
+    mixer: AudioMixer,
+    frame: { frameId: string; frameRevision: number },
+    offsetMs = 0,
+  ) {
+    const snapshot = mixer.getFrameSnapshot(frame.frameId, frame.frameRevision);
+    expect(snapshot).not.toBeNull();
+    return mixer.mixFrame(snapshot!, offsetMs);
+  }
+
+  it('never relabels an old operator track into a replacement mixed frame', async () => {
+    const mixer = new AudioMixer(0);
+    const firstFrame = { frameId: 'frame-1', frameRevision: 1, slotId: 'slot-0' };
+    mixer.addOperatorAudio('a', new Float32Array([0.1, 0.1]), 12_000, 1, 'a-1', 0, firstFrame);
+    mixer.addOperatorAudio('b', new Float32Array([0.2, 0.2]), 12_000, 1, 'b-1', 0, firstFrame);
+    await expect(mix(mixer, firstFrame)).resolves.toMatchObject({
+      operatorIds: ['a', 'b'],
+      frameId: 'frame-1',
+      frameRevision: 1,
+    });
+
+    const replacementFrame = { frameId: 'frame-2', frameRevision: 2, slotId: 'slot-0' };
+    mixer.addOperatorAudio('a', new Float32Array([0.3, 0.3]), 12_000, 1, 'a-2', 0, replacementFrame);
+    await expect(mix(mixer, replacementFrame)).resolves.toMatchObject({
+      operatorIds: ['a'],
+      frameId: 'frame-2',
+      frameRevision: 2,
+    });
+
+    mixer.addOperatorAudio('b', new Float32Array([0.4, 0.4]), 12_000, 1, 'b-2', 0, replacementFrame);
+    await expect(mix(mixer, replacementFrame)).resolves.toMatchObject({
+      operatorIds: ['a', 'b'],
+      frameId: 'frame-2',
+      frameRevision: 2,
+    });
+  });
+
+  it('freezes frame identity while an asynchronous resample is pending', async () => {
+    let resolveResample!: (samples: Float32Array) => void;
+    resampleDeferred.mockImplementationOnce(() => new Promise<Float32Array>((resolve) => {
+      resolveResample = resolve;
+    }));
+
+    const mixer = new AudioMixer(0);
+    mixer.addOperatorAudio(
+      'a',
+      new Float32Array([0.1, 0.1]),
+      6_000,
+      1,
+      'a-1',
+      10,
+      { frameId: 'frame-1', frameRevision: 1, slotId: 'slot-0' },
+    );
+    mixer.addOperatorAudio(
+      'b',
+      new Float32Array([0.15, 0.15, 0.15, 0.15]),
+      12_000,
+      1,
+      'b-1',
+      10,
+      { frameId: 'frame-1', frameRevision: 1, slotId: 'slot-0' },
+    );
+    const firstSnapshot = mixer.getFrameSnapshot('frame-1', 1)!;
+    const mixing = mixer.mixFrame(firstSnapshot);
+    await vi.waitFor(() => expect(resampleDeferred).toHaveBeenCalledTimes(1));
+
+    mixer.addOperatorAudio(
+      'a',
+      new Float32Array([0.2, 0.2]),
+      12_000,
+      1,
+      'a-2',
+      20,
+      { frameId: 'frame-2', frameRevision: 2, slotId: 'slot-0' },
+    );
+    resolveResample(new Float32Array([0.3, 0.3]));
+
+    await expect(mixing).resolves.toMatchObject({
+      operatorIds: ['a', 'b'],
+      frameId: 'frame-1',
+      frameRevision: 1,
+      txDialShiftHz: 10,
+    });
+  });
+
+  it('clears only the cancelled frame tracks when a newer frame is cached', () => {
+    const mixer = new AudioMixer(0);
+    mixer.addOperatorAudio('a', new Float32Array([0.1]), 12_000, 1, 'a-1', 0, {
+      frameId: 'frame-1', frameRevision: 1, slotId: 'slot-0',
+    });
+    mixer.addOperatorAudio('b', new Float32Array([0.2]), 12_000, 1, 'b-2', 0, {
+      frameId: 'frame-2', frameRevision: 2, slotId: 'slot-0',
+    });
+
+    expect(mixer.clearFrame('frame-1', 1)).toBe(1);
+    expect(mixer.getFrameSnapshot('frame-1', 1)).toBeNull();
+    expect(mixer.getFrameSnapshot('frame-2', 2)?.tracks.get('b')).toMatchObject({
+      operatorId: 'b',
+    });
+  });
+
+  it('rebinds retained encoded tracks without copying a removed participant into the mix', async () => {
+    const mixer = new AudioMixer(0);
+    const firstFrame = { frameId: 'frame-1', frameRevision: 1, slotId: 'slot-0' };
+    mixer.addOperatorAudio('a', new Float32Array([0.1, 0.1]), 12_000, 1, 'a-1', 0, firstFrame);
+    mixer.addOperatorAudio('b', new Float32Array([0.2, 0.2]), 12_000, 1, 'b-1', 0, firstFrame);
+
+    const cloned = mixer.cloneFrameTracks(
+      { frameId: 'frame-1', frameRevision: 1 },
+      { frameId: 'frame-2', frameRevision: 2, slotId: 'slot-0' },
+      ['b'],
+    );
+    expect(Array.from(cloned!.tracks.keys())).toEqual(['b']);
+    expect(mixer.getFrameSnapshot('frame-1', 1)?.tracks.has('a')).toBe(true);
+    await expect(mixer.mixFrame(cloned!)).resolves.toMatchObject({
+      operatorIds: ['b'],
+      frameId: 'frame-2',
+      frameRevision: 2,
+    });
+  });
+
+  it('restores the retained frame identity after cancelling a partially encoded replacement', async () => {
+    const mixer = new AudioMixer(0);
+    mixer.addOperatorAudio('b', new Float32Array([0.2, 0.2]), 12_000, 1, 'b-1', 0, {
+      frameId: 'frame-1', frameRevision: 1, slotId: 'slot-0',
+    });
+    mixer.addOperatorAudio('a', new Float32Array([0.3, 0.3]), 12_000, 1, 'a-2', 0, {
+      frameId: 'frame-2', frameRevision: 2, slotId: 'slot-0',
+    });
+
+    expect(mixer.clearFrame('frame-2', 2)).toBe(1);
+    await expect(mix(mixer, { frameId: 'frame-1', frameRevision: 1 })).resolves.toMatchObject({
+      operatorIds: ['b'],
+      frameId: 'frame-1',
+      frameRevision: 1,
+    });
+  });
+
+  it('starts a mid-slot frame at the requested waveform offset', async () => {
+    const mixer = new AudioMixer(0);
+    mixer.addOperatorAudio(
+      'a',
+      new Float32Array([1, 2, 3, 4, 5]),
+      1_000,
+      0,
+      'a-1',
+      0,
+      { frameId: 'frame-mid-slot', frameRevision: 1, slotId: 'slot-0' },
+    );
+
+    const mixed = await mix(mixer, { frameId: 'frame-mid-slot', frameRevision: 1 }, 2);
+    expect(mixed?.audioData).toEqual(new Float32Array([3, 4, 5]));
+    expect(mixed?.duration).toBeCloseTo(0.003, 6);
+  });
+});

--- a/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
+++ b/packages/server/src/audio/__tests__/AudioStreamManager.icom-wlan.test.ts
@@ -66,6 +66,16 @@ type MockOpenWebRXAdapter = EventEmitter & {
   stopReceiving: ReturnType<typeof vi.fn>;
 };
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function createIcomManager(adapter: MockIcomAdapter): AudioStreamManager {
   const manager = new AudioStreamManager();
   manager.setIcomWlanAudioAdapter(adapter as never);
@@ -120,6 +130,24 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     expect(adapter.sendAudio).toHaveBeenCalledTimes(10);
   });
 
+  it('acknowledges playback start only after the first ICOM audio write succeeds', async () => {
+    const firstWrite = deferred<void>();
+    const adapter: MockIcomAdapter = {
+      sendAudio: vi.fn().mockImplementation(() => firstWrite.promise),
+      getSampleRate: vi.fn().mockReturnValue(12000),
+    };
+    const manager = createIcomManager(adapter);
+    const onPlaybackStarted = vi.fn();
+
+    const playback = manager.playAudio(new Float32Array(1024), 12000, { onPlaybackStarted });
+    await vi.waitFor(() => expect(adapter.sendAudio).toHaveBeenCalledTimes(1));
+    expect(onPlaybackStarted).not.toHaveBeenCalled();
+
+    firstWrite.resolve();
+    await expect(playback).resolves.toBeUndefined();
+    expect(onPlaybackStarted).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps stopCurrentPlayback responsive while ICOM WLAN pacing waits', async () => {
     const adapter: MockIcomAdapter = {
       sendAudio: vi.fn().mockResolvedValue(undefined),
@@ -141,6 +169,33 @@ describe('AudioStreamManager ICOM WLAN output pacing', () => {
     const playbackError = await playbackResult;
     expect(playbackError).toBeInstanceOf(Error);
     expect(playbackError.message).toBe('playback interrupted');
+  });
+
+  it('does not let a late stop cleanup clear a newer playback', async () => {
+    const oldSend = deferred<void>();
+    const newSend = deferred<void>();
+    const adapter: MockIcomAdapter = {
+      sendAudio: vi.fn()
+        .mockImplementationOnce(() => oldSend.promise)
+        .mockImplementationOnce(() => newSend.promise),
+      getSampleRate: vi.fn().mockReturnValue(12000),
+    };
+    const manager = createIcomManager(adapter);
+    const clip = new Float32Array(1024);
+
+    const oldPlayback = manager.playAudio(clip, 12000).catch((error) => error);
+    await vi.waitFor(() => expect(adapter.sendAudio).toHaveBeenCalledTimes(1));
+    const stoppingOldPlayback = manager.stopCurrentPlayback({ kind: 'digital' });
+
+    const newPlayback = manager.playAudio(clip, 12000);
+    await vi.waitFor(() => expect(adapter.sendAudio).toHaveBeenCalledTimes(2));
+    oldSend.resolve();
+    await stoppingOldPlayback;
+
+    expect(manager.isPlaying('digital')).toBe(true);
+    newSend.resolve();
+    await expect(newPlayback).resolves.toBeUndefined();
+    await expect(oldPlayback).resolves.toBeInstanceOf(Error);
   });
 
   it('paces TCI chunks through the same radio-audio output path', async () => {

--- a/packages/server/src/audio/__tests__/AudioStreamManager.rtaudio-output.test.ts
+++ b/packages/server/src/audio/__tests__/AudioStreamManager.rtaudio-output.test.ts
@@ -123,6 +123,10 @@ const { mockConfigManager, mockLogger, mockResampleAudioProfessional, mockRtAudi
     emitRtAudioError(type: number, message: string) {
       this.errorCallback?.(type, message);
     }
+
+    consumeNextFrame() {
+      this.frameOutputCallback?.();
+    }
   }
 
   return {
@@ -406,6 +410,81 @@ describe('AudioStreamManager RtAudio output diagnostics', () => {
     );
   });
 
+  it('acknowledges RtAudio playback only after the device consumes a frame', async () => {
+    mockRtAudioState.consumeOnWrite = false;
+    const manager = new AudioStreamManager();
+    const onPlaybackStarted = vi.fn();
+    await manager.startOutput();
+
+    const playback = manager.playAudio(new Float32Array(256).fill(0.5), 48000, { onPlaybackStarted });
+    await vi.waitFor(() => expect(mockRtAudioState.writes.length).toBeGreaterThan(0));
+    expect(onPlaybackStarted).not.toHaveBeenCalled();
+
+    const output = (manager as unknown as { rtAudioOutput: { consumeNextFrame: () => void } }).rtAudioOutput;
+    output.consumeNextFrame();
+    expect(onPlaybackStarted).toHaveBeenCalledTimes(1);
+    await playback;
+  });
+
+  it('does not enqueue a new RtAudio playback behind undrained output', async () => {
+    mockRtAudioState.consumeOnWrite = false;
+    const manager = new AudioStreamManager();
+    await manager.startOutput();
+
+    await manager.playAudio(new Float32Array(256).fill(0.5), 48000);
+
+    await expect(manager.playAudio(new Float32Array(256).fill(0.5), 48000))
+      .rejects.toThrow('undrained audio from a previous playback');
+  });
+
+  it('waits for every previously submitted RtAudio chunk before allowing replacement playback', async () => {
+    mockRtAudioState.consumeOnWrite = false;
+    const manager = new AudioStreamManager();
+    await manager.startOutput();
+    await manager.playAudio(new Float32Array(256).fill(0.5), 48000);
+
+    let drained = false;
+    const drain = manager.waitForOutputDrain({ timeoutMs: 200 }).then((waited) => {
+      drained = true;
+      return waited;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    const output = (manager as unknown as {
+      rtAudioOutput: { consumeNextFrame: () => void };
+    }).rtAudioOutput;
+    for (let index = 0; index < mockRtAudioState.writes.length; index++) {
+      output.consumeNextFrame();
+    }
+
+    await expect(drain).resolves.toBe(true);
+    mockRtAudioState.consumeOnWrite = true;
+    await expect(manager.playAudio(new Float32Array(256).fill(0.25), 48000)).resolves.toBeUndefined();
+  });
+
+  it('bounds waiting for an RtAudio FIFO that never drains', async () => {
+    mockRtAudioState.consumeOnWrite = false;
+    const manager = new AudioStreamManager();
+    await manager.startOutput();
+    await manager.playAudio(new Float32Array(256).fill(0.5), 48000);
+
+    await expect(manager.waitForOutputDrain({ timeoutMs: 10 }))
+      .rejects.toThrow('RtAudio output drain timed out after 10ms');
+  });
+
+  it('rejects an output-drain waiter when the RtAudio stream is stopped', async () => {
+    mockRtAudioState.consumeOnWrite = false;
+    const manager = new AudioStreamManager();
+    await manager.startOutput();
+    await manager.playAudio(new Float32Array(256).fill(0.5), 48000);
+
+    const drain = expect(manager.waitForOutputDrain({ timeoutMs: 200 }))
+      .rejects.toThrow('output stopped before previous playback drained');
+    await manager.stopOutput();
+    await drain;
+  });
+
   it('surfaces RtAudio output error callbacks through AudioStreamManager error events', async () => {
     const manager = new AudioStreamManager();
     const runtimeErrors: Error[] = [];
@@ -636,6 +715,22 @@ describe('AudioStreamManager RtAudio output diagnostics', () => {
         fails: expect.any(Number),
       }),
     );
+  });
+
+  it('fails playback after bounded consecutive RtAudio write errors without acknowledging start', async () => {
+    mockRtAudioState.throwOnWrite = true;
+    const manager = new AudioStreamManager();
+    await manager.startOutput();
+    const onPlaybackStarted = vi.fn();
+
+    await expect(manager.playAudio(
+      new Float32Array(256).fill(0.5),
+      48000,
+      { onPlaybackStarted },
+    )).rejects.toThrow('20 consecutive times');
+
+    expect(onPlaybackStarted).not.toHaveBeenCalled();
+    expect(manager.isPlaying()).toBe(false);
   });
 
   it('logs sliding-window eviction at debug (not warn) for the RX/input buffer', () => {

--- a/packages/server/src/audio/index.ts
+++ b/packages/server/src/audio/index.ts
@@ -1,3 +1,3 @@
 export { SpectrumAnalyzer, type SpectrumConfig as SpectrumAnalyzerConfig } from './SpectrumAnalyzer.js';
 export { SpectrumScheduler, type SpectrumConfig, type SpectrumSchedulerEvents } from './SpectrumScheduler.js';
-export { AudioMixer, type MixedAudio, type OperatorSlotAudio } from './AudioMixer.js';
+export { AudioMixer, type MixedAudio } from './AudioMixer.js';

--- a/packages/server/src/config/ProfileManager.ts
+++ b/packages/server/src/config/ProfileManager.ts
@@ -3,6 +3,7 @@ import type { AudioDeviceSettings } from '@tx5dr/contracts';
 import { ConfigManager, normalizeAudioDeviceSettings } from './config-manager.js';
 import { DigitalRadioEngine } from '../DigitalRadioEngine.js';
 import { createLogger } from '../utils/logger.js';
+import { normalizeHamlibConfig } from '../radio/hamlibConfigUtils.js';
 
 const logger = createLogger('ProfileManager');
 
@@ -47,7 +48,7 @@ export class ProfileManager {
     const profile: RadioProfile = {
       id: `profile-${now}-${Math.random().toString(36).substr(2, 9)}`,
       name: data.name,
-      radio: data.radio,
+      radio: normalizeHamlibConfig(data.radio),
       audio,
       audioLockedToRadio,
       createdAt: now,

--- a/packages/server/src/config/__tests__/ConfigManager.digitalModeMigration.test.ts
+++ b/packages/server/src/config/__tests__/ConfigManager.digitalModeMigration.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigManager } from '../config-manager.js';
+
+describe('ConfigManager digital mode preference migration', () => {
+  it('migrates only missing Profile preferences to USB', () => {
+    const config = {
+      profiles: [
+        { id: 'legacy', radio: { type: 'serial' } },
+        { id: 'manual', radio: { type: 'serial', digitalModeRadioMode: 'none' } },
+        { id: 'data', radio: { type: 'serial', digitalModeRadioMode: 'usb-data' } },
+      ],
+    };
+    const migrate = (ConfigManager.prototype as unknown as {
+      migrateMissingDigitalModeRadioMode: (candidate: unknown) => boolean;
+    }).migrateMissingDigitalModeRadioMode;
+
+    expect(migrate.call({}, config)).toBe(true);
+    expect(config.profiles.map((profile) => profile.radio.digitalModeRadioMode)).toEqual([
+      'usb',
+      'none',
+      'usb-data',
+    ]);
+    expect(migrate.call({}, config)).toBe(false);
+  });
+});

--- a/packages/server/src/config/config-manager.ts
+++ b/packages/server/src/config/config-manager.ts
@@ -477,6 +477,11 @@ export class ConfigManager {
       logger.info('Profile migration complete');
     }
 
+    if (this.migrateMissingDigitalModeRadioMode(parsedConfig)) {
+      logger.info('Legacy Profile digital radio mode preferences migrated to USB');
+      migrated = true;
+    }
+
     if (this.migrateLegacyStandardQSOSettings(parsedConfig)) {
       logger.info('Legacy standard-qso operator settings migrated to plugin config');
       migrated = true;
@@ -638,6 +643,24 @@ export class ConfigManager {
       }
     }
 
+    return changed;
+  }
+
+  private migrateMissingDigitalModeRadioMode(parsedConfig: any): boolean {
+    if (!Array.isArray(parsedConfig.profiles)) {
+      return false;
+    }
+
+    let changed = false;
+    for (const profile of parsedConfig.profiles) {
+      if (!isPlainObject(profile) || !isPlainObject(profile.radio)) {
+        continue;
+      }
+      if (profile.radio.digitalModeRadioMode === undefined) {
+        profile.radio.digitalModeRadioMode = 'usb';
+        changed = true;
+      }
+    }
     return changed;
   }
 
@@ -827,7 +850,10 @@ export class ConfigManager {
    * 添加 Profile
    */
   async addProfile(profile: RadioProfile): Promise<void> {
-    this.config.profiles.push(profile);
+    this.config.profiles.push({
+      ...profile,
+      radio: normalizeHamlibConfig(profile.radio),
+    });
     await this.saveConfig();
   }
 
@@ -875,6 +901,12 @@ export class ConfigManager {
       nextUpdates = {
         ...nextUpdates,
         audio: normalizeAudioDeviceSettings({ ...existing.audio, ...nextAudio }),
+      };
+    }
+    if (updates.radio) {
+      nextUpdates = {
+        ...nextUpdates,
+        radio: normalizeHamlibConfig({ ...existing.radio, ...updates.radio }),
       };
     }
 

--- a/packages/server/src/cw/CWKeyerManager.ts
+++ b/packages/server/src/cw/CWKeyerManager.ts
@@ -15,6 +15,7 @@ import type { CWKeyerBackend } from './CWKeyerBackend.js';
 import { getDataFilePath } from '../utils/app-paths.js';
 import { ConfigManager } from '../config/config-manager.js';
 import type { PhysicalRadioManager } from '../radio/PhysicalRadioManager.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('CWKeyerManager');
@@ -134,6 +135,7 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
   private _startingPromise: Promise<void> | null = null;
   private configLoaded = false;
   private configLoadPromise: Promise<void> | null = null;
+  private physicalLeaseId: string | null = null;
   private rootDir: string | null = null;
   private config: CWKeyerConfig = {
     backend: 'cat',
@@ -158,7 +160,10 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
     lastText: null,
   };
 
-  constructor(getRadioManager?: () => PhysicalRadioManager) {
+  constructor(
+    getRadioManager?: () => PhysicalRadioManager,
+    private readonly physicalTxCoordinator?: PhysicalTxCoordinator,
+  ) {
     super();
     this.backends = {
       cat: new RadioCatCWKeyerBackend(() => {
@@ -290,8 +295,10 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
     try {
       await this.ensureStarted();
       phase = 'keyDown';
+      await this.acquirePhysicalLease('CW keyer test', () => backend.keyUp!());
       await backend.keyDown();
       keyDown = true;
+      this.confirmPhysicalLease();
       this.setStatus(this.statusFor(active.clientId, active.label, 'keying', null));
 
       await this.delay(Math.max(0, Math.round(durationMs)), active);
@@ -300,6 +307,7 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
         phase = 'keyUp';
         await backend.keyUp();
         keyDown = false;
+        await this.releasePhysicalLease('CW keyer test complete');
       }
     } catch (error) {
       if (keyDown) {
@@ -313,6 +321,7 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
           );
         }
       }
+      await this.releasePhysicalLease('CW keyer test failed').catch(() => undefined);
       throw new CWKeyerTestFailure(
         phase,
         error instanceof Error ? error.message : String(error),
@@ -359,8 +368,11 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
 
     if (action === 'key-down') {
       // 独占锁：同一时间只能一个客户端手键
-      if (this.active && this.active.mode === 'manual' && this.active.clientId !== clientId) {
-        logger.debug('Manual key rejected: already keying by another client');
+      if (this.active?.mode === 'manual') {
+        if (this.active.clientId !== clientId) {
+          logger.debug('Manual key rejected: already keying by another client');
+        }
+        // Browser/WS key repeat must not acquire a second physical lease.
         return;
       }
 
@@ -382,9 +394,12 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
 
       try {
         await this.ensureStarted();
+        await this.acquirePhysicalLease('CW manual key', () => backend.keyUp!());
         await backend.keyDown();
+        this.confirmPhysicalLease();
         this.setStatus(this.statusFor(clientId, label, 'keying', null));
       } catch (error) {
+        await this.abortPhysicalLease('CW manual key failed');
         this.active = null;
         throw error;
       }
@@ -394,8 +409,14 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
         return;
       }
 
-      await this.ensureStarted();
-      await backend.keyUp();
+      try {
+        await this.ensureStarted();
+        await backend.keyUp();
+        await this.releasePhysicalLease('CW manual key released');
+      } catch (error) {
+        await this.abortPhysicalLease('CW manual key release failed');
+        throw error;
+      }
       this.active = null;
       this.setStatus(this.idleStatus());
     }
@@ -609,7 +630,13 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
     active.stopRequested = true;
     this.clearActiveDelay(active);
 
-    await this.getBackend().stopActive();
+    try {
+      await this.getBackend().stopActive();
+      await this.releasePhysicalLease(reason);
+    } catch (error) {
+      await this.abortPhysicalLease(reason);
+      throw error;
+    }
 
     this.active = null;
     logger.info('CW keying stopped', { reason });
@@ -630,18 +657,28 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
     }
 
     const backend = this.getBackend();
-    await backend.sendText(text, this.config.wpm, {
-      isStopped: () => active.stopRequested || this.active !== active,
-      wait: async (ms) => {
-        await this.delay(ms, active);
-        return !active.stopRequested && this.active === active;
-      },
-      onKeyDown: () => {
-        if (!active.stopRequested && this.active === active) {
-          this.setStatus(this.statusFor(active.clientId, active.label, 'playing', active.messageId, null, active.currentText));
-        }
-      },
-    });
+    await this.acquirePhysicalLease('CW message', () => backend.stopActive());
+    if (active.stopRequested || this.active !== active) {
+      await this.abortPhysicalLease('CW message cancelled while starting');
+      return;
+    }
+    try {
+      await backend.sendText(text, this.config.wpm, {
+        isStopped: () => active.stopRequested || this.active !== active,
+        wait: async (ms) => {
+          await this.delay(ms, active);
+          return !active.stopRequested && this.active === active;
+        },
+        onKeyDown: () => {
+          if (!active.stopRequested && this.active === active) {
+            this.confirmPhysicalLease();
+            this.setStatus(this.statusFor(active.clientId, active.label, 'playing', active.messageId, null, active.currentText));
+          }
+        },
+      });
+    } finally {
+      await this.releasePhysicalLease('CW message complete');
+    }
 
     if (active.stopRequested || this.active !== active) {
       return;
@@ -707,6 +744,37 @@ export class CWKeyerManager extends EventEmitter<CWKeyerManagerEvents> {
       logger.warn('Failed to read active CW slot', { error: (error as Error).message });
       return null;
     }
+  }
+
+  private async acquirePhysicalLease(reason: string, interrupt: () => Promise<void>): Promise<void> {
+    if (!this.physicalTxCoordinator) return;
+    this.physicalLeaseId = await this.physicalTxCoordinator.acquireLease({
+      source: 'cw',
+      reason,
+      assertPtt: false,
+      deferActiveUntilAudio: true,
+      interrupt,
+    });
+  }
+
+  private confirmPhysicalLease(): void {
+    if (this.physicalTxCoordinator && this.physicalLeaseId) {
+      this.physicalTxCoordinator.markSelfKeyedLeaseActive(this.physicalLeaseId);
+    }
+  }
+
+  private async releasePhysicalLease(reason: string): Promise<void> {
+    if (!this.physicalTxCoordinator || !this.physicalLeaseId) return;
+    const leaseId = this.physicalLeaseId;
+    this.physicalLeaseId = null;
+    await this.physicalTxCoordinator.releaseLease(leaseId, reason);
+  }
+
+  private async abortPhysicalLease(reason: string): Promise<void> {
+    if (!this.physicalTxCoordinator || !this.physicalLeaseId) return;
+    const leaseId = this.physicalLeaseId;
+    this.physicalLeaseId = null;
+    await this.physicalTxCoordinator.forceInterruptLease(leaseId, reason).catch(() => undefined);
   }
 
   private delay(ms: number, active: ActiveKeying): Promise<void> {

--- a/packages/server/src/cw/__tests__/CWKeyerManager.test.ts
+++ b/packages/server/src/cw/__tests__/CWKeyerManager.test.ts
@@ -7,7 +7,12 @@ import type { CWKeyerBackend } from '../CWKeyerBackend.js';
 
 const tempDirs: string[] = [];
 
-async function createManager(options: { catAvailable?: boolean; catError?: string | null; keyPort?: string } = {}) {
+async function createManager(options: {
+  catAvailable?: boolean;
+  catError?: string | null;
+  keyPort?: string;
+  physicalTxCoordinator?: any;
+} = {}) {
   const root = await mkdtemp(join(tmpdir(), 'tx5dr-cw-keyer-'));
   tempDirs.push(root);
 
@@ -35,7 +40,7 @@ async function createManager(options: { catAvailable?: boolean; catError?: strin
     keyUp: vi.fn().mockResolvedValue(undefined),
   };
 
-  const manager = new CWKeyerManager();
+  const manager = new CWKeyerManager(undefined, options.physicalTxCoordinator);
   (manager as unknown as { rootDir: string }).rootDir = root;
   const managerBackends = (manager as unknown as { backends: Record<string, CWKeyerBackend> }).backends;
   managerBackends.cat = backend;
@@ -235,6 +240,59 @@ describe('CWKeyerManager', () => {
       currentMethod: 'rts',
       currentActiveLevel: 'high',
     });
+  });
+
+  it('treats repeated manual key-down from the same client as idempotent', async () => {
+    const { manager, serialBackend } = await createManager({
+      catAvailable: false,
+      keyPort: '/dev/cw',
+    });
+    await manager.start({
+      backend: 'serial',
+      keyPort: '/dev/cw',
+      keyMethod: 'rts',
+      keyActiveLevel: 'high',
+      wpm: 20,
+    });
+
+    await manager.handleKeyAction('client-1', 'Operator', 'key-down');
+    await manager.handleKeyAction('client-1', 'Operator', 'key-down');
+    await manager.handleKeyAction('client-1', 'Operator', 'key-up');
+
+    expect(serialBackend.keyDown).toHaveBeenCalledTimes(1);
+    expect(serialBackend.keyUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the physical lease when manual key-up fails', async () => {
+    const physicalTxCoordinator = {
+      acquireLease: vi.fn().mockResolvedValue('cw-lease'),
+      markSelfKeyedLeaseActive: vi.fn(),
+      releaseLease: vi.fn(),
+      forceInterruptLease: vi.fn().mockResolvedValue(null),
+    };
+    const { manager, serialBackend } = await createManager({
+      catAvailable: false,
+      keyPort: '/dev/cw',
+      physicalTxCoordinator,
+    });
+    await manager.start({
+      backend: 'serial',
+      keyPort: '/dev/cw',
+      keyMethod: 'rts',
+      keyActiveLevel: 'high',
+      wpm: 20,
+    });
+    await manager.handleKeyAction('client-1', 'Operator', 'key-down');
+    vi.mocked(serialBackend.keyUp!).mockRejectedValueOnce(new Error('serial key-up failed'));
+
+    await expect(manager.handleKeyAction('client-1', 'Operator', 'key-up'))
+      .rejects.toThrow('serial key-up failed');
+
+    expect(physicalTxCoordinator.forceInterruptLease).toHaveBeenCalledWith(
+      'cw-lease',
+      'CW manual key release failed',
+    );
+    expect(physicalTxCoordinator.releaseLease).not.toHaveBeenCalled();
   });
 
   it('rejects hardware tests while CW keying is already active', async () => {

--- a/packages/server/src/decode/WSJTXEncodeWorkQueue.ts
+++ b/packages/server/src/decode/WSJTXEncodeWorkQueue.ts
@@ -19,6 +19,9 @@ export interface EncodeRequest {
   timeSinceSlotStartMs?: number; // 从时隙开始到现在经过的时间（毫秒）
   requestId?: string; // 编码请求唯一ID（用于去重和追踪）
   txDialShiftHz?: number; // 虚拟频率：本时隙冻结的 dial 平移量（Hz），随音频负载流转到 PTT 时点
+  frameId?: string;
+  frameRevision?: number;
+  decisionEpoch?: number;
 }
 
 export interface EncodeResult {

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -36,8 +36,15 @@ import { createLogger } from '../utils/logger.js';
 import { normalizeCallsign } from '../utils/callsign.js';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
+import { DigitalFrameCoordinator } from '../transmission/DigitalFrameCoordinator.js';
+import { OperatorIntentCoordinator } from '../transmission/OperatorIntentCoordinator.js';
+import { TargetReservationCoordinator } from '../transmission/TargetReservationCoordinator.js';
 
 const logger = createLogger('RadioOperatorManager');
+
+type QueuedTransmitRequest = TransmitRequest & {
+  waitForTransmitCycle?: boolean;
+};
 
 const DEFAULT_MAX_SAME_TRANSMISSION_COUNT = 20;
 const SAME_TRANSMISSION_GUARD_RESET_REASON = 'same transmission guard limit';
@@ -81,6 +88,9 @@ export interface UnsavedQsoAttempt {
   operatorId: string;
   logBookId: string;
   qsoRecord: QSORecord;
+  qsoLifecycleId?: string;
+  qsoLifecycleEpoch?: number;
+  qsoRuntimeGeneration?: number;
   createdAt: number;
 }
 
@@ -99,6 +109,9 @@ export interface RadioOperatorManagerOptions {
   // 虚拟频率是否生效（已计入与 rig split 的互斥）；编码时据此决定是否平移音频载波
   getFakeFrequencyEnabled?: () => boolean;
   callsignTracker?: CallsignContextTracker;
+  digitalFrameCoordinator?: DigitalFrameCoordinator;
+  getTransmitCompensationMs?: () => number;
+  intentCoordinator?: OperatorIntentCoordinator;
 }
 
 /**
@@ -106,7 +119,7 @@ export interface RadioOperatorManagerOptions {
  */
 export class RadioOperatorManager {
   private operators: Map<string, RadioOperator> = new Map();
-  private pendingTransmissions: TransmitRequest[] = [];
+  private pendingTransmissions: QueuedTransmitRequest[] = [];
   private eventEmitter: EventEmitter<DigitalRadioEngineEvents>;
   private encodeQueue: WSJTXEncodeWorkQueue;
   private clockSource: ClockSourceSystem;
@@ -120,6 +133,9 @@ export class RadioOperatorManager {
   private getKnownRadioFrequency?: () => number | null;
   private getFakeFrequencyEnabled?: () => boolean;
   private callsignTracker?: CallsignContextTracker;
+  private readonly digitalFrameCoordinator: DigitalFrameCoordinator;
+  private readonly getTransmitCompensationMs: () => number;
+  private readonly intentCoordinator: OperatorIntentCoordinator;
 
   // 虚拟频率：当前时隙冻结的 dial 平移量（Hz）。按 slotStartMs 冻结，
   // 保证同一时隙内中途加入的操作员复用同一 shift，与已编码音频匹配。
@@ -165,9 +181,6 @@ export class RadioOperatorManager {
     return baseFreq > 1_000_000 ? getBandFromFrequency(baseFreq) : 'Unknown';
   }
 
-  // 每个操作员的最新编码请求ID，用于丢弃过期编码结果
-  private latestEncodeRequestIds: Map<string, string> = new Map();
-
   // 📊 Day13优化：记录上次发射的操作员状态哈希，用于去重
   private lastEmittedStatusHash: Map<string, string> = new Map();
 
@@ -177,9 +190,15 @@ export class RadioOperatorManager {
   // 每操作员连续相同发射文本计数，用于防止插件/策略卡住后无限重复发射。
   private sameTransmissionGuardStates: Map<string, SameTransmissionGuardState> = new Map();
   private readonly unsavedQsoAttempts = new Map<string, UnsavedQsoAttempt>();
-  private readonly qsoPersistenceInFlight = new Set<string>();
+  private readonly qsoPersistenceInFlight = new Map<string, string>();
   private readonly unsavedQsoRetryFlights = new Map<string, Promise<QSORecord>>();
   private readonly preparedQsoCandidates = new Map<string, QSORecord>();
+  private readonly activeQsoLifecycles = new Map<string, {
+    epoch: number;
+    runtimeGeneration?: number;
+  }>();
+  private readonly targetReservations = new TargetReservationCoordinator();
+  private transmissionMaintenanceReason: string | null = null;
 
   constructor(options: RadioOperatorManagerOptions) {
     this.eventEmitter = options.eventEmitter;
@@ -197,10 +216,23 @@ export class RadioOperatorManager {
     this.getKnownRadioFrequency = options.getKnownRadioFrequency;
     this.getFakeFrequencyEnabled = options.getFakeFrequencyEnabled;
     this.callsignTracker = options.callsignTracker;
+    this.digitalFrameCoordinator = options.digitalFrameCoordinator ?? new DigitalFrameCoordinator();
+    this.intentCoordinator = options.intentCoordinator ?? new OperatorIntentCoordinator();
+    this.getTransmitCompensationMs = options.getTransmitCompensationMs ?? (() => 0);
 
     // 监听发射请求
     const handleRequestTransmit = (request: TransmitRequest) => {
-      this.pendingTransmissions.push(request);
+      if (this.transmissionMaintenanceReason) {
+        logger.debug('Discarded transmit request during maintenance', {
+          operatorId: request.operatorId,
+          reason: this.transmissionMaintenanceReason,
+        });
+        return;
+      }
+      this.pendingTransmissions.push({
+        ...request,
+        decisionEpoch: request.decisionEpoch ?? this.intentCoordinator.getCurrentEpoch(request.operatorId),
+      });
     };
     this.eventEmitter.on('requestTransmit', handleRequestTransmit);
     this.eventListeners.set('requestTransmit', handleRequestTransmit);
@@ -208,19 +240,26 @@ export class RadioOperatorManager {
     // 监听记录QSO事件
     const handleRecordQSO = async (data: {
       operatorId: string;
+      qsoLifecycleId?: string;
+      qsoLifecycleEpoch?: number;
+      qsoRuntimeGeneration?: number;
       qsoRecord: QSORecord;
       retryAttemptId?: string;
       resolve?: (record: QSORecord) => void;
       reject?: (error: unknown) => void;
     }) => {
-      if (this.qsoPersistenceInFlight.has(data.operatorId)) {
+      const persistenceKey = data.qsoLifecycleId ?? `${data.operatorId}:legacy:${data.qsoRecord.id}`;
+      const activePersistence = this.qsoPersistenceInFlight.get(data.operatorId);
+      if (activePersistence) {
         data.reject?.(new LogbookOperationError(
           'LOGBOOK_MAINTENANCE',
-          'A QSO persistence operation is already in progress for this operator',
+          activePersistence === persistenceKey
+            ? 'This QSO persistence lifecycle is already in progress'
+            : 'A QSO persistence operation is already in progress for this operator',
         ));
         return;
       }
-      this.qsoPersistenceInFlight.add(data.operatorId);
+      this.qsoPersistenceInFlight.set(data.operatorId, persistenceKey);
       try {
         logger.debug(`Recording QSO: ${data.qsoRecord.callsign} (operator: ${data.operatorId})`);
 
@@ -230,7 +269,13 @@ export class RadioOperatorManager {
             'LOGBOOK_MAINTENANCE',
             'Resolve the existing unsaved QSO before recording another contact',
           );
-          this.pauseOperatorAfterLogbookFailure(data.operatorId);
+          if (this.isCurrentQsoLifecycle(
+            data.operatorId,
+            data.qsoLifecycleEpoch,
+            data.qsoRuntimeGeneration,
+          )) {
+            this.pauseOperatorAfterLogbookFailure(data.operatorId);
+          }
           data.reject?.(error);
           return;
         }
@@ -254,7 +299,14 @@ export class RadioOperatorManager {
           this.eventEmitter.emit('logbookWriteFailed' as any, {
             logBookId: callsign ? `logbook-${normalizeCallsign(callsign)}` : `operator-${data.operatorId}`,
             operatorId: data.operatorId,
-            attemptId: this.rememberUnsavedQso(data.operatorId, callsign ? `logbook-${normalizeCallsign(callsign)}` : `operator-${data.operatorId}`, data.qsoRecord),
+            attemptId: this.rememberUnsavedQso(
+              data.operatorId,
+              callsign ? `logbook-${normalizeCallsign(callsign)}` : `operator-${data.operatorId}`,
+              data.qsoRecord,
+              data.qsoLifecycleId,
+              data.qsoLifecycleEpoch,
+              data.qsoRuntimeGeneration,
+            ),
             unsavedCount: 1,
             error: {
               code: 'LOGBOOK_UNAVAILABLE',
@@ -264,7 +316,13 @@ export class RadioOperatorManager {
           });
           const error = new LogbookOperationError('LOGBOOK_UNAVAILABLE', message);
           data.reject?.(error);
-          this.pauseOperatorAfterLogbookFailure(data.operatorId);
+          if (this.isCurrentQsoLifecycle(
+            data.operatorId,
+            data.qsoLifecycleEpoch,
+            data.qsoRuntimeGeneration,
+          )) {
+            this.pauseOperatorAfterLogbookFailure(data.operatorId);
+          }
           return;
         }
         
@@ -307,7 +365,7 @@ export class RadioOperatorManager {
         const completedQSO = await this.completeAutomaticQSORecord(data.operatorId, normalizedQSO);
         // Retain the exact first candidate so an explicit retry cannot silently
         // rebuild a different history, report, or frequency later.
-        this.preparedQsoCandidates.set(data.operatorId, completedQSO);
+        this.preparedQsoCandidates.set(persistenceKey, completedQSO);
         const mergeCandidate = await this.findMergeCandidate(logBook.provider, completedQSO);
 
         let persistedQSO: QSORecord;
@@ -331,10 +389,18 @@ export class RadioOperatorManager {
           throw new Error('Logbook provider completed without returning the durably committed QSO');
         }
 
-        this.clearUnsavedQsoForOperator(data.operatorId);
-        this.preparedQsoCandidates.delete(data.operatorId);
-        this.operators.get(data.operatorId)?.clearLogbookFailureBlock();
-        this.qsoPersistenceInFlight.delete(data.operatorId);
+        this.clearUnsavedQsoForLifecycle(data.operatorId, data.qsoLifecycleId);
+        this.preparedQsoCandidates.delete(persistenceKey);
+        if (this.isCurrentQsoLifecycle(
+          data.operatorId,
+          data.qsoLifecycleEpoch,
+          data.qsoRuntimeGeneration,
+        )) {
+          this.operators.get(data.operatorId)?.clearLogbookFailureBlock();
+        }
+        if (this.qsoPersistenceInFlight.get(data.operatorId) === persistenceKey) {
+          this.qsoPersistenceInFlight.delete(data.operatorId);
+        }
         data.resolve?.(persistedQSO);
 
         // Everything below is a post-commit side effect. A listener, sync plugin,
@@ -385,10 +451,19 @@ export class RadioOperatorManager {
         const attemptId = this.rememberUnsavedQso(
           data.operatorId,
           this.logManager.getOperatorLogBookId(data.operatorId) ?? `operator-${data.operatorId}`,
-          this.preparedQsoCandidates.get(data.operatorId) ?? data.qsoRecord,
+          this.preparedQsoCandidates.get(persistenceKey) ?? data.qsoRecord,
+          data.qsoLifecycleId,
+          data.qsoLifecycleEpoch,
+          data.qsoRuntimeGeneration,
         );
-        this.preparedQsoCandidates.delete(data.operatorId);
-        this.pauseOperatorAfterLogbookFailure(data.operatorId);
+        this.preparedQsoCandidates.delete(persistenceKey);
+        if (this.isCurrentQsoLifecycle(
+          data.operatorId,
+          data.qsoLifecycleEpoch,
+          data.qsoRuntimeGeneration,
+        )) {
+          this.pauseOperatorAfterLogbookFailure(data.operatorId);
+        }
         const operationError = error instanceof LogbookOperationError ? error : undefined;
         this.eventEmitter.emit('logbookWriteFailed' as any, {
           logBookId: this.logManager.getOperatorLogBookId(data.operatorId) ?? `operator-${data.operatorId}`,
@@ -404,11 +479,26 @@ export class RadioOperatorManager {
         });
         data.reject?.(error);
       } finally {
-        this.qsoPersistenceInFlight.delete(data.operatorId);
+        if (this.qsoPersistenceInFlight.get(data.operatorId) === persistenceKey) {
+          this.qsoPersistenceInFlight.delete(data.operatorId);
+        }
       }
     };
     this.eventEmitter.on('recordQSO', handleRecordQSO);
     this.eventListeners.set('recordQSO', handleRecordQSO);
+
+    const handleQsoLifecycleChanged = (data: {
+      operatorId: string;
+      lifecycleEpoch: number;
+      runtimeGeneration?: number;
+    }) => {
+      this.activeQsoLifecycles.set(data.operatorId, {
+        epoch: data.lifecycleEpoch,
+        runtimeGeneration: data.runtimeGeneration,
+      });
+    };
+    this.eventEmitter.on('qsoLifecycleChanged', handleQsoLifecycleChanged);
+    this.eventListeners.set('qsoLifecycleChanged', handleQsoLifecycleChanged);
 
     // 监听检查是否已通联事件
     const handleCheckHasWorkedCallsign = async (data: { operatorId: string; callsign: string; requestId: string }) => {
@@ -451,11 +541,21 @@ export class RadioOperatorManager {
     this.eventListeners.set('checkHasWorkedCallsign', handleCheckHasWorkedCallsign);
 
     // 监听操作员发射周期变更事件
-    const handleOperatorTransmitCyclesChanged = (data: { operatorId: string; transmitCycles: number[] }) => {
+    const handleOperatorTransmitCyclesChanged = (data: {
+      operatorId: string;
+      transmitCycles: number[];
+      commandEpoch?: number;
+      source?: 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+      reason?: string;
+    }) => {
       logger.debug(`Operator ${data.operatorId} transmit cycles changed: [${data.transmitCycles.join(', ')}]`);
       this._pluginManager?.invalidateDecisionMessageSet(data.operatorId);
-      // 立即检查并触发发射
-      this.checkAndTriggerTransmission(data.operatorId);
+      this.requestOperatorFrameMutation(data.operatorId, {
+        kind: 'transmit-cycles',
+        source: data.source,
+        commandEpoch: data.commandEpoch,
+        reason: data.reason ?? 'operator transmit cycles changed',
+      });
       this.emitOperatorStatusUpdate(data.operatorId);
     };
     this.eventEmitter.on('operatorTransmitCyclesChanged', handleOperatorTransmitCyclesChanged);
@@ -486,19 +586,22 @@ export class RadioOperatorManager {
         isTransmitting: operator?.isTransmitting ?? false,
         elapsedInSlotMs: now - slotStartMs,
       });
-      // 立即检查并触发发射
-      this.checkAndTriggerTransmission(data.operatorId);
+      this.requestOperatorFrameMutation(data.operatorId, {
+        kind: 'slot',
+        reason: 'operator transmit slot changed',
+      });
       this.emitOperatorStatusUpdate(data.operatorId);
     };
     this.eventEmitter.on('operatorSlotChanged', handleOperatorSlotChanged);
     this.eventListeners.set('operatorSlotChanged', handleOperatorSlotChanged);
 
-    // 监听操作员频率变更事件 — 仅当该操作员正在实际 PTT 发射时触发重编码
+    // 兼容仍通过事件更新频率的 host 入口；内置 Manager 路径直接调用同一 mutation 方法。
     const handleOperatorFrequencyChanged = (data: { operatorId: string; frequency: number }) => {
       logger.debug(`Operator ${data.operatorId} frequency changed: ${data.frequency}`);
-      if (this.activeTransmissionOperatorIds.has(data.operatorId)) {
-        this.checkAndTriggerTransmission(data.operatorId);
-      }
+      this.requestOperatorFrameMutation(data.operatorId, {
+        kind: 'frequency',
+        reason: 'operator audio frequency changed',
+      });
       this.emitOperatorStatusUpdate(data.operatorId);
     };
     this.eventEmitter.on('operatorFrequencyChanged', handleOperatorFrequencyChanged);
@@ -508,10 +611,13 @@ export class RadioOperatorManager {
     const handleOperatorSlotContentChanged = (data: { operatorId: string; slot: string; content: string }) => {
       logger.debug(`Operator ${data.operatorId} slot content edited: slot=${data.slot}`);
       // 立即检查并触发发射（如果当前正在该槽位发射）
-      const currentSlot = this._pluginManager?.getOperatorRuntimeStatus(data.operatorId).currentSlot;
+      const currentSlot = this._pluginManager?.getOperatorRuntimeStatus(data.operatorId)?.currentSlot;
       if (currentSlot === data.slot) {
         logger.debug(`Currently transmitting on slot ${data.slot}, updating content immediately`);
-        this.checkAndTriggerTransmission(data.operatorId);
+        this.requestOperatorFrameMutation(data.operatorId, {
+          kind: 'slot-content',
+          reason: 'current transmit slot content changed',
+        });
       }
       this.emitOperatorStatusUpdate(data.operatorId);
     };
@@ -637,6 +743,7 @@ export class RadioOperatorManager {
     this.logManager.disconnectOperatorFromLogBook(operatorId);
     
     this.operators.delete(operatorId);
+    this.targetReservations.releaseOperator(operatorId);
     this.clearSameTransmissionGuard(operatorId);
     this._pluginManager?.removeInstancesForOperator(operatorId);
     logger.info(`Operator removed: ${operatorId}`);
@@ -701,6 +808,18 @@ export class RadioOperatorManager {
   /** getOperatorById — alias for getOperator (used by PluginManager) */
   getOperatorById(id: string): RadioOperator | undefined {
     return this.operators.get(id);
+  }
+
+  getTransmissionFactContext(operatorId: string): {
+    frequency: number;
+    frequencyContext?: import('@tx5dr/contracts').SlotPackFrequencyContext;
+  } | null {
+    const operator = this.operators.get(operatorId);
+    if (!operator) return null;
+    return {
+      frequency: operator.config.frequency || 0,
+      frequencyContext: this.slotPackManager.getFrequencyContext(),
+    };
   }
 
   /** 设置插件管理器（引擎初始化完成后由 DigitalRadioEngine 调用） */
@@ -799,12 +918,22 @@ export class RadioOperatorManager {
   /**
    * 更新操作员上下文
    */
-  async updateOperatorContext(operatorId: string, context: any): Promise<void> {
+  async updateOperatorContext(
+    operatorId: string,
+    context: any,
+    mutation?: {
+      commandEpoch?: number;
+      source?: 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+      reason?: string;
+    },
+  ): Promise<void> {
     const operator = this.operators.get(operatorId);
     if (!operator) {
       throw new Error(`operator ${operatorId} not found`);
     }
     const normalizedContext = normalizeOperatorContext(context);
+    const transmissionBefore = this._pluginManager?.getCurrentTransmission(operatorId) ?? null;
+    let frequencyChanged = false;
 
     // 构建更新对象（只包含实际变化的字段）
     const updates: Partial<RadioOperatorConfig> = {};
@@ -823,23 +952,36 @@ export class RadioOperatorManager {
       if (clampedFreq !== operator.config.frequency) {
         operator.config.frequency = clampedFreq;
         updates.frequency = clampedFreq;
-        // 如果该操作员正在实际 PTT 发射，触发重编码和重混音
-        if (this.activeTransmissionOperatorIds.has(operatorId)) {
-          if (this.isFakeFrequencyCommittedForCurrentSlot()) {
-            // 虚拟频率已为本时隙提交 dial 平移：物理上 tone 期间不可移动 dial，
-            // 频率变更顺延到下一时隙（届时由 dial 吸收、音频回甜区）。仅更新 config，不重编码。
-            logger.debug('Deferring mid-slot frequency change to next slot (fake frequency committed)', {
-              operatorId,
-              clampedFreq,
-            });
-          } else {
-            this.checkAndTriggerTransmission(operatorId);
-          }
-        }
+        frequencyChanged = true;
       }
     }
 
-    // 如果有任何字段发生了变化，保存到配置文件
+    const runtimePatch: Record<string, unknown> = {};
+    if (normalizedContext.targetCallsign !== undefined) runtimePatch.targetCallsign = normalizedContext.targetCallsign;
+    if (normalizedContext.targetGrid !== undefined) runtimePatch.targetGrid = normalizedContext.targetGrid;
+    if (normalizedContext.reportSent !== undefined) runtimePatch.reportSent = normalizedContext.reportSent;
+    if (normalizedContext.reportReceived !== undefined) runtimePatch.reportReceived = normalizedContext.reportReceived;
+    if (Object.keys(runtimePatch).length > 0) {
+      this._pluginManager?.patchOperatorRuntimeContext(operatorId, runtimePatch as any);
+    }
+
+    const transmissionAfter = this._pluginManager?.getCurrentTransmission(operatorId) ?? null;
+    const transmissionChanged = this.canonicalizeTransmissionMessage(transmissionBefore ?? '')
+      !== this.canonicalizeTransmissionMessage(transmissionAfter ?? '');
+    if (frequencyChanged || transmissionChanged) {
+      this.requestOperatorFrameMutation(operatorId, {
+        kind: frequencyChanged ? 'frequency' : 'context',
+        reason: mutation?.reason ?? (frequencyChanged
+          ? 'operator audio frequency changed'
+          : 'operator context changed current transmit text'),
+        commandEpoch: mutation?.commandEpoch,
+        source: mutation?.source,
+      });
+    }
+
+    // Frame mutation is latency-sensitive and follows the in-memory desired
+    // state. Configuration durability remains awaited by the API caller, but
+    // cannot delay an in-slot replacement behind filesystem I/O.
     if (Object.keys(updates).length > 0) {
       const configManager = ConfigManager.getInstance();
       await configManager.updateOperatorConfig(operatorId, updates);
@@ -852,15 +994,6 @@ export class RadioOperatorManager {
         );
       }
       logger.debug(`Saved operator ${operatorId} config to file:`, updates);
-    }
-
-    const runtimePatch: Record<string, unknown> = {};
-    if (normalizedContext.targetCallsign !== undefined) runtimePatch.targetCallsign = normalizedContext.targetCallsign;
-    if (normalizedContext.targetGrid !== undefined) runtimePatch.targetGrid = normalizedContext.targetGrid;
-    if (normalizedContext.reportSent !== undefined) runtimePatch.reportSent = normalizedContext.reportSent;
-    if (normalizedContext.reportReceived !== undefined) runtimePatch.reportReceived = normalizedContext.reportReceived;
-    if (Object.keys(runtimePatch).length > 0) {
-      this._pluginManager?.patchOperatorRuntimeContext(operatorId, runtimePatch as any);
     }
 
     logger.debug(`Updated operator ${operatorId} context:`, normalizedContext);
@@ -1004,12 +1137,23 @@ export class RadioOperatorManager {
     const retry = operator.recordQSOLog({
         ...attempt.qsoRecord,
         messageHistory: [...attempt.qsoRecord.messageHistory],
-      }, { retryAttemptId: attempt.attemptId })
+      }, {
+        retryAttemptId: attempt.attemptId,
+        qsoLifecycleId: attempt.qsoLifecycleId,
+        qsoLifecycleEpoch: attempt.qsoLifecycleEpoch,
+        qsoRuntimeGeneration: attempt.qsoRuntimeGeneration,
+      })
       .then((persisted) => {
-        this._pluginManager?.resetOperatorPluginRuntime(
+        if (this.isCurrentQsoLifecycle(
           attempt.operatorId,
-          'unsaved QSO durably persisted by explicit retry',
-        );
+          attempt.qsoLifecycleEpoch,
+          attempt.qsoRuntimeGeneration,
+        )) {
+          this._pluginManager?.resetOperatorPluginRuntime(
+            attempt.operatorId,
+            'unsaved QSO durably persisted by explicit retry',
+          );
+        }
         return persisted;
       })
       .finally(() => {
@@ -1055,7 +1199,14 @@ export class RadioOperatorManager {
     return attempt;
   }
 
-  private rememberUnsavedQso(operatorId: string, logBookId: string, record: QSORecord): string {
+  private rememberUnsavedQso(
+    operatorId: string,
+    logBookId: string,
+    record: QSORecord,
+    qsoLifecycleId?: string,
+    qsoLifecycleEpoch?: number,
+    qsoRuntimeGeneration?: number,
+  ): string {
     const existing = this.getUnsavedQsoForOperator(operatorId);
     if (existing) return existing.attemptId;
     const attemptId = randomUUID();
@@ -1064,6 +1215,9 @@ export class RadioOperatorManager {
       operatorId,
       logBookId,
       qsoRecord: { ...record, messageHistory: [...record.messageHistory] },
+      qsoLifecycleId,
+      qsoLifecycleEpoch,
+      qsoRuntimeGeneration,
       createdAt: Date.now(),
     });
     return attemptId;
@@ -1073,10 +1227,27 @@ export class RadioOperatorManager {
     return [...this.unsavedQsoAttempts.values()].find(attempt => attempt.operatorId === operatorId);
   }
 
-  private clearUnsavedQsoForOperator(operatorId: string): void {
+  private clearUnsavedQsoForLifecycle(operatorId: string, qsoLifecycleId?: string): void {
     for (const [attemptId, attempt] of this.unsavedQsoAttempts) {
-      if (attempt.operatorId === operatorId) this.unsavedQsoAttempts.delete(attemptId);
+      if (attempt.operatorId === operatorId
+          && (qsoLifecycleId === undefined || attempt.qsoLifecycleId === qsoLifecycleId)) {
+        this.unsavedQsoAttempts.delete(attemptId);
+      }
     }
+  }
+
+  private isCurrentQsoLifecycle(
+    operatorId: string,
+    lifecycleEpoch?: number,
+    runtimeGeneration?: number,
+  ): boolean {
+    if (lifecycleEpoch === undefined) return true;
+    const active = this.activeQsoLifecycles.get(operatorId);
+    if (!active) return true;
+    if (active.epoch !== lifecycleEpoch) return false;
+    return runtimeGeneration === undefined
+      || active.runtimeGeneration === undefined
+      || active.runtimeGeneration === runtimeGeneration;
   }
 
   private pauseOperatorAfterLogbookFailure(operatorId: string): void {
@@ -1084,6 +1255,7 @@ export class RadioOperatorManager {
     if (!operator) return;
     this.clearSameTransmissionGuard(operatorId);
     operator.blockForLogbookFailure();
+    const frameStop = this.requestStrategyStop(operatorId, 'logbook durability failure');
     const resetPluginRuntime = this._pluginManager?.resetOperatorPluginRuntime?.bind(this._pluginManager);
     if (resetPluginRuntime) {
       try {
@@ -1095,18 +1267,8 @@ export class RadioOperatorManager {
     } else {
       this.resetPluginRuntime(operatorId, 'logbook durability failure');
     }
-    try {
-      const interruption = this._pluginManager?.interruptOperatorTransmission?.(operatorId);
-      if (interruption) {
-        void interruption.catch((error) => {
-          logger.warn(`Failed to interrupt active transmission for ${operatorId} after a logbook failure`, error);
-        });
-      }
-    } catch (error) {
-      logger.warn(`Failed to interrupt active transmission for ${operatorId} after a logbook failure`, error);
-    }
     this.emitOperatorStatusUpdate(operatorId);
-    logger.error(`Paused operator ${operatorId} after a logbook durability failure`);
+    logger.error(`Paused operator ${operatorId} after a logbook durability failure`, { frameStop });
   }
 
   private canonicalizeTransmissionMessage(message: string): string {
@@ -1222,128 +1384,157 @@ export class RadioOperatorManager {
    * @param slotInfo 时隙信息(包含准确的时间戳)
    */
   processPendingTransmissions(slotInfo: any): void {
-    if (!this.isRunning) {
-      logger.debug('Manager not running, skipping transmission queue processing');
+    if (this.transmissionMaintenanceReason) {
+      this.pendingTransmissions = [];
       return;
     }
-
-    if (this.pendingTransmissions.length === 0) {
-      logger.debug('Transmission queue is empty, no pending requests');
-      return;
-    }
-
-    logger.debug(`Processing transmission queue: ${this.pendingTransmissions.length} pending request(s)`);
+    if (!this.isRunning || this.pendingTransmissions.length === 0) return;
 
     const currentMode = this.getCurrentMode();
-    const slotStartMs = slotInfo.startMs; // 使用 slotInfo 中的准确时间戳
+    const slotStartMs = slotInfo.startMs;
     const now = this.clockSource.now();
     const timeSinceSlotStartMs = now - slotStartMs;
-
-    // 处理队列中的所有请求
     const requests = [...this.pendingTransmissions];
-    this.pendingTransmissions = []; // 清空队列
+    this.pendingTransmissions = [];
 
-    // 去重：相同操作员+相同消息只处理一次（防止重复发射）
-    const uniqueRequests = requests.filter((req, index, self) =>
-      index === self.findIndex(r =>
-        r.operatorId === req.operatorId && r.transmission === req.transmission
-      )
+    const slotId = `slot-${slotStartMs}`;
+    const latestByOperator = new Map<string, QueuedTransmitRequest>();
+    for (const request of requests) latestByOperator.set(request.operatorId, request);
+
+    // A physical mixed frame is atomic. A correction for one participant must
+    // re-encode every remaining participant so no track from the old revision
+    // can be relabelled as part of the replacement frame.
+    const currentFrame = this.digitalFrameCoordinator.getCurrentFrameForSlot(slotId);
+    if (currentFrame && requests.length > 0) {
+      const currentIntents = this.digitalFrameCoordinator.getIntentRequests(currentFrame.frameId);
+      for (const intent of currentIntents) {
+        if (latestByOperator.has(intent.operatorId)) continue;
+        const transmission = intent.text ?? this._pluginManager?.getCurrentTransmission(intent.operatorId);
+        if (!transmission) continue;
+        latestByOperator.set(intent.operatorId, {
+          operatorId: intent.operatorId,
+          transmission,
+          replaceExisting: true,
+          source: intent.source === 'persistence' || intent.source === 'device'
+            ? 'plugin'
+            : intent.source,
+          reason: 'complete mixed-frame rebuild',
+          decisionEpoch: intent.decisionEpoch,
+        });
+      }
+    }
+    const uniqueRequests = Array.from(latestByOperator.values()).map((request) => currentFrame
+      ? {
+          ...request,
+          replaceExisting: true,
+          reason: request.reason ?? 'complete mixed-frame rebuild',
+        }
+      : request);
+    if (uniqueRequests.length < requests.length) {
+      logger.warn(`Superseded transmit requests detected: ${requests.length} -> ${uniqueRequests.length}`);
+    }
+
+    const waitingForTransmitCycle: QueuedTransmitRequest[] = [];
+    const eligibleRequests = uniqueRequests.filter((request) => {
+      const operator = this.operators.get(request.operatorId);
+      if (!operator?.isTransmitting) return false;
+      if (request.decisionEpoch !== this.intentCoordinator.getCurrentEpoch(request.operatorId)) {
+        logger.debug('Discarded stale queued transmission intent', {
+          operatorId: request.operatorId,
+          requestEpoch: request.decisionEpoch,
+          currentEpoch: this.intentCoordinator.getCurrentEpoch(request.operatorId),
+        });
+        return false;
+      }
+      if (request.waitForTransmitCycle && !CycleUtils.isOperatorTransmitCycleFromMs(
+        operator.getTransmitCycles(),
+        slotStartMs,
+        currentMode.slotMs,
+      )) {
+        waitingForTransmitCycle.push(request);
+        return false;
+      }
+      if (!this.shouldAllowTransmission(request.operatorId, request.transmission, slotStartMs)) return false;
+      if (FT8MessageParser.rawContainsUndecodedCallsign(request.transmission)) {
+        logger.warn(`Refusing undecoded placeholder transmission: operator=${request.operatorId}`);
+        return false;
+      }
+      return true;
+    });
+    if (waitingForTransmitCycle.length > 0) {
+      this.requeueForNextSlot(waitingForTransmitCycle, 'waiting for operator transmit cycle');
+    }
+    if (eligibleRequests.length === 0) return;
+
+    const playbackStartMs = slotStartMs + Math.max(
+      0,
+      (currentMode.transmitTiming || 0) - this.getTransmitCompensationMs(),
     );
 
-    if (uniqueRequests.length < requests.length) {
-      logger.warn(`Duplicate transmit requests detected: ${requests.length} → ${uniqueRequests.length}`);
+    const prepared = this.digitalFrameCoordinator.prepareFrame({
+      slotId,
+      intents: eligibleRequests.map((request) => ({
+        operatorId: request.operatorId,
+        source: request.source ?? (request.replaceExisting ? 'late-decode' : 'plugin'),
+        reason: request.reason ?? (request.replaceExisting ? 'replace existing frame' : 'slot transmission'),
+        text: request.transmission,
+        decisionEpoch: request.decisionEpoch
+          ?? this.intentCoordinator.getCurrentEpoch(request.operatorId),
+      })),
+      nowMs: now,
+      slotEndMs: slotStartMs + currentMode.slotMs,
+      expectedDurationMs: currentMode.name === 'FT4' ? 6_000 : 12_640,
+      playbackStartMs,
+    });
+    if (!prepared.frame || prepared.action === 'defer-next-slot') {
+      logger.info('Transmission correction deferred to next slot', {
+        slotId,
+        reason: prepared.reason,
+        operatorIds: eligibleRequests.map((request) => request.operatorId),
+      });
+      this.requeueForNextSlot(eligibleRequests, prepared.reason ?? 'complete frame does not fit current slot');
+      return;
     }
+    this.digitalFrameCoordinator.beginEncoding(prepared.frame.frameId);
 
-    // 虚拟频率：计算/复用本时隙统一的 dial 平移量（按 slotStartMs 冻结）
-    const fakeFrequencyEnabled = this.getFakeFrequencyEnabled?.() ?? false;
-    const slotShiftHz = this.resolveSlotTxDialShift(slotStartMs, uniqueRequests, fakeFrequencyEnabled);
-    if (slotShiftHz !== 0) {
-      logger.debug('Fake frequency active for slot', { slotStartMs, slotShiftHz });
-    }
+    const slotShiftHz = this.resolveSlotTxDialShift(
+      slotStartMs,
+      eligibleRequests,
+      this.getFakeFrequencyEnabled?.() ?? false,
+    );
 
-    for (const request of uniqueRequests) {
+    for (const request of eligibleRequests) {
       const operatorId = request.operatorId;
       const transmission = request.transmission;
-
-      // 获取操作员的频率
-      const operator = this.operators.get(operatorId);
-      if (!operator) {
-        logger.warn(`Operator ${operatorId} not found, skipping transmit request`);
-        continue;
-      }
-      if (!operator.isTransmitting) {
-        logger.debug(`Operator ${operatorId} is not transmitting, skipping transmit request`);
-        continue;
-      }
-
-      if (!this.shouldAllowTransmission(operatorId, transmission, slotStartMs)) {
-        continue;
-      }
-
-      // 发射兜底：含未解码占位符（`<...>`/`...`）的文本绝不编码上射频
-      if (FT8MessageParser.rawContainsUndecodedCallsign(transmission)) {
-        logger.warn(`Refusing to transmit message containing undecoded placeholder: operator=${operatorId} text="${transmission}"`);
-        continue;
-      }
-
+      const operator = this.operators.get(operatorId)!;
       const frequency = operator.config.frequency || 0;
-
-      // 广播发射日志
-      this.eventEmitter.emit('transmissionLog' as any, {
-        operatorId,
-        time: new Date(slotStartMs).toISOString().slice(11, 19).replace(/:/g, ''),
-        message: transmission,
-        frequency: frequency,
-        slotStartMs: slotStartMs,
-        replaceExisting: request.replaceExisting,
-        frequencyContext: this.slotPackManager.getFrequencyContext(),
-      });
-
-      // 启动传输跟踪
+      const intent = prepared.intents.find((candidate) => candidate.operatorId === operatorId)!;
+      const requestId = `${prepared.frame.frameId}:${operatorId}:${intent.decisionEpoch}`;
       if (this.transmissionTracker) {
-        const slotId = `slot-${slotStartMs}`;
-        const targetTransmitTime = slotStartMs + (currentMode.transmitTiming || 0);
-        this.transmissionTracker.startTransmission(operatorId, slotId, targetTransmitTime);
+        this.transmissionTracker.startTransmission(operatorId, slotId, playbackStartMs);
         this.transmissionTracker.updatePhase(operatorId, 'preparing' as any);
       }
 
-      // 生成唯一的编码请求ID（用于去重和追踪）
-      const requestId = `${operatorId}-${slotStartMs}-${Date.now()}`;
-
-      // 记录该操作员的最新编码请求ID（用于丢弃过期编码结果）
-      this.latestEncodeRequestIds.set(operatorId, requestId);
-
-      // 虚拟频率：编码音频载波归到甜区（origFreq - shift）；dial 将由发射管线反向平移 +shift，
-      // 使打到空中的绝对 RF 不变。clamp >=0 仅在操作员铺得极宽时兜底（极端情况下牺牲个别 RF 精度）。
       const encodeFrequency = slotShiftHz !== 0
         ? Math.max(0, Math.round(frequency - slotShiftHz))
         : frequency;
-
-      // 多操作员物理限制：中途加入的操作员若远低于本时隙冻结的中心，frequency - shift 会 < 0
-      // 被钳位到 0，导致其空中 RF 偏移。单 VFO 无法对相距过远（铺宽 > ~1500Hz）的操作员分别居中。
-      // 初次整时隙计算因 freq∈[1,3000]、spread≤3000 → 恒 >=0，此告警只可能出现在极端中途加入。
       if (slotShiftHz !== 0 && Math.round(frequency - slotShiftHz) < 0) {
-        logger.warn('Fake frequency clamp: operator audio below 0Hz under frozen slot shift, on-air RF will be offset', {
-          operatorId,
-          frequency,
-          slotShiftHz,
-        });
+        logger.warn('Fake frequency clamp under frozen slot shift', { operatorId, frequency, slotShiftHz });
       }
 
-      // 提交到编码队列
-      this.encodeQueue.push({
+      void this.encodeQueue.push({
         operatorId,
         message: transmission,
         frequency: encodeFrequency,
         mode: currentMode.name === 'FT4' ? 'FT4' : 'FT8',
-        slotStartMs: slotStartMs,
-        timeSinceSlotStartMs: timeSinceSlotStartMs,
+        slotStartMs,
+        timeSinceSlotStartMs,
         requestId,
-        txDialShiftHz: slotShiftHz
+        txDialShiftHz: slotShiftHz,
+        frameId: prepared.frame.frameId,
+        frameRevision: prepared.frame.revision,
+        decisionEpoch: intent.decisionEpoch,
       });
-      this._pluginManager?.notifyTransmissionQueued?.(operatorId, transmission);
-
-      logger.debug(`Processed transmit request for operator ${operatorId}: "${transmission}", requestId=${requestId}`);
     }
   }
 
@@ -1399,10 +1590,97 @@ export class RadioOperatorManager {
   }
 
   /**
+   * Reconciles one already-applied operator property change with the current
+   * candidate/physical frame. Configuration remains the source of the desired
+   * state; this method is the only bridge that mutates the frame lifecycle.
+   */
+  private requestOperatorFrameMutation(
+    operatorId: string,
+    mutation: {
+      kind: 'frequency' | 'transmit-cycles' | 'slot' | 'slot-content' | 'context';
+      reason: string;
+      source?: 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+      commandEpoch?: number;
+    },
+  ): void {
+    if (this.transmissionMaintenanceReason) return;
+
+    if (mutation.kind === 'frequency' && this.isFakeFrequencyCommittedForCurrentSlot()) {
+      logger.debug('Deferring operator frequency mutation to next slot because fake frequency is committed', {
+        operatorId,
+      });
+      return;
+    }
+
+    const decisionEpoch = mutation.commandEpoch
+      ?? this.intentCoordinator.abortOperator(operatorId, mutation.reason);
+    if (mutation.commandEpoch !== undefined
+        && mutation.commandEpoch !== this.intentCoordinator.getCurrentEpoch(operatorId)) {
+      logger.debug('Discarded stale operator frame mutation', {
+        operatorId,
+        mutation: mutation.kind,
+        commandEpoch: mutation.commandEpoch,
+        currentEpoch: this.intentCoordinator.getCurrentEpoch(operatorId),
+      });
+      return;
+    }
+
+    this.pendingTransmissions = this.pendingTransmissions.filter(
+      (request) => request.operatorId !== operatorId,
+    );
+
+    const operator = this.operators.get(operatorId);
+    const mode = this.getCurrentMode();
+    const now = this.clockSource.now();
+    const slotStartMs = Math.floor(now / mode.slotMs) * mode.slotMs;
+    const isTransmitCycle = !!operator && CycleUtils.isOperatorTransmitCycleFromMs(
+      operator.getTransmitCycles(),
+      slotStartMs,
+      mode.slotMs,
+    );
+    const transmission = operator?.isTransmitting
+      ? this._pluginManager?.getCurrentTransmission(operatorId)
+      : null;
+
+    if (!operator?.isTransmitting || !isTransmitCycle || !transmission) {
+      const outcome = this.requestStrategyStop(operatorId, mutation.reason);
+      logger.debug('Operator frame mutation removed or deferred its current contribution', {
+        operatorId,
+        mutation: mutation.kind,
+        outcome,
+        isTransmitting: operator?.isTransmitting ?? false,
+        isTransmitCycle,
+        hasTransmission: Boolean(transmission),
+      });
+      return;
+    }
+
+    const slotId = `slot-${slotStartMs}`;
+    const currentFrame = this.digitalFrameCoordinator.getCurrentFrameForSlot(slotId);
+    const source: TransmitRequest['source'] = mutation.source === 'late-decode'
+      ? 'late-decode'
+      : mutation.source === 'plugin' || mutation.source === 'slot-auto'
+        ? 'plugin'
+        : 'operator-edit';
+    this.checkAndTriggerTransmission(operatorId, {
+      replaceExisting: Boolean(currentFrame),
+      source,
+      reason: mutation.reason,
+      decisionEpoch,
+    });
+  }
+
+  /**
    * 检查并触发单个操作员的发射
    * 用于在时隙中间启动或切换发射周期时立即触发
    */
-  private checkAndTriggerTransmission(operatorId: string, options?: { replaceExisting?: boolean }): void {
+  private checkAndTriggerTransmission(operatorId: string, options?: {
+    replaceExisting?: boolean;
+    source?: TransmitRequest['source'];
+    reason?: string;
+    decisionEpoch?: number;
+  }): void {
+    if (this.transmissionMaintenanceReason) return;
     const operator = this.operators.get(operatorId);
     if (!operator || !operator.isTransmitting) {
       return;
@@ -1435,10 +1713,22 @@ export class RadioOperatorManager {
     logger.debug(`Mid-slot transmission triggered: operator=${operatorId}, elapsed=${timeSinceSlotStartMs}ms`);
 
     // 将发射请求加入队列（仅入队，交由统一的队列消费层处理）
+    const currentFrame = this.digitalFrameCoordinator.getCurrentFrameForSlot(`slot-${currentSlotStartMs}`);
     const request: TransmitRequest = {
       operatorId,
       transmission,
-      replaceExisting: options?.replaceExisting,
+      // Any new intent inside an already prepared/physical frame must rebuild
+      // the complete mixed frame. Otherwise a double-click or a mid-slot TX
+      // toggle would silently drop the other participants from the waveform.
+      replaceExisting: options?.replaceExisting ?? !!currentFrame,
+      source: options?.source
+        ?? (options?.replaceExisting ? 'late-decode' : (currentFrame ? 'operator-edit' : undefined)),
+      reason: options?.reason
+        ?? (options?.replaceExisting
+          ? 'replace existing frame'
+          : (currentFrame ? 'complete mixed-frame rebuild after operator edit' : undefined)),
+      decisionEpoch: options?.decisionEpoch
+        ?? this.intentCoordinator.getCurrentEpoch(operatorId),
     };
     this.pendingTransmissions.push(request);
 
@@ -1483,43 +1773,108 @@ export class RadioOperatorManager {
       return;
     }
 
-    // 立即执行重决策（不 debounce），依赖 messageSet 过滤 + latestEncodeRequestIds 防止副作用
+    // 立即执行重决策；operator command epoch 会丢弃晚到的旧决策结果。
     this.executeReDecision(slotPack);
-  }
-
-  /**
-   * 获取操作员的最新编码请求ID（用于过期编码结果检查）
-   */
-  getLatestEncodeRequestId(operatorId: string): string | undefined {
-    return this.latestEncodeRequestIds.get(operatorId);
-  }
-
-  /**
-   * 时隙边界清理：清空编码请求ID映射
-   */
-  onSlotBoundary(): void {
-    this.latestEncodeRequestIds.clear();
   }
 
   /**
    * 当 DecisionOrchestrator 检测到 slotStart/encodeStart 竞态导致的过时编码时调用。
    * 使用 replaceExisting=true 替换当前时隙中已排队的编码。
    */
-  triggerPostDecisionReEncode(operatorId: string): void {
+  triggerPostDecisionReEncode(
+    operatorId: string,
+    options?: { source?: TransmitRequest['source']; reason?: string; decisionEpoch?: number },
+  ): void {
     logger.info(`Post-decision re-encode triggered: operator=${operatorId}`);
-    this.checkAndTriggerTransmission(operatorId, { replaceExisting: true });
+    this.checkAndTriggerTransmission(operatorId, {
+      replaceExisting: true,
+      source: options?.source,
+      reason: options?.reason,
+      decisionEpoch: options?.decisionEpoch,
+    });
   }
 
   resetPluginRuntime(operatorId: string, reason: string): void {
     this.pendingTransmissions = this.pendingTransmissions.filter(
       (request) => request.operatorId !== operatorId,
     );
-    this.latestEncodeRequestIds.delete(operatorId);
-    this.activeTransmissionOperatorIds.delete(operatorId);
     this.clearSameTransmissionGuard(operatorId);
     this.lastEmittedStatusHash.delete(operatorId);
     logger.info(`Operator plugin runtime reset: operator=${operatorId}, reason=${reason}`);
     this.emitOperatorStatusUpdate(operatorId);
+  }
+
+  requestStrategyStop(operatorId: string, reason: string): 'cancelled' | 'deferred' | 'not-found' {
+    const currentFrame = this.digitalFrameCoordinator.getCurrentFrameForOperator(operatorId);
+    const remainingIntents = currentFrame
+      ? this.digitalFrameCoordinator.getIntentRequests(currentFrame.frameId)
+        .filter((intent) => intent.operatorId !== operatorId)
+      : [];
+    const outcome = this.digitalFrameCoordinator.requestStrategyStop(operatorId, reason);
+
+    if (outcome === 'cancelled' && remainingIntents.length > 0) {
+      for (const intent of remainingIntents) {
+        if (!intent.text || !this.operators.get(intent.operatorId)?.isTransmitting) continue;
+        this.pendingTransmissions.push({
+          operatorId: intent.operatorId,
+          transmission: intent.text,
+          replaceExisting: true,
+          source: intent.source === 'persistence' || intent.source === 'device'
+            ? 'plugin'
+            : intent.source,
+          reason: `mixed-frame rebuild after ${reason}`,
+          decisionEpoch: intent.decisionEpoch,
+        });
+      }
+      if (this.pendingTransmissions.length > 0) {
+        const mode = this.getCurrentMode();
+        const now = this.clockSource.now();
+        const slotStartMs = Math.floor(now / mode.slotMs) * mode.slotMs;
+        this.processPendingTransmissions({ id: `slot-${slotStartMs}`, startMs: slotStartMs });
+      }
+    }
+    return outcome;
+  }
+
+  notifyPhysicalTransmissionComplete(operatorId: string, transmission: string): void {
+    this._pluginManager?.notifyTransmissionQueued?.(operatorId, transmission);
+  }
+
+  deferPreparedFrameToNextSlot(frameId: string, reason: string): boolean {
+    const intents = this.digitalFrameCoordinator.getIntentRequests(frameId);
+    const cancelled = this.digitalFrameCoordinator.deferFrame(frameId, reason);
+    if (cancelled?.phase !== 'cancelled' || intents.length === 0) return false;
+    this.requeueForNextSlot(intents.flatMap((intent) => {
+      if (!intent.text) return [];
+      return [{
+        operatorId: intent.operatorId,
+        transmission: intent.text,
+        replaceExisting: true,
+        source: intent.source === 'persistence' || intent.source === 'device'
+          ? 'plugin' as const
+          : intent.source,
+        reason,
+        decisionEpoch: intent.decisionEpoch,
+      }];
+    }), reason);
+    return true;
+  }
+
+  private requeueForNextSlot(requests: QueuedTransmitRequest[], reason: string): void {
+    const byOperator = new Map(
+      this.pendingTransmissions.map((request) => [request.operatorId, request]),
+    );
+    for (const request of requests) {
+      if (!this.operators.get(request.operatorId)?.isTransmitting) continue;
+      if (byOperator.has(request.operatorId)) continue;
+      byOperator.set(request.operatorId, {
+        ...request,
+        replaceExisting: true,
+        reason: `deferred to next slot: ${reason}`,
+        waitForTransmitCycle: true,
+      });
+    }
+    this.pendingTransmissions = Array.from(byOperator.values());
   }
 
   /**
@@ -1558,91 +1913,6 @@ export class RadioOperatorManager {
   }
 
   /**
-   * 处理发射请求
-   * @param midSlot 是否在时隙中间调用（默认false）
-   */
-  handleTransmissions(midSlot: boolean = false): void {
-    if (!this.isRunning) {
-      logger.debug('Manager not running, skipping transmission handling');
-      return;
-    }
-
-    // 获取当前时隙信息
-    const now = this.clockSource.now();
-    const currentMode = this.getCurrentMode();
-    const currentSlotStartMs = Math.floor(now / currentMode.slotMs) * currentMode.slotMs;
-    const currentTimeSinceSlotStartMs = now - currentSlotStartMs;
-
-    logger.debug(`Handling transmissions:`, {
-      midSlot,
-      currentSlotStartMs: new Date(currentSlotStartMs).toISOString(),
-      timeSinceSlotStart: currentTimeSinceSlotStartMs
-    });
-
-    // 处理每个操作员的发射请求
-    this.operators.forEach((operator, operatorId) => {
-      if (!operator.isTransmitting) {
-        return;
-      }
-
-      const isTransmitCycle = CycleUtils.isOperatorTransmitCycleFromMs(
-        operator.getTransmitCycles(),
-        currentSlotStartMs,
-        currentMode.slotMs
-      );
-
-      if (!isTransmitCycle) {
-        logger.debug(`Operator ${operatorId} is not in a transmit cycle`);
-        return;
-      }
-
-      // 获取操作员的发射内容
-      const transmission = this._pluginManager?.getCurrentTransmission(operatorId);
-      if (!transmission) {
-        return;
-      }
-
-      if (!this.shouldAllowTransmission(operatorId, transmission, currentSlotStartMs)) {
-        return;
-      }
-
-      // 获取操作员的频率
-      const frequency = operator.config.frequency || 0;
-
-      // 注释：不在发射过程中设置频率，避免电台在PTT状态下拒绝频率变更
-      // 频率应该在发射前预先设置，而不是在发射过程中设置
-
-      // 📝 注意：这里不发射 transmissionLog 事件
-      // 原因：该方法当前未被调用（旧代码路径），且会与 processPendingTransmissions() 产生重复发射
-      // transmissionLog 事件应该只在 processPendingTransmissions() 中统一发射
-
-      // 启动传输跟踪
-      if (this.transmissionTracker) {
-        const slotId = `slot-${currentSlotStartMs}`;
-        const targetTransmitTime = currentSlotStartMs + (currentMode.transmitTiming || 0);
-        this.transmissionTracker.startTransmission(operatorId, slotId, targetTransmitTime);
-        this.transmissionTracker.updatePhase(operatorId, 'preparing' as any);
-      }
-
-      // 生成唯一的编码请求ID（用于去重和追踪）
-      const requestId = `${operatorId}-${currentSlotStartMs}-${Date.now()}`;
-
-      // 提交到编码队列
-      this.encodeQueue.push({
-        operatorId,
-        message: transmission,
-        frequency,
-        mode: currentMode.name === 'FT4' ? 'FT4' : 'FT8',
-        slotStartMs: currentSlotStartMs,
-        timeSinceSlotStartMs: currentTimeSinceSlotStartMs,
-        requestId
-      });
-
-      logger.debug(`Mid-slot transmission triggered: ${operatorId}, requestId=${requestId}`);
-    });
-  }
-
-  /**
    * 停止操作员发射
    */
   stopOperator(operatorId: string): void {
@@ -1651,6 +1921,10 @@ export class RadioOperatorManager {
       throw new Error(`operator ${operatorId} not found`);
     }
     
+    const epoch = this.intentCoordinator.abortOperator(operatorId, 'operator stopped');
+    this.pendingTransmissions = this.pendingTransmissions.filter((request) => request.operatorId !== operatorId);
+    this.releaseTargetReservation(operatorId, epoch);
+    this.requestStrategyStop(operatorId, 'operator stopped');
     this.clearSameTransmissionGuard(operatorId);
     operator.stop();
     logger.info(`Stopped transmitting for operator ${operatorId}`);
@@ -1666,6 +1940,9 @@ export class RadioOperatorManager {
     
     this.operators.forEach((operator, operatorId) => {
       if (operator.isTransmitting) {
+        const epoch = this.intentCoordinator.abortOperator(operatorId, 'all operators stopped');
+        this.releaseTargetReservation(operatorId, epoch);
+        this.requestStrategyStop(operatorId, 'all operators stopped');
         operator.stop();
         this.clearSameTransmissionGuard(operatorId);
         stoppedCount++;
@@ -1677,6 +1954,19 @@ export class RadioOperatorManager {
     if (stoppedCount > 0) {
       logger.info(`Stopped ${stoppedCount} operator(s) transmitting (radio disconnected)`);
     }
+  }
+
+  enterTransmissionMaintenance(reason: string): void {
+    this.transmissionMaintenanceReason = reason;
+    this.pendingTransmissions = [];
+    for (const operatorId of this.operators.keys()) {
+      this.intentCoordinator.abortOperator(operatorId, reason);
+    }
+    this.digitalFrameCoordinator.cancelAllPreCommitFrames(reason);
+  }
+
+  exitTransmissionMaintenance(): void {
+    this.transmissionMaintenanceReason = null;
   }
 
   /**
@@ -1791,6 +2081,7 @@ export class RadioOperatorManager {
     for (const [id, operator] of this.operators.entries()) {
       operator.stop();
       this.operators.delete(id);
+      this.targetReservations.releaseOperator(id);
       this.clearSameTransmissionGuard(id);
       logger.info(`Operator removed: ${id}`);
     }
@@ -1905,6 +2196,7 @@ export class RadioOperatorManager {
     this.eventListeners.clear();
 
     this.operators.clear();
+    this.targetReservations.clear();
     this.pendingTransmissions = [];
     this.sameTransmissionGuardStates.clear();
 
@@ -2056,6 +2348,10 @@ export class RadioOperatorManager {
     const normalizedMyCall = myCallsign.toUpperCase();
     const normalizedTarget = targetCallsign.toUpperCase();
 
+    if (this.targetReservations.isReservedByOther(normalizedMyCall, normalizedTarget, currentOperatorId)) {
+      return true;
+    }
+
     for (const [operatorId, operator] of this.operators.entries()) {
       // 跳过自己
       if (operatorId === currentOperatorId) continue;
@@ -2088,6 +2384,21 @@ export class RadioOperatorManager {
     }
 
     return false; // 无冲突
+  }
+
+  transitionTargetReservation(operatorId: string, epoch: number, targetCallsign?: string): boolean {
+    const operator = this.operators.get(operatorId);
+    if (!operator) return false;
+    return this.targetReservations.tryTransition({
+      stationCallsign: operator.config.myCallsign,
+      targetCallsign,
+      operatorId,
+      epoch,
+    });
+  }
+
+  releaseTargetReservation(operatorId: string, epoch?: number): void {
+    this.targetReservations.releaseOperator(operatorId, epoch);
   }
 
   private async completeAutomaticQSORecord(operatorId: string, qsoRecord: QSORecord): Promise<QSORecord> {

--- a/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
+++ b/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
@@ -53,6 +53,7 @@ function createManager(options: {
   getKnownRadioFrequency?: () => number | null;
   callsignTracker?: { getGrid: (callsign: string) => string | undefined };
   getFakeFrequencyEnabled?: () => boolean;
+  getTransmitCompensationMs?: () => number;
 }) {
   const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
   const slotPackManager = {
@@ -92,6 +93,7 @@ function createManager(options: {
     getKnownRadioFrequency: options.getKnownRadioFrequency,
     callsignTracker: options.callsignTracker as any,
     getFakeFrequencyEnabled: options.getFakeFrequencyEnabled,
+    getTransmitCompensationMs: options.getTransmitCompensationMs,
   });
 
   return {
@@ -104,7 +106,16 @@ function createManager(options: {
   };
 }
 
-async function invokeRecordQSO(manager: RadioOperatorManager, payload: { operatorId: string; qsoRecord: QSORecord }) {
+async function invokeRecordQSO(manager: RadioOperatorManager, payload: {
+  operatorId: string;
+  qsoLifecycleId?: string;
+  qsoLifecycleEpoch?: number;
+  qsoRuntimeGeneration?: number;
+  qsoRecord: QSORecord;
+  retryAttemptId?: string;
+  resolve?: (record: QSORecord) => void;
+  reject?: (error: unknown) => void;
+}) {
   const handler = (manager as any).eventListeners.get('recordQSO') as ((data: typeof payload) => Promise<void>) | undefined;
   expect(handler).toBeTypeOf('function');
   await handler!(payload);
@@ -144,6 +155,14 @@ function mockMaxSameTransmissionCount(limit: number) {
   } as any);
 }
 
+function mockConfigManagerForOperatorMutation() {
+  return vi.spyOn(ConfigManager, 'getInstance').mockReturnValue({
+    updateOperatorConfig: vi.fn().mockResolvedValue(undefined),
+    getOperatorConfig: vi.fn(() => undefined),
+    getFT8Config: () => ({ maxSameTransmissionCount: 20 }),
+  } as any);
+}
+
 async function addBasicOperator(manager: RadioOperatorManager, id: string, callsign = 'BG4IAJ') {
   await manager.addOperator({
     id,
@@ -158,6 +177,34 @@ async function addBasicOperator(manager: RadioOperatorManager, id: string, calls
   operator!.start();
   return operator!;
 }
+
+describe('RadioOperatorManager transmission maintenance', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('drops queued and incoming RF intents until maintenance ends', () => {
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test', provider: {} },
+    });
+    const request = {
+      operatorId: 'op1',
+      transmission: 'CQ BG4IAJ OM96',
+    };
+
+    eventEmitter.emit('requestTransmit', request);
+    expect(manager.getPendingTransmissionsCount()).toBe(1);
+
+    manager.enterTransmissionMaintenance('mode change');
+    expect(manager.getPendingTransmissionsCount()).toBe(0);
+    eventEmitter.emit('requestTransmit', request);
+    expect(manager.getPendingTransmissionsCount()).toBe(0);
+
+    manager.exitTransmissionMaintenance();
+    eventEmitter.emit('requestTransmit', request);
+    expect(manager.getPendingTransmissionsCount()).toBe(1);
+  });
+});
 
 describe('RadioOperatorManager logbook startup binding', () => {
   afterEach(() => {
@@ -312,7 +359,6 @@ describe('RadioOperatorManager same transmission guard', () => {
     expect(encodeQueue.push).toHaveBeenCalledTimes(20);
     expect(manager.getOperatorById('op1')?.isTransmitting).toBe(false);
     expect(manager.getPendingTransmissionsCount()).toBe(0);
-    expect(manager.getLatestEncodeRequestId('op1')).toBeUndefined();
     expect(resetOperatorPluginRuntime).toHaveBeenCalledTimes(1);
     expect(resetOperatorPluginRuntime).toHaveBeenCalledWith('op1', 'same transmission guard limit');
     expect(textMessageSpy).toHaveBeenCalledTimes(1);
@@ -344,6 +390,7 @@ describe('RadioOperatorManager same transmission guard', () => {
 
     let pluginManager!: PluginManager;
     pluginManager = new PluginManager({
+      intentCoordinator: (manager as any).intentCoordinator,
       eventEmitter,
       getOperators: () => manager.getAllOperators(),
       getOperatorById: (id) => manager.getOperatorById(id),
@@ -832,7 +879,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     }));
   });
 
-  it('pauses on the first failure and retains exactly one unsaved attempt', async () => {
+  it('pauses on the first failure without interrupting RF and retains exactly one unsaved attempt', async () => {
     const provider = {
       addQSO: vi.fn().mockRejectedValue(new Error('disk full')),
       updateQSO: vi.fn(),
@@ -853,8 +900,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     const { notifyQSOComplete, autoSync, interruptOperatorTransmission } = attachQSOHookSpy(manager);
 
     await invokeRecordQSO(manager, { operatorId: 'op1', qsoRecord: automaticQSO('failed-1') });
-    expect(interruptOperatorTransmission).toHaveBeenCalledOnce();
-    expect(interruptOperatorTransmission).toHaveBeenCalledWith('op1');
+    expect(interruptOperatorTransmission).not.toHaveBeenCalled();
     await invokeRecordQSO(manager, { operatorId: 'op1', qsoRecord: automaticQSO('failed-2', 'JA1AAA') });
 
     expect(operator.isTransmitting).toBe(false);
@@ -869,6 +915,142 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     expect(updatedSpy).not.toHaveBeenCalled();
     expect(autoSync).not.toHaveBeenCalled();
     expect(notifyQSOComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not let an old lifecycle write failure pause the current QSO lifecycle', async () => {
+    let rejectWrite!: (error: Error) => void;
+    const provider = {
+      addQSO: vi.fn(() => new Promise<QSORecord>((_resolve, reject) => {
+        rejectWrite = reject;
+      })),
+      updateQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn(),
+    };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5DRB',
+    });
+    const operator = await addBasicOperator(manager, 'op1', 'BG5DRB');
+    attachQSOHookSpy(manager);
+
+    eventEmitter.emit('qsoLifecycleChanged' as any, { operatorId: 'op1', lifecycleEpoch: 1 });
+    const oldWrite = invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoLifecycleId: 'op1:qso:1:old-record',
+      qsoLifecycleEpoch: 1,
+      qsoRecord: automaticQSO('old-record'),
+    });
+    await vi.waitFor(() => expect(provider.addQSO).toHaveBeenCalledOnce());
+
+    eventEmitter.emit('qsoLifecycleChanged' as any, { operatorId: 'op1', lifecycleEpoch: 2 });
+    operator.start();
+    rejectWrite(new Error('late disk failure'));
+    await oldWrite;
+
+    expect(operator.isTransmitting).toBe(true);
+    expect(operator.isLogbookPersistenceBlocked).toBe(false);
+    expect(manager.listUnsavedQsos('log-1')).toEqual([
+      expect.objectContaining({ callsign: 'N0CALL' }),
+    ]);
+    expect([...(manager as any).unsavedQsoAttempts.values()]).toEqual([
+      expect.objectContaining({ qsoLifecycleEpoch: 1, qsoLifecycleId: 'op1:qso:1:old-record' }),
+    ]);
+  });
+
+  it('does not confuse equal lifecycle epochs from different runtime generations', async () => {
+    let rejectWrite!: (error: Error) => void;
+    const provider = {
+      addQSO: vi.fn(() => new Promise<QSORecord>((_resolve, reject) => {
+        rejectWrite = reject;
+      })),
+      updateQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn(),
+    };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5DRB',
+    });
+    const operator = await addBasicOperator(manager, 'op1', 'BG5DRB');
+    attachQSOHookSpy(manager);
+
+    eventEmitter.emit('qsoLifecycleChanged' as any, {
+      operatorId: 'op1',
+      lifecycleEpoch: 1,
+      runtimeGeneration: 10,
+    });
+    const oldWrite = invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoLifecycleId: 'op1:runtime:10:qso:1:old-record',
+      qsoLifecycleEpoch: 1,
+      qsoRuntimeGeneration: 10,
+      qsoRecord: automaticQSO('old-record'),
+    });
+    await vi.waitFor(() => expect(provider.addQSO).toHaveBeenCalledOnce());
+
+    eventEmitter.emit('qsoLifecycleChanged' as any, {
+      operatorId: 'op1',
+      lifecycleEpoch: 1,
+      runtimeGeneration: 11,
+    });
+    operator.start();
+    rejectWrite(new Error('late failure from replaced runtime'));
+    await oldWrite;
+
+    expect(operator.isTransmitting).toBe(true);
+    expect(operator.isLogbookPersistenceBlocked).toBe(false);
+  });
+
+  it('does not let an old lifecycle write success clear the current lifecycle block or attempt', async () => {
+    let resolveWrite!: (record: QSORecord) => void;
+    const provider = {
+      addQSO: vi.fn(() => new Promise<QSORecord>((resolve) => {
+        resolveWrite = resolve;
+      })),
+      updateQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 1 }),
+    };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5DRB',
+    });
+    const operator = await addBasicOperator(manager, 'op1', 'BG5DRB');
+    attachQSOHookSpy(manager);
+
+    eventEmitter.emit('qsoLifecycleChanged' as any, { operatorId: 'op1', lifecycleEpoch: 1 });
+    const oldWrite = invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoLifecycleId: 'op1:qso:1:old-record',
+      qsoLifecycleEpoch: 1,
+      qsoRecord: automaticQSO('old-record'),
+    });
+    await vi.waitFor(() => expect(provider.addQSO).toHaveBeenCalledOnce());
+
+    eventEmitter.emit('qsoLifecycleChanged' as any, { operatorId: 'op1', lifecycleEpoch: 2 });
+    operator.blockForLogbookFailure();
+    const currentAttemptId = (manager as any).rememberUnsavedQso(
+      'op1',
+      'log-1',
+      automaticQSO('current-record', 'JA1AAA'),
+      'op1:qso:2:current-record',
+      2,
+    );
+    resolveWrite({ ...automaticQSO('persisted-old'), id: 'persisted-old' });
+    await oldWrite;
+
+    expect(operator.isLogbookPersistenceBlocked).toBe(true);
+    expect(manager.listUnsavedQsos('log-1')).toEqual([
+      expect.objectContaining({ attemptId: currentAttemptId, callsign: 'JA1AAA' }),
+    ]);
+    expect([...(manager as any).unsavedQsoAttempts.values()]).toEqual([
+      expect.objectContaining({
+        attemptId: currentAttemptId,
+        qsoLifecycleEpoch: 2,
+        qsoLifecycleId: 'op1:qso:2:current-record',
+      }),
+    ]);
   });
 
   it('retries the exact completed candidate captured by the first failed write', async () => {
@@ -1092,6 +1274,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
 
     let pluginManager!: PluginManager;
     pluginManager = new PluginManager({
+      intentCoordinator: (manager as any).intentCoordinator,
       eventEmitter,
       getOperators: () => manager.getAllOperators(),
       getOperatorById: (id) => manager.getOperatorById(id),
@@ -1166,16 +1349,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       expect(encodeQueue.push).toHaveBeenCalledTimes(2);
       expect(encodeQueue.push.mock.calls[0]?.[0]?.message).toBe('BG5DRB BG4IAJ -06');
       expect(encodeQueue.push.mock.calls[1]?.[0]?.message).toBe('BG5DRB BG4IAJ RR73');
-      expect(transmissionLogSpy).toHaveBeenCalledTimes(2);
-      expect(transmissionLogSpy.mock.calls[0]?.[0]).toMatchObject({
-        operatorId: 'op1',
-        message: 'BG5DRB BG4IAJ -06',
-      });
-      expect(transmissionLogSpy.mock.calls[1]?.[0]).toMatchObject({
-        operatorId: 'op1',
-        message: 'BG5DRB BG4IAJ RR73',
-        replaceExisting: true,
-      });
+      expect(transmissionLogSpy).not.toHaveBeenCalled();
     } finally {
       manager.stop();
       await pluginManager.shutdown().catch(() => undefined);
@@ -1251,11 +1425,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
         slotStartMs: 60_000,
         timeSinceSlotStartMs: 4_500,
       });
-      expect(transmissionLogSpy.mock.calls[0]?.[0]).toMatchObject({
-        operatorId: 'op1',
-        message: 'BG5DRB BG4IAJ RR73',
-        replaceExisting: true,
-      });
+      expect(transmissionLogSpy).not.toHaveBeenCalled();
     } finally {
       manager.stop();
     }
@@ -1349,6 +1519,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
 
     let pluginManager!: PluginManager;
     pluginManager = new PluginManager({
+      intentCoordinator: (manager as any).intentCoordinator,
       eventEmitter,
       getOperators: () => manager.getAllOperators(),
       getOperatorById: (id) => manager.getOperatorById(id),
@@ -1363,6 +1534,9 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       interruptOperatorTransmission: async () => {},
       hasWorkedCallsign: async () => false,
       resetOperatorRuntime: () => {},
+      triggerReEncode: (operatorId, options) => {
+        manager.triggerPostDecisionReEncode(operatorId, options);
+      },
       dataDir,
     });
 
@@ -1388,16 +1562,21 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       const statusSpy = vi.fn();
       eventEmitter.on('operatorStatusUpdate', statusSpy);
 
-      pluginManager.requestCall('op1', 'BH3RAU', {
-        message: {
-          message: 'CQ BH3RAU OM99',
-          snr: 0,
-          dt: 0.6,
-          freq: 1502,
-          confidence: 1,
+      pluginManager.requestCall(
+        'op1',
+        'BH3RAU',
+        {
+          message: {
+            message: 'CQ BH3RAU OM99',
+            snr: 0,
+            dt: 0.6,
+            freq: 1502,
+            confidence: 1,
+          },
+          slotInfo: createSlotInfo(45_000),
         },
-        slotInfo: createSlotInfo(45_000),
-      });
+        { submitCurrentFrame: true, source: 'operator-edit' },
+      );
 
       expect(encodeQueue.push).toHaveBeenCalledTimes(1);
       expect(encodeQueue.push.mock.calls[0]?.[0]).toMatchObject({
@@ -1459,6 +1638,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
 
     let pluginManager!: PluginManager;
     pluginManager = new PluginManager({
+      intentCoordinator: (manager as any).intentCoordinator,
       eventEmitter,
       getOperators: () => manager.getAllOperators(),
       getOperatorById: (id) => manager.getOperatorById(id),
@@ -1783,7 +1963,7 @@ describe('RadioOperatorManager transmission acceptance notification', () => {
     vi.restoreAllMocks();
   });
 
-  it('notifies the strategy runtime only after a transmission passes validation and enters the encode queue', async () => {
+  it('notifies the strategy runtime only after the physical transmission completes', async () => {
     mockMaxSameTransmissionCount(20);
     const encodeQueue = { push: vi.fn() };
     const { manager, eventEmitter } = createManager({
@@ -1816,8 +1996,409 @@ describe('RadioOperatorManager transmission acceptance notification', () => {
     manager.processPendingTransmissions(createSlotInfo(MODES.FT8.slotMs));
 
     expect(encodeQueue.push).toHaveBeenCalledTimes(1);
+    expect(notifyTransmissionQueued).not.toHaveBeenCalled();
+
+    manager.notifyPhysicalTransmissionComplete('op1', 'BG5DRB BG4IAJ 73');
     expect(notifyTransmissionQueued).toHaveBeenCalledTimes(1);
     expect(notifyTransmissionQueued).toHaveBeenCalledWith('op1', 'BG5DRB BG4IAJ 73');
+  });
+
+  it('re-encodes every participant when one operator replaces a mixed frame', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    await addBasicOperator(manager, 'op2');
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: 'BG5AAA BG4IAJ -10' });
+    eventEmitter.emit('requestTransmit', { operatorId: 'op2', transmission: 'BG5BBB BG4IAJ -08' });
+    manager.processPendingTransmissions(createSlotInfo(0));
+    const firstRequests = encodeQueue.push.mock.calls.map(([request]) => request);
+    expect(firstRequests).toHaveLength(2);
+    expect(new Set(firstRequests.map((request) => request.frameId)).size).toBe(1);
+
+    eventEmitter.emit('requestTransmit', {
+      operatorId: 'op1',
+      transmission: 'BG5AAA BG4IAJ RR73',
+      replaceExisting: true,
+      source: 'late-decode',
+    });
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    const replacementRequests = encodeQueue.push.mock.calls.slice(2).map(([request]) => request);
+    expect(replacementRequests.map((request) => request.operatorId).sort()).toEqual(['op1', 'op2']);
+    expect(new Set(replacementRequests.map((request) => request.frameId)).size).toBe(1);
+    expect(replacementRequests[0].frameId).not.toBe(firstRequests[0].frameId);
+    expect(new Set(replacementRequests.map((request) => request.frameRevision)).size).toBe(1);
+  });
+
+  it('treats an in-slot operator edit as a complete mixed-frame replacement', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 5_000,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    await addBasicOperator(manager, 'op2');
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: 'BG5AAA BG4IAJ -10' });
+    eventEmitter.emit('requestTransmit', { operatorId: 'op2', transmission: 'BG5BBB BG4IAJ -08' });
+    manager.processPendingTransmissions(createSlotInfo(0));
+    const firstFrameId = encodeQueue.push.mock.calls[0][0].frameId;
+
+    // This is the shape produced by a manual double-click/requestCall path:
+    // the high-level request does not need to know about physical frame state.
+    eventEmitter.emit('requestTransmit', {
+      operatorId: 'op1',
+      transmission: 'BG5CCC BG4IAJ RR73',
+      source: 'operator-edit',
+    });
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    const replacementRequests = encodeQueue.push.mock.calls.slice(2).map(([request]) => request);
+    expect(replacementRequests.map((request) => request.operatorId).sort()).toEqual(['op1', 'op2']);
+    expect(replacementRequests.every((request) => request.frameId !== firstFrameId)).toBe(true);
+  });
+
+  it('treats a frequency change during candidate encoding as a complete mixed-frame mutation', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const transmissions = new Map([
+      ['op1', 'BG5AAA BG4IAJ -10'],
+      ['op2', 'BG5BBB BG4IAJ -08'],
+    ]);
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 2_000,
+      encodeQueue,
+    });
+    mockConfigManagerForOperatorMutation();
+    await addBasicOperator(manager, 'op1');
+    await addBasicOperator(manager, 'op2');
+    manager.setPluginManager({
+      getCurrentTransmission: (operatorId: string) => transmissions.get(operatorId) ?? null,
+      getOperatorRuntimeStatus: () => undefined,
+      invalidateDecisionMessageSet: vi.fn(),
+    } as any);
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: transmissions.get('op1')! });
+    eventEmitter.emit('requestTransmit', { operatorId: 'op2', transmission: transmissions.get('op2')! });
+    manager.processPendingTransmissions(createSlotInfo(0));
+    const firstFrameId = encodeQueue.push.mock.calls[0][0].frameId;
+
+    await manager.updateOperatorContext('op1', { frequency: 1750 });
+
+    const replacement = encodeQueue.push.mock.calls.slice(2).map(([request]) => request);
+    expect(replacement.map((request) => request.operatorId).sort()).toEqual(['op1', 'op2']);
+    expect(new Set(replacement.map((request) => request.frameId)).size).toBe(1);
+    expect(replacement.every((request) => request.frameId !== firstFrameId)).toBe(true);
+    expect(replacement.find((request) => request.operatorId === 'op1')).toMatchObject({ frequency: 1750 });
+  });
+
+  it('rebuilds a committed starting frame when its operator frequency changes', async () => {
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 2_000,
+      encodeQueue,
+    });
+    mockConfigManagerForOperatorMutation();
+    await addBasicOperator(manager, 'op1');
+    manager.setPluginManager({
+      getCurrentTransmission: () => 'BG5AAA BG4IAJ RR73',
+      getOperatorRuntimeStatus: () => undefined,
+    } as any);
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: 'BG5AAA BG4IAJ RR73' });
+    manager.processPendingTransmissions(createSlotInfo(0));
+    const firstRequest = encodeQueue.push.mock.calls[0][0];
+    const coordinator = (manager as any).digitalFrameCoordinator;
+    coordinator.acceptEncodeResult({
+      frameId: firstRequest.frameId,
+      operatorId: 'op1',
+      decisionEpoch: firstRequest.decisionEpoch,
+      revision: firstRequest.frameRevision,
+    });
+    coordinator.prepareFrameForHandover(firstRequest.frameId, ['op1']);
+    coordinator.commitFrame(firstRequest.frameId);
+
+    await manager.updateOperatorContext('op1', { frequency: 1900 });
+
+    expect(encodeQueue.push).toHaveBeenCalledTimes(2);
+    expect(encodeQueue.push.mock.calls[1][0]).toMatchObject({
+      operatorId: 'op1',
+      frequency: 1900,
+    });
+    expect(encodeQueue.push.mock.calls[1][0].frameId).not.toBe(firstRequest.frameId);
+  });
+
+  it('removes a pre-commit contribution when transmit cycles move out of the current slot', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const transmissions = new Map([
+      ['op1', 'BG5AAA BG4IAJ -10'],
+      ['op2', 'BG5BBB BG4IAJ -08'],
+    ]);
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 2_000,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    await addBasicOperator(manager, 'op2');
+    manager.setPluginManager({
+      getCurrentTransmission: (operatorId: string) => transmissions.get(operatorId) ?? null,
+      getOperatorRuntimeStatus: () => undefined,
+      invalidateDecisionMessageSet: vi.fn(),
+    } as any);
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: transmissions.get('op1')! });
+    eventEmitter.emit('requestTransmit', { operatorId: 'op2', transmission: transmissions.get('op2')! });
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    manager.getOperatorById('op1')!.setTransmitCycles([1]);
+
+    const rebuilt = encodeQueue.push.mock.calls.slice(2).map(([request]) => request);
+    expect(rebuilt).toHaveLength(1);
+    expect(rebuilt[0]).toMatchObject({ operatorId: 'op2', message: transmissions.get('op2') });
+  });
+
+  it('removes only the edited operator when its current slot content becomes empty', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const transmissions = new Map<string, string>([
+      ['op1', 'CQ BG4IAJ OM96'],
+      ['op2', 'BG5BBB BG4IAJ -08'],
+    ]);
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 2_000,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    await addBasicOperator(manager, 'op2');
+    manager.setPluginManager({
+      getCurrentTransmission: (operatorId: string) => transmissions.get(operatorId) ?? null,
+      getOperatorRuntimeStatus: () => ({ currentSlot: 'TX6' }),
+    } as any);
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: transmissions.get('op1')! });
+    eventEmitter.emit('requestTransmit', { operatorId: 'op2', transmission: transmissions.get('op2')! });
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    transmissions.delete('op1');
+    eventEmitter.emit('operatorSlotContentChanged', { operatorId: 'op1', slot: 'TX6', content: '' });
+
+    const rebuilt = encodeQueue.push.mock.calls.slice(2).map(([request]) => request);
+    expect(rebuilt).toHaveLength(1);
+    expect(rebuilt[0]).toMatchObject({ operatorId: 'op2', message: transmissions.get('op2') });
+  });
+
+  it('lets an on-air frame finish when transmit cycles move out of the current slot', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 2_000,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    manager.setPluginManager({
+      getCurrentTransmission: () => 'BG5AAA BG4IAJ RR73',
+      getOperatorRuntimeStatus: () => undefined,
+      invalidateDecisionMessageSet: vi.fn(),
+    } as any);
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', { operatorId: 'op1', transmission: 'BG5AAA BG4IAJ RR73' });
+    manager.processPendingTransmissions(createSlotInfo(0));
+    const request = encodeQueue.push.mock.calls[0][0];
+    const coordinator = (manager as any).digitalFrameCoordinator;
+    coordinator.acceptEncodeResult({
+      frameId: request.frameId,
+      operatorId: 'op1',
+      decisionEpoch: request.decisionEpoch,
+      revision: request.frameRevision,
+    });
+    coordinator.prepareFrameForHandover(request.frameId, ['op1']);
+    coordinator.commitFrame(request.frameId);
+    coordinator.markOnAir(request.frameId);
+
+    manager.getOperatorById('op1')!.setTransmitCycles([1]);
+
+    expect(encodeQueue.push).toHaveBeenCalledTimes(1);
+    expect(coordinator.getFrame(request.frameId)).toMatchObject({ phase: 'on_air' });
+  });
+
+  it('queues encoding immediately when TX is enabled during its current cycle', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 4_500,
+      encodeQueue,
+    });
+    await manager.addOperator({
+      id: 'op1',
+      myCallsign: 'BG4IAJ',
+      myGrid: 'OM96',
+      frequency: 1_500,
+      transmitCycles: [0],
+      mode: MODES.FT8,
+    });
+    manager.setPluginManager({
+      getCurrentTransmission: vi.fn(() => 'CQ BG4IAJ OM96'),
+      getOperatorRuntimeStatus: vi.fn(() => undefined),
+    } as any);
+    manager.start();
+
+    manager.startOperator('op1');
+
+    expect(encodeQueue.push).toHaveBeenCalledTimes(1);
+    expect(encodeQueue.push.mock.calls[0]?.[0]).toMatchObject({
+      operatorId: 'op1',
+      message: 'CQ BG4IAJ OM96',
+      slotStartMs: 0,
+      timeSinceSlotStartMs: 4_500,
+    });
+  });
+
+  it('anchors the mid-slot waveform cursor to the compensated transmit start', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 4_500,
+      encodeQueue,
+      getTransmitCompensationMs: () => 200,
+    });
+    await addBasicOperator(manager, 'op1');
+    manager.start();
+
+    eventEmitter.emit('requestTransmit', {
+      operatorId: 'op1',
+      transmission: 'BG5AAA BG4IAJ RR73',
+      source: 'operator-edit',
+    });
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    const request = encodeQueue.push.mock.calls[0]?.[0];
+    expect(request).toBeDefined();
+    const coordinator = (manager as any).digitalFrameCoordinator;
+    expect(coordinator.getPlaybackOffsetMs(request.frameId, 4_500)).toBe(4_200);
+  });
+
+  it('keeps a too-late correction queued for the next slot', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter, clockSource } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 4_000,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    manager.start();
+
+    const coordinator = (manager as any).digitalFrameCoordinator;
+    const current = coordinator.prepareFrame({
+      slotId: 'slot-0',
+      intents: [{ operatorId: 'op1', source: 'plugin', reason: 'current', text: 'CQ BG4IAJ OM96' }],
+    });
+    coordinator.beginEncoding(current.frame.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: current.frame.frameId,
+      operatorId: 'op1',
+      decisionEpoch: current.intents[0].decisionEpoch,
+      revision: current.frame.revision,
+    });
+    coordinator.prepareFrameForHandover(current.frame.frameId, ['op1']);
+    coordinator.commitFrame(current.frame.frameId);
+    coordinator.markOnAir(current.frame.frameId);
+
+    eventEmitter.emit('requestTransmit', {
+      operatorId: 'op1',
+      transmission: 'BG5AAA BG4IAJ RR73',
+      replaceExisting: true,
+      source: 'late-decode',
+    });
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    expect(encodeQueue.push).not.toHaveBeenCalled();
+    expect(manager.getPendingTransmissionsCount()).toBe(1);
+
+    clockSource.now.mockReturnValue(MODES.FT8.slotMs);
+    manager.processPendingTransmissions(createSlotInfo(MODES.FT8.slotMs));
+    expect(encodeQueue.push).not.toHaveBeenCalled();
+    expect(manager.getPendingTransmissionsCount()).toBe(1);
+
+    clockSource.now.mockReturnValue(MODES.FT8.slotMs * 2);
+    manager.processPendingTransmissions(createSlotInfo(MODES.FT8.slotMs * 2));
+    expect(encodeQueue.push).toHaveBeenCalledTimes(1);
+    expect(encodeQueue.push.mock.calls[0][0]).toMatchObject({
+      operatorId: 'op1',
+      message: 'BG5AAA BG4IAJ RR73',
+    });
+  });
+
+  it('does not let a delayed old frame overwrite a newer queued intent', async () => {
+    mockMaxSameTransmissionCount(20);
+    const encodeQueue = { push: vi.fn() };
+    const { manager, eventEmitter } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
+      callsign: 'BG4IAJ',
+      clockNow: 0,
+      encodeQueue,
+    });
+    await addBasicOperator(manager, 'op1');
+    manager.start();
+
+    const coordinator = (manager as any).digitalFrameCoordinator;
+    const old = coordinator.prepareFrame({
+      slotId: 'slot-0',
+      intents: [{ operatorId: 'op1', source: 'late-decode', reason: 'old', text: 'BG5AAA BG4IAJ R-10' }],
+    });
+    coordinator.beginEncoding(old.frame.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: old.frame.frameId,
+      operatorId: 'op1',
+      decisionEpoch: old.intents[0].decisionEpoch,
+      revision: old.frame.revision,
+    });
+
+    eventEmitter.emit('requestTransmit', {
+      operatorId: 'op1',
+      transmission: 'BG5AAA BG4IAJ RR73',
+      replaceExisting: true,
+      source: 'operator-edit',
+    });
+    expect(manager.deferPreparedFrameToNextSlot(old.frame.frameId, 'old encode completed too late')).toBe(true);
+    manager.processPendingTransmissions(createSlotInfo(0));
+
+    expect(encodeQueue.push).toHaveBeenCalledTimes(1);
+    expect(encodeQueue.push.mock.calls[0][0]).toMatchObject({
+      message: 'BG5AAA BG4IAJ RR73',
+    });
   });
 });
 
@@ -1946,6 +2527,10 @@ describe('RadioOperatorManager fake frequency dial shift', () => {
 
     queueAndProcess(manager, eventEmitter, ['op1'], 0); // 提交本时隙 shift
     manager.updateActiveTransmissionOperators(['op1']);
+    manager.setPluginManager({
+      getCurrentTransmission: () => 'CQ BG4IAJ OM96',
+      getOperatorRuntimeStatus: () => undefined,
+    } as any);
 
     const retrigger = vi.spyOn(manager as any, 'checkAndTriggerTransmission').mockImplementation(() => {});
     await manager.updateOperatorContext('op1', { frequency: 1000 });
@@ -1970,100 +2555,14 @@ describe('RadioOperatorManager fake frequency dial shift', () => {
 
     queueAndProcess(manager, eventEmitter, ['op1'], 0);
     manager.updateActiveTransmissionOperators(['op1']);
+    manager.setPluginManager({
+      getCurrentTransmission: () => 'CQ BG4IAJ OM96',
+      getOperatorRuntimeStatus: () => undefined,
+    } as any);
 
     const retrigger = vi.spyOn(manager as any, 'checkAndTriggerTransmission').mockImplementation(() => {});
     await manager.updateOperatorContext('op1', { frequency: 1000 });
 
     expect(retrigger).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('getTransmittingOperatorCount', () => {
-  it('returns 0 when no operators exist', () => {
-    const { manager } = createManager({
-      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
-      callsign: 'BG4IAJ',
-    });
-    expect(manager.getTransmittingOperatorCount()).toBe(0);
-  });
-
-  it('returns 0 when operators exist but none are transmitting', async () => {
-    const { manager } = createManager({
-      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
-      callsign: 'BG4IAJ',
-    });
-    await manager.addOperator({
-      id: 'op1',
-      myCallsign: 'BG4IAJ',
-      myGrid: 'OM96',
-      frequency: 1500,
-      transmitCycles: [0],
-      mode: MODES.FT8,
-    });
-    expect(manager.getTransmittingOperatorCount()).toBe(0);
-  });
-
-  it('returns count of transmitting operators', async () => {
-    const { manager } = createManager({
-      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
-      callsign: 'BG4IAJ',
-    });
-    await manager.addOperator({
-      id: 'op1',
-      myCallsign: 'BG4IAJ',
-      myGrid: 'OM96',
-      frequency: 1500,
-      transmitCycles: [0],
-      mode: MODES.FT8,
-    });
-    await manager.addOperator({
-      id: 'op2',
-      myCallsign: 'BG4IAJ',
-      myGrid: 'OM96',
-      frequency: 2000,
-      transmitCycles: [0],
-      mode: MODES.FT8,
-    });
-
-    expect(manager.getTransmittingOperatorCount()).toBe(0);
-
-    const op1 = manager.getOperatorById('op1');
-    op1!.start();
-    expect(manager.getTransmittingOperatorCount()).toBe(1);
-
-    const op2 = manager.getOperatorById('op2');
-    op2!.start();
-    expect(manager.getTransmittingOperatorCount()).toBe(2);
-
-    op1!.stop();
-    expect(manager.getTransmittingOperatorCount()).toBe(1);
-  });
-});
-
-describe('isFakeFrequencyEffective', () => {
-  it('returns false when getFakeFrequencyEnabled is not provided', () => {
-    const { manager } = createManager({
-      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
-      callsign: 'BG4IAJ',
-    });
-    expect(manager.isFakeFrequencyEffective()).toBe(false);
-  });
-
-  it('returns the value from getFakeFrequencyEnabled callback', () => {
-    const { manager } = createManager({
-      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
-      callsign: 'BG4IAJ',
-      getFakeFrequencyEnabled: () => true,
-    });
-    expect(manager.isFakeFrequencyEffective()).toBe(true);
-  });
-
-  it('returns false when getFakeFrequencyEnabled returns false', () => {
-    const { manager } = createManager({
-      logBook: { id: 'log-1', name: 'Test Log', provider: {} },
-      callsign: 'BG4IAJ',
-      getFakeFrequencyEnabled: () => false,
-    });
-    expect(manager.isFakeFrequencyEffective()).toBe(false);
   });
 });

--- a/packages/server/src/plugin/DecisionOrchestrator.ts
+++ b/packages/server/src/plugin/DecisionOrchestrator.ts
@@ -19,13 +19,15 @@ import {
   type AutoCallExecutionRequest,
   type ScoredCandidate,
   type StrategyDecision,
-  type StrategyDecisionMeta,
+  type StrategyDecisionResult,
+  type StrategyDecisionSource,
 } from '@tx5dr/plugin-api';
 import type { AutoCallProposalResult } from './PluginHookDispatcher.js';
 import { evaluateAutomaticTargetEligibility } from './AutoTargetEligibility.js';
 import type { DecisionOrchestratorDeps, OperatorDecisionState } from './types.js';
 import { createLogger } from '../utils/logger.js';
 import { FT8MessageParser, CycleUtils, isUndecodedCallsignPlaceholder } from '@tx5dr/core';
+import type { OperatorCommandToken } from '../transmission/OperatorIntentCoordinator.js';
 
 const logger = createLogger('DecisionOrchestrator');
 
@@ -79,15 +81,34 @@ export class DecisionOrchestrator {
   // ===== Public API =====
 
   async handleSlotStart(slotInfo: SlotInfo, slotPack: SlotPack | null): Promise<void> {
-    for (const operator of this.deps.getOperators()) {
+    await Promise.all(this.deps.getOperators().map(async (operator) => {
+      await this.deps.intentCoordinator.submit(
+        operator.config.id,
+        'slot-auto',
+        (token, signal) => this.handleOperatorSlotStart(operator.config.id, slotInfo, slotPack, token, signal),
+      );
+    }));
+  }
+
+  private async handleOperatorSlotStart(
+    operatorId: string,
+    slotInfo: SlotInfo,
+    slotPack: SlotPack | null,
+    token: OperatorCommandToken,
+    signal: AbortSignal,
+  ): Promise<void> {
+      const operator = this.deps.getOperatorById(operatorId);
+      if (!operator) return;
       const parsedMessages = slotPack
-        ? await this.parseSlotPackMessages(slotPack, operator.config.id)
+        ? await this.parseSlotPackMessages(slotPack, operatorId)
         : [];
+      if (!this.isCommandCurrent(token, signal)) return;
       // 决策分水岭：部分解码消息仅供广播/监控观察，绝不进入任何自动决策路径
       const actionableMessages = parsedMessages.filter((message) => !message.isPartialDecode);
 
-      await this.deps.dispatcher.dispatchBroadcast(
-        operator.config.id,
+      // Passive hooks are guarded and observed, but never hold the RF decision lane.
+      void this.deps.dispatcher.dispatchBroadcast(
+        operatorId,
         'onSlotActivity',
         (hook, ctx) => hook({
           slotInfo,
@@ -99,71 +120,77 @@ export class DecisionOrchestrator {
         (instance) => this.deps.getCtxForInstance(instance),
       );
 
-      await this.deps.dispatcher.dispatchBroadcast(
-        operator.config.id,
+      void this.deps.dispatcher.dispatchBroadcast(
+        operatorId,
         'onSlotStart',
         (hook, ctx) => hook(slotInfo, parsedMessages, ctx),
         (instance) => this.deps.getCtxForInstance(instance),
       );
 
-      await this.deps.dispatcher.dispatchBroadcast(
-        operator.config.id,
+      void this.deps.dispatcher.dispatchBroadcast(
+        operatorId,
         'onDecode',
         (hook, ctx) => hook(parsedMessages, ctx),
         (instance) => this.deps.getCtxForInstance(instance),
       );
 
       if (!operator.isTransmitting
-          && await this.tryWakeFromSilentDirectedCallGate(operator.config.id, actionableMessages, slotInfo, slotPack)) {
-        continue;
+          && await this.tryWakeFromSilentDirectedCallGate(operatorId, actionableMessages, slotInfo, slotPack, token, signal)) {
+        return;
       }
+      if (!this.isCommandCurrent(token, signal)) return;
 
       if (!operator.isTransmitting
-          && await this.tryWakeFromStoppedDirectCallAutoReply(operator.config.id, actionableMessages, slotInfo, slotPack)) {
-        continue;
+          && await this.tryWakeFromStoppedDirectCallAutoReply(operatorId, actionableMessages, slotInfo, slotPack, token, signal)) {
+        return;
       }
+      if (!this.isCommandCurrent(token, signal)) return;
 
       let automaticTargetMessages: ParsedFT8Message[] | undefined;
-      if (this.isOperatorPureStandby(operator.config.id)) {
+      if (this.isOperatorPureStandby(operatorId)) {
         automaticTargetMessages = await this.getScoredAutomaticTargetMessages(
-          operator.config.id,
+          operatorId,
           actionableMessages,
         );
+        if (!this.isCommandCurrent(token, signal)) return;
 
         const autoCallProposals = await this.deps.dispatcher.dispatchAutoCallCandidates(
-          operator.config.id,
+          operatorId,
           slotInfo,
           automaticTargetMessages,
           (instance) => this.deps.getCtxForInstance(instance),
         );
-        await this.applyAutoCallProposal(operator.config.id, slotInfo, automaticTargetMessages, autoCallProposals);
+        if (!this.isCommandCurrent(token, signal)) return;
+        await this.applyAutoCallProposal(operatorId, slotInfo, automaticTargetMessages, autoCallProposals, token);
       }
 
-      if (!operator.isTransmitting) continue;
+      if (!operator.isTransmitting || !this.isCommandCurrent(token, signal)) return;
 
-      const session = this.getOrCreateDecisionState(operator.config.id);
+      const session = this.getOrCreateDecisionState(operatorId);
       session.lastDecisionTransmission = null;
       session.lastDecisionMessageSet = null;
       session.preDecisionEncodedTransmission = undefined;
       automaticTargetMessages ??= await this.getScoredAutomaticTargetMessages(
-        operator.config.id,
+        operatorId,
         actionableMessages,
       );
+      if (!this.isCommandCurrent(token, signal)) return;
 
-      let decision;
-      session.decisionInProgress = true;
-      try {
-        decision = await this.invokeStrategyDecision(operator.config.id, automaticTargetMessages, { isReDecision: false });
-      } finally {
-        session.decisionInProgress = false;
-      }
+      const decision = await this.invokeStrategyDecision(
+        operatorId,
+        automaticTargetMessages,
+        { isReDecision: false },
+        token,
+        signal,
+      );
+      if (!this.isCommandCurrent(token, signal)) return;
 
       if (slotPack) {
-        session.lastDecisionMessageSet = this.buildDecisionMessageSet(slotPack, operator.config.id);
+        session.lastDecisionMessageSet = this.buildDecisionMessageSet(slotPack, operatorId);
       }
-      session.lastDecisionTransmission = this.readCurrentTransmission(operator.config.id);
-      await this.notifyQSOFailIfPresent(operator.config.id, decision);
-      this.updateSilentDirectedCallGate(operator.config.id, decision, slotInfo, slotPack);
+      session.lastDecisionTransmission = this.readCurrentTransmission(operatorId);
+      await this.notifyQSOFailIfPresent(operatorId, decision);
+      this.updateSilentDirectedCallGate(operatorId, decision, slotInfo, slotPack);
 
       // 竞态检测：如果 handleEncodeStart 在决策完成前已排队了发射内容，
       // 且决策结果与之不同，触发替换编码以纠正过时的发射
@@ -171,18 +198,24 @@ export class DecisionOrchestrator {
           && session.lastDecisionTransmission !== null
           && session.lastDecisionTransmission !== session.preDecisionEncodedTransmission) {
         logger.info('Stale encode corrected after decision', {
-          operatorId: operator.config.id,
+          operatorId,
           stale: session.preDecisionEncodedTransmission,
           correct: session.lastDecisionTransmission,
         });
-        this.deps.triggerReEncode?.(operator.config.id);
+        this.deps.triggerReEncode?.(operatorId, {
+          source: 'late-decode',
+          reason: 'slot decision corrected an already encoded frame',
+        });
       }
       session.preDecisionEncodedTransmission = undefined;
 
       if (decision?.stop) {
-        await this.applyStrategyStop(operator.config.id);
+        await this.applyStrategyStop(operatorId);
       }
-    }
+  }
+
+  private isCommandCurrent(token: OperatorCommandToken, signal: AbortSignal): boolean {
+    return !signal.aborted && this.deps.intentCoordinator.isCurrent(token);
   }
 
   handleEncodeStart(slotInfo: SlotInfo): void {
@@ -200,11 +233,12 @@ export class DecisionOrchestrator {
       );
       if (!isTransmitSlot) continue;
 
-      const runtime = this.deps.getStrategyRuntime(operator.config.id);
-      if (!runtime) continue;
-
       try {
-        const transmission = runtime.getTransmitText();
+        const transmission = this.deps.invokeStrategyRuntimeSync(
+          operator.config.id,
+          'getTransmitText:encode-start',
+          (runtime) => runtime.getTransmitText(),
+        );
         if (!transmission) continue;
 
         // 记录即将编码的内容，供 handleSlotStart 检测竞态
@@ -214,6 +248,7 @@ export class DecisionOrchestrator {
         this.deps.eventEmitter.emit('requestTransmit', {
           operatorId: operator.config.id,
           transmission,
+          decisionEpoch: this.deps.intentCoordinator.getCurrentEpoch(operator.config.id),
         });
       } catch (err) {
         logger.error(`strategy runtime getTransmitText error: operator=${operator.config.id}`, err);
@@ -222,6 +257,20 @@ export class DecisionOrchestrator {
   }
 
   async reDecideOperator(operatorId: string, slotPack: SlotPack): Promise<boolean> {
+    const outcome = await this.deps.intentCoordinator.submit(
+      operatorId,
+      'late-decode',
+      (token, signal) => this.reDecideOperatorInLane(operatorId, slotPack, token, signal),
+    );
+    return outcome.status === 'completed' ? outcome.value : false;
+  }
+
+  private async reDecideOperatorInLane(
+    operatorId: string,
+    slotPack: SlotPack,
+    token: OperatorCommandToken,
+    signal: AbortSignal,
+  ): Promise<boolean> {
     const operator = this.deps.getOperatorById(operatorId);
     if (!operator) {
       return false;
@@ -230,18 +279,29 @@ export class DecisionOrchestrator {
     if (!operator.isTransmitting) {
       const slotInfo = this.buildSlotInfoFromSlotPack(slotPack);
       const parsedMessages = await this.parseSlotPackMessages(slotPack, operatorId);
+      if (!this.isCommandCurrent(token, signal)) return false;
       const actionableMessages = parsedMessages.filter((message) => !message.isPartialDecode);
-      if (await this.tryWakeFromSilentDirectedCallGate(operatorId, actionableMessages, slotInfo, slotPack)) {
+      if (await this.tryWakeFromSilentDirectedCallGate(
+        operatorId,
+        actionableMessages,
+        slotInfo,
+        slotPack,
+        token,
+        signal,
+      )) {
         return true;
       }
-      return this.tryWakeFromStoppedDirectCallAutoReply(operatorId, actionableMessages, slotInfo, slotPack);
+      return this.tryWakeFromStoppedDirectCallAutoReply(
+        operatorId,
+        actionableMessages,
+        slotInfo,
+        slotPack,
+        token,
+        signal,
+      );
     }
 
     const session = this.getOrCreateDecisionState(operatorId);
-    if (session.decisionInProgress) {
-      return false;
-    }
-
     const newMessageSet = this.buildDecisionMessageSet(slotPack, operatorId);
     if (session.lastDecisionMessageSet) {
       const hasNewMessage = Array.from(newMessageSet).some((message) => !session.lastDecisionMessageSet?.has(message));
@@ -251,25 +311,28 @@ export class DecisionOrchestrator {
     }
 
     const parsedMessages = await this.parseSlotPackMessages(slotPack, operatorId);
+    if (!this.isCommandCurrent(token, signal)) return false;
     const actionableMessages = parsedMessages.filter((message) => !message.isPartialDecode);
     const automaticTargetMessages = await this.getScoredAutomaticTargetMessages(
       operatorId,
       actionableMessages,
     );
+    if (!this.isCommandCurrent(token, signal)) return false;
 
-    let decision: StrategyDecision | null = null;
-    session.decisionInProgress = true;
-    try {
-      decision = await this.invokeStrategyDecision(operatorId, automaticTargetMessages, { isReDecision: true });
-    } finally {
-      session.decisionInProgress = false;
-    }
+    const decision = await this.invokeStrategyDecision(
+      operatorId,
+      automaticTargetMessages,
+      { isReDecision: true },
+      token,
+      signal,
+    );
+    if (!this.isCommandCurrent(token, signal)) return false;
 
     await this.notifyQSOFailIfPresent(operatorId, decision);
     this.updateSilentDirectedCallGate(operatorId, decision, this.buildSlotInfoFromSlotPack(slotPack), slotPack);
 
     if (decision?.stop) {
-      await this.applyStrategyStop(operatorId, { interruptActiveTransmission: true });
+      await this.applyStrategyStop(operatorId);
       return false;
     }
 
@@ -288,13 +351,12 @@ export class DecisionOrchestrator {
   }
 
   readCurrentTransmission(operatorId: string): string | null {
-    const runtime = this.deps.getStrategyRuntime(operatorId);
-    if (!runtime) {
-      return null;
-    }
-
     try {
-      return runtime.getTransmitText() ?? null;
+      return this.deps.invokeStrategyRuntimeSync(
+        operatorId,
+        'getTransmitText:read-current',
+        (runtime) => runtime.getTransmitText(),
+      ) ?? null;
     } catch (err) {
       logger.error(`Failed to read current transmission: operator=${operatorId}`, err);
       return null;
@@ -319,7 +381,6 @@ export class DecisionOrchestrator {
 
   clearDecisionState(operatorId: string): void {
     this.decisionStates.set(operatorId, {
-      decisionInProgress: false,
       lastDecisionTransmission: null,
       lastDecisionMessageSet: null,
     });
@@ -604,15 +665,179 @@ export class DecisionOrchestrator {
   private async invokeStrategyDecision(
     operatorId: string,
     messages: ParsedFT8Message[],
-    meta: StrategyDecisionMeta,
-  ): Promise<StrategyDecision | null> {
-    const runtime = this.deps.getStrategyRuntime(operatorId);
-    if (!runtime) {
+    meta: { isReDecision: boolean },
+    token: OperatorCommandToken,
+    signal: AbortSignal,
+  ): Promise<StrategyDecisionResult | null> {
+    if (!this.deps.getStrategyRuntime(operatorId)) {
       return null;
     }
+    const runtimeGeneration = this.deps.getStrategyRuntimeGeneration(operatorId);
+    if (runtimeGeneration === undefined) return null;
 
-    const result = runtime.decide(messages, meta);
-    return result instanceof Promise ? await result : result;
+    const checkpoint = this.deps.invokeStrategyRuntimeSync(
+      operatorId,
+      'checkpoint:decision',
+      (runtime) => structuredClone(runtime.checkpoint()),
+    );
+    if (checkpoint === undefined) return null;
+    const source: StrategyDecisionSource = meta.isReDecision ? 'late-decode' : 'slot-auto';
+    const rejectedTargets = new Set<string>();
+    const maxAttempts = Math.max(
+      1,
+      new Set(messages.map((message) => getParsedMessageSenderCallsign(message.message)).filter(Boolean)).size + 1,
+    );
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      try {
+        const result = await this.deps.invokeStrategyRuntime(
+          operatorId,
+          `decide:${source}`,
+          (runtime) => runtime.decide(messages, {
+            epoch: token.epoch,
+            source,
+            isReDecision: meta.isReDecision,
+            signal,
+          }),
+          { signal },
+        );
+        if (!result) return null;
+        if (!this.isCommandCurrent(token, signal)) {
+          this.deps.invokeStrategyRuntimeSync(
+            operatorId,
+            'restore:superseded-decision',
+            (runtime) => runtime.restore(checkpoint),
+          );
+          return null;
+        }
+
+        const nextTarget = result.snapshot.context?.targetCallsign?.trim().toUpperCase();
+        if (this.deps.transitionTargetReservation
+            && !this.deps.transitionTargetReservation(operatorId, token.epoch, nextTarget)) {
+          this.deps.invokeStrategyRuntimeSync(
+            operatorId,
+            'restore:target-reservation-conflict',
+            (runtime) => runtime.restore(checkpoint),
+          );
+          if (!nextTarget || rejectedTargets.has(nextTarget)) {
+            logger.warn('Strategy repeatedly selected a target reserved by another operator', {
+              operatorId,
+              epoch: token.epoch,
+              targetCallsign: nextTarget ?? null,
+            });
+            return null;
+          }
+          rejectedTargets.add(nextTarget);
+          continue;
+        }
+
+        const operator = this.deps.getOperatorById(operatorId);
+        if (operator) {
+          if (result.snapshot.slots) {
+            operator.notifySlotsUpdated(result.snapshot.slots as import('@tx5dr/contracts').OperatorSlots);
+          }
+          operator.notifyStateChanged(result.snapshot.currentState);
+        }
+        if (result.snapshot.qsoLifecycleEpoch !== undefined) {
+          this.deps.eventEmitter.emit('qsoLifecycleChanged', {
+            operatorId,
+            lifecycleEpoch: result.snapshot.qsoLifecycleEpoch,
+            runtimeGeneration,
+          });
+        }
+        if (result.qsoCompletion) {
+          this.commitQSOCompletionEffect(operatorId, runtimeGeneration, result.qsoCompletion);
+        }
+        return result;
+      } catch (error) {
+        this.deps.invokeStrategyRuntimeSync(
+          operatorId,
+          'restore:failed-decision',
+          (runtime) => runtime.restore(checkpoint),
+        );
+        if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+          logger.debug('Discarded aborted strategy decision', { operatorId, epoch: token.epoch, source });
+          return null;
+        }
+        throw error;
+      }
+    }
+    return null;
+  }
+
+  private commitQSOCompletionEffect(
+    operatorId: string,
+    runtimeGeneration: number,
+    effect: import('@tx5dr/plugin-api').StrategyQSOCompletionEffect,
+  ): void {
+    const { record: qsoRecord, lifecycleEpoch } = effect;
+    const qsoLifecycleId = `${operatorId}:runtime:${runtimeGeneration}:qso:${lifecycleEpoch}:${qsoRecord.id}`;
+    void new Promise<import('@tx5dr/contracts').QSORecord>((resolve, reject) => {
+      this.deps.eventEmitter.emit('recordQSO', {
+        operatorId,
+        qsoLifecycleId,
+        qsoLifecycleEpoch: lifecycleEpoch,
+        qsoRuntimeGeneration: runtimeGeneration,
+        qsoRecord,
+        resolve,
+        reject,
+      });
+    }).then(() => {
+      this.settleStrategyQSOCompletion(
+        operatorId,
+        runtimeGeneration,
+        lifecycleEpoch,
+        qsoRecord.id,
+        'committed',
+      );
+    }).catch((error) => {
+      this.settleStrategyQSOCompletion(
+        operatorId,
+        runtimeGeneration,
+        lifecycleEpoch,
+        qsoRecord.id,
+        'failed',
+      );
+      logger.warn('Declarative QSO completion failed after decision commit', {
+        operatorId,
+        qsoLifecycleId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private settleStrategyQSOCompletion(
+    operatorId: string,
+    runtimeGeneration: number,
+    lifecycleEpoch: number,
+    recordId: string,
+    status: 'committed' | 'failed',
+  ): void {
+    if (this.deps.getStrategyRuntimeGeneration(operatorId) !== runtimeGeneration) {
+      logger.debug('Skipped QSO settlement for a replaced strategy runtime', {
+        operatorId,
+        runtimeGeneration,
+        lifecycleEpoch,
+        recordId,
+        status,
+      });
+      return;
+    }
+    try {
+      this.deps.invokeStrategyRuntimeSync(
+        operatorId,
+        `settle-qso:${status}`,
+        (runtime) => runtime.settleQSOCompletion?.({ lifecycleEpoch, recordId, status }),
+      );
+    } catch (error) {
+      logger.warn('Failed to settle strategy QSO lifecycle', {
+        operatorId,
+        lifecycleEpoch,
+        recordId,
+        status,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private async notifyQSOFailIfPresent(
@@ -695,6 +920,8 @@ export class DecisionOrchestrator {
     parsedMessages: ParsedFT8Message[],
     slotInfo: SlotInfo,
     slotPack: SlotPack | null,
+    token: OperatorCommandToken,
+    signal: AbortSignal,
   ): Promise<boolean> {
     const operator = this.deps.getOperatorById(operatorId);
     const gate = this.getActiveSilentDirectedCallGate(operatorId, slotPack?.startMs);
@@ -714,7 +941,14 @@ export class DecisionOrchestrator {
     }
 
     const before = this.deps.getOperatorAutomationSnapshot(operatorId);
-    const decision = await this.invokeStrategyDecision(operatorId, directedMessages, { isReDecision: true });
+    const decision = await this.invokeStrategyDecision(
+      operatorId,
+      directedMessages,
+      { isReDecision: true },
+      token,
+      signal,
+    );
+    if (!this.isCommandCurrent(token, signal)) return false;
     await this.notifyQSOFailIfPresent(operatorId, decision);
     if (decision?.stop) {
       this.updateSilentDirectedCallGate(operatorId, decision, slotInfo, slotPack);
@@ -736,7 +970,11 @@ export class DecisionOrchestrator {
 
     this.silentDirectedCallGates.delete(operatorId);
     operator.start();
-    operator.setTransmitCycles((sourceSlotInfo.cycleNumber + 1) % 2);
+    operator.setTransmitCycles((sourceSlotInfo.cycleNumber + 1) % 2, {
+      commandEpoch: token.epoch,
+      source: 'late-decode',
+      reason: 'silent directed call selected transmit cycle',
+    });
 
     logger.info('Silent directed-call gate woke stopped operator', {
       operatorId,
@@ -754,6 +992,8 @@ export class DecisionOrchestrator {
     parsedMessages: ParsedFT8Message[],
     slotInfo: SlotInfo,
     slotPack: SlotPack | null,
+    token: OperatorCommandToken,
+    signal: AbortSignal,
   ): Promise<boolean> {
     const operator = this.deps.getOperatorById(operatorId);
     if (!operator
@@ -773,7 +1013,14 @@ export class DecisionOrchestrator {
     }
 
     const before = this.deps.getOperatorAutomationSnapshot(operatorId);
-    const decision = await this.invokeStrategyDecision(operatorId, directedMessages, { isReDecision: true });
+    const decision = await this.invokeStrategyDecision(
+      operatorId,
+      directedMessages,
+      { isReDecision: true },
+      token,
+      signal,
+    );
+    if (!this.isCommandCurrent(token, signal)) return false;
     await this.notifyQSOFailIfPresent(operatorId, decision);
     if (decision?.stop) {
       return false;
@@ -795,7 +1042,11 @@ export class DecisionOrchestrator {
     const sourceSlotInfo = this.buildSourceSlotInfoFromParsedMessage(operatorId, sourceMessage, slotInfo);
 
     operator.start();
-    operator.setTransmitCycles((sourceSlotInfo.cycleNumber + 1) % 2);
+    operator.setTransmitCycles((sourceSlotInfo.cycleNumber + 1) % 2, {
+      commandEpoch: token.epoch,
+      source: 'late-decode',
+      reason: 'stopped direct call selected transmit cycle',
+    });
 
     logger.info('Stopped direct-call auto-reply woke operator', {
       operatorId,
@@ -809,27 +1060,14 @@ export class DecisionOrchestrator {
     return true;
   }
 
-  private async applyStrategyStop(
-    operatorId: string,
-    options?: { interruptActiveTransmission?: boolean },
-  ): Promise<void> {
+  private async applyStrategyStop(operatorId: string): Promise<void> {
     const operator = this.deps.getOperatorById(operatorId);
     if (!operator) {
       return;
     }
 
     operator.stop();
-
-    if (!options?.interruptActiveTransmission) {
-      return;
-    }
-
-    try {
-      await this.deps.interruptOperatorTransmission(operatorId);
-    } catch (error) {
-      logger.error(`Failed to interrupt active transmission after strategy stop: operator=${operatorId}`, error);
-      throw error;
-    }
+    this.deps.requestOperatorStrategyStop?.(operatorId, 'strategy stop');
   }
 
   private isOperatorPureStandby(operatorId: string): boolean {
@@ -856,6 +1094,7 @@ export class DecisionOrchestrator {
     slotInfo: SlotInfo,
     messages: ParsedFT8Message[],
     proposals: AutoCallProposalResult[],
+    token: OperatorCommandToken,
   ): Promise<void> {
     if (proposals.length === 0 || !this.isOperatorPureStandby(operatorId)) {
       return;
@@ -915,8 +1154,8 @@ export class DecisionOrchestrator {
       lastMessage: winner.proposal.lastMessage,
     };
     const executionPlan = await this.resolveAutoCallExecutionPlan(operatorId, request);
-    await this.applyAutoCallExecutionPlan(operatorId, request, executionPlan);
-    this.deps.requestCall(operatorId, request.callsign, request.lastMessage);
+    await this.applyAutoCallExecutionPlan(operatorId, request, executionPlan, token);
+    this.deps.requestCall(operatorId, request.callsign, request.lastMessage, { commandToken: token });
   }
 
   private isAutoCallProposalEligible(
@@ -1098,6 +1337,7 @@ export class DecisionOrchestrator {
     operatorId: string,
     request: AutoCallExecutionRequest,
     plan: AutoCallExecutionPlan,
+    token: OperatorCommandToken,
   ): Promise<void> {
     if (!this.deps.setOperatorAudioFrequency) {
       return;
@@ -1114,7 +1354,7 @@ export class DecisionOrchestrator {
     }
 
     try {
-      await this.deps.setOperatorAudioFrequency(operatorId, requestedFrequency);
+      await this.deps.setOperatorAudioFrequency(operatorId, requestedFrequency, token);
       logger.info('Auto call execution plan applied audio frequency', {
         operatorId,
         slotId: request.slotInfo.id,
@@ -1168,7 +1408,6 @@ export class DecisionOrchestrator {
     let state = this.decisionStates.get(operatorId);
     if (!state) {
       state = {
-        decisionInProgress: false,
         lastDecisionTransmission: null,
         lastDecisionMessageSet: null,
       };

--- a/packages/server/src/plugin/LogbookSyncHost.ts
+++ b/packages/server/src/plugin/LogbookSyncHost.ts
@@ -17,6 +17,15 @@ const logger = createLogger('LogbookSyncHost');
 interface RegisteredProvider {
   pluginName: string;
   provider: LogbookSyncProvider;
+  owner: LogbookSyncProviderOwner;
+  info: LogbookSyncProviderInfo;
+}
+
+export interface LogbookSyncProviderOwner {
+  generation: number;
+  isCurrent(): boolean;
+  invoke<T>(operation: string, callback: () => T | Promise<T>): Promise<T>;
+  invokeSync<T>(operation: string, callback: () => T): T;
 }
 
 /**
@@ -61,7 +70,11 @@ export class LogbookSyncHost {
    * Registers a sync provider. Called from PluginContextFactory when a plugin
    * invokes `ctx.logbookSync.register()`.
    */
-  register(pluginName: string, provider: LogbookSyncProvider): void {
+  register(
+    pluginName: string,
+    provider: LogbookSyncProvider,
+    owner: LogbookSyncProviderOwner,
+  ): void {
     if (this.providers.has(provider.id)) {
       logger.warn('Overwriting existing sync provider', {
         id: provider.id,
@@ -69,7 +82,22 @@ export class LogbookSyncHost {
         newPlugin: pluginName,
       });
     }
-    this.providers.set(provider.id, { pluginName, provider });
+    const entry: RegisteredProvider = {
+      pluginName,
+      provider,
+      owner,
+      info: {
+        id: provider.id,
+        pluginName,
+        displayName: provider.displayName,
+        icon: provider.icon,
+        color: provider.color,
+        settingsPageId: provider.settingsPageId,
+        accessScope: provider.accessScope ?? 'admin',
+        actions: provider.actions ? structuredClone(provider.actions) : undefined,
+      },
+    };
+    this.providers.set(provider.id, entry);
     logger.info('Logbook sync provider registered', {
       id: provider.id,
       pluginName,
@@ -81,9 +109,10 @@ export class LogbookSyncHost {
    * Unregisters all providers from a specific plugin. Called during plugin
    * unload/reload.
    */
-  unregisterByPlugin(pluginName: string): void {
+  unregisterByPlugin(pluginName: string, generation?: number): void {
     for (const [id, entry] of this.providers) {
-      if (entry.pluginName === pluginName) {
+      if (entry.pluginName === pluginName
+          && (generation === undefined || entry.owner.generation === generation)) {
         this.providers.delete(id);
         // Clean up any active upload entries for this provider to avoid dangling references.
         for (const key of this.activeUploads.keys()) {
@@ -100,17 +129,34 @@ export class LogbookSyncHost {
   }
 
   private toProviderInfo(entry: RegisteredProvider): LogbookSyncProviderInfo {
-    const { pluginName, provider } = entry;
-    return {
-      id: provider.id,
-      pluginName,
-      displayName: provider.displayName,
-      icon: provider.icon,
-      color: provider.color,
-      settingsPageId: provider.settingsPageId,
-      accessScope: provider.accessScope ?? 'admin',
-      actions: provider.actions,
-    };
+    return structuredClone(entry.info);
+  }
+
+  private isCurrent(entry: RegisteredProvider): boolean {
+    return entry.owner.isCurrent()
+      && this.providers.get(entry.info.id) === entry;
+  }
+
+  private async invoke<T>(
+    entry: RegisteredProvider,
+    operation: string,
+    callback: () => T | Promise<T>,
+  ): Promise<T> {
+    if (!this.isCurrent(entry)) {
+      throw new Error('PLUGIN_INVOCATION_EXPIRED: logbook sync provider is no longer active');
+    }
+    const result = await entry.owner.invoke(`logbook-sync:${operation}`, callback);
+    if (!this.isCurrent(entry)) {
+      throw new Error('PLUGIN_INVOCATION_EXPIRED: stale logbook sync result discarded');
+    }
+    return result;
+  }
+
+  private invokeSync<T>(entry: RegisteredProvider, operation: string, callback: () => T): T {
+    if (!this.isCurrent(entry)) {
+      throw new Error('PLUGIN_INVOCATION_EXPIRED: logbook sync provider is no longer active');
+    }
+    return entry.owner.invokeSync(`logbook-sync:${operation}`, callback);
   }
 
   /** Returns info about all registered providers for the frontend. */
@@ -143,7 +189,7 @@ export class LogbookSyncHost {
       });
       return { success: false, message: failure.message, failures: [failure] };
     }
-    return entry.provider.testConnection(callsign);
+    return this.invoke(entry, 'test-connection', () => entry.provider.testConnection(callsign));
   }
 
   /**
@@ -176,13 +222,13 @@ export class LogbookSyncHost {
     }
 
     const key = LogbookSyncHost.uploadKey(providerId, callsign);
-    return this.enqueueUpload(key, () => entry.provider.upload(callsign, {
+    return this.enqueueUpload(key, () => this.invoke(entry, 'upload', () => entry.provider.upload(callsign, {
       trigger: 'manual',
       since: options?.since,
       until: options?.until,
       includeAlreadyUploaded: options?.includeAlreadyUploaded,
       skipBlockedQsos: options?.skipBlockedQsos,
-    }));
+    })));
   }
 
   async getUploadPreflight(
@@ -194,7 +240,7 @@ export class LogbookSyncHost {
     if (!entry?.provider.getUploadPreflight) {
       return null;
     }
-    return entry.provider.getUploadPreflight(callsign, options);
+    return this.invoke(entry, 'upload-preflight', () => entry.provider.getUploadPreflight!(callsign, options));
   }
 
   /**
@@ -224,7 +270,7 @@ export class LogbookSyncHost {
         ],
       };
     }
-    return entry.provider.download(callsign, options);
+    return this.invoke(entry, 'download', () => entry.provider.download(callsign, options));
   }
 
   /**
@@ -236,9 +282,10 @@ export class LogbookSyncHost {
    * buffered and drained in the next serialized auto batch.
    */
   onQSOComplete(callsign: string, qsoRecord: QSORecord): void {
-    for (const [id, { provider, pluginName }] of this.providers) {
+    for (const [id, entry] of this.providers) {
+      const { provider, pluginName } = entry;
       try {
-        if (!provider.isAutoUploadEnabled(callsign)) {
+        if (!this.invokeSync(entry, 'is-auto-upload-enabled', () => provider.isAutoUploadEnabled(callsign))) {
           continue;
         }
 
@@ -246,7 +293,7 @@ export class LogbookSyncHost {
         const queuedRecords = this.pendingAutoRecords.get(key) ?? new Map<string, QSORecord>();
         queuedRecords.set(qsoRecord.id, qsoRecord);
         this.pendingAutoRecords.set(key, queuedRecords);
-        this.scheduleAutoDrain(key, provider, callsign, pluginName);
+        this.scheduleAutoDrain(key, entry, callsign);
       } catch (err) {
         logger.warn('Auto-upload check failed', {
           providerId: id,
@@ -293,9 +340,8 @@ export class LogbookSyncHost {
 
   private scheduleAutoDrain(
     key: string,
-    provider: LogbookSyncProvider,
+    entry: RegisteredProvider,
     callsign: string,
-    pluginName: string,
   ): void {
     if (this.scheduledAutoDrains.has(key)) {
       return;
@@ -309,22 +355,22 @@ export class LogbookSyncHost {
       }
 
       this.pendingAutoRecords.delete(key);
-      return provider.upload(callsign, {
+      return this.invoke(entry, 'auto-upload', () => entry.provider.upload(callsign, {
         trigger: 'auto',
         records: Array.from(queuedRecords.values()),
-      });
+      }));
     }).catch((err) => {
       logger.warn('Auto-upload failed', {
-        providerId: provider.id,
-        pluginName,
+        providerId: entry.info.id,
+        pluginName: entry.pluginName,
         callsign,
         error: err instanceof Error ? err.message : String(err),
       });
     }).finally(() => {
       this.scheduledAutoDrains.delete(key);
       const remainingRecords = this.pendingAutoRecords.get(key);
-      if (remainingRecords && remainingRecords.size > 0) {
-        this.scheduleAutoDrain(key, provider, callsign, pluginName);
+      if (remainingRecords && remainingRecords.size > 0 && this.isCurrent(entry)) {
+        this.scheduleAutoDrain(key, entry, callsign);
       } else {
         this.pendingAutoRecords.delete(key);
       }
@@ -334,14 +380,23 @@ export class LogbookSyncHost {
   /** Checks if a specific provider is configured for the given callsign. */
   isConfigured(providerId: string, callsign: string): boolean {
     const entry = this.providers.get(providerId);
-    return entry?.provider.isConfigured(callsign) ?? false;
+    if (!entry) return false;
+    try {
+      return this.invokeSync(entry, 'is-configured', () => entry.provider.isConfigured(callsign));
+    } catch {
+      return false;
+    }
   }
 
   /** Returns configuration status for all providers (provider.isConfigured). */
   getConfiguredStatus(callsign: string): Record<string, boolean> {
     const result: Record<string, boolean> = {};
-    for (const [id, { provider }] of this.providers) {
-      result[id] = provider.isConfigured(callsign);
+    for (const [id, entry] of this.providers) {
+      try {
+        result[id] = this.invokeSync(entry, 'is-configured', () => entry.provider.isConfigured(callsign));
+      } catch {
+        result[id] = false;
+      }
     }
     return result;
   }

--- a/packages/server/src/plugin/PluginContextFactory.ts
+++ b/packages/server/src/plugin/PluginContextFactory.ts
@@ -4,16 +4,17 @@ import * as hostHamlib from 'hamlib';
 import type { RemoteInfo, Socket, SocketType } from 'node:dgram';
 import {
   getBandFromFrequency,
-  isUndecodedCallsignPlaceholder,
   LogbookOperationError,
   toAdifMode,
 } from '@tx5dr/core';
+import { getPluginContextCapabilityKeys } from '@tx5dr/plugin-api';
 import type {
   HostSettingsControl,
   HamlibHostDependency,
   LogbookSyncProvider,
   OtherOperatorSnapshot,
-  PluginContext,
+  PluginContextBase,
+  RuntimePluginContext,
   RadioOperatingMode,
   PluginUIInstanceTarget,
   QSOQueryFilter,
@@ -27,14 +28,11 @@ import type {
   PluginUIPageDescriptor,
   PluginPermission,
   EngineMode,
-  RadioPowerTarget,
-  WriteCapabilityPayload,
 } from '@tx5dr/contracts';
 import {
   MODES,
   RealtimeSettingsResponseDataSchema,
   RadioPowerTargetSchema,
-  WriteCapabilityPayloadSchema,
 } from '@tx5dr/contracts';
 import { ConfigManager } from '../config/config-manager.js';
 import { LogManager } from '../log/LogManager.js';
@@ -55,16 +53,14 @@ type HostHamlibModule = {
 };
 
 function createAllowedHamlibDependency(source: HostHamlibModule): HamlibHostDependency {
-  return Object.freeze({
+  return {
     Rotator: source.Rotator,
-    PASSBAND: Object.freeze({
+    PASSBAND: {
       NORMAL: source.PASSBAND.NORMAL,
       NOCHANGE: source.PASSBAND.NOCHANGE,
-    }),
-  });
+    },
+  };
 }
-
-const HOST_HAMLIB_DEPENDENCY = createAllowedHamlibDependency(hostHamlib as unknown as HostHamlibModule);
 
 type SavedPluginFrequency = {
   frequency: number;
@@ -93,6 +89,8 @@ function cloneModeDescriptor(mode: ModeDescriptor): ModeDescriptor {
  * 为插件实例创建 PluginContext。
  */
 export class PluginContextFactory {
+  private readonly audioFrequencyReservationsBySlot = new Map<string, Map<string, number>>();
+
   constructor(
     private deps: PluginManagerDeps,
     private readonly onPanelMeta?: (payload: PluginPanelMetaPayload) => void,
@@ -113,7 +111,8 @@ export class PluginContextFactory {
     onTimer: (timerId: string) => void,
     getPluginSettings: () => Record<string, unknown>,
     updatePluginSettings?: (patch: Record<string, unknown>) => Promise<void>,
-  ): Promise<PluginContext> {
+    invokeResourceCallback?: <T>(operation: string, callback: () => T | Promise<T>) => Promise<T>,
+  ): Promise<RuntimePluginContext> {
     const globalStorage = new PluginStorageProvider(`${pluginStorageDir}/global.json`);
     const operatorStorageName = operatorId ? `operator-${operatorId}.json` : 'instance-global.json';
     const operatorStorage = new PluginStorageProvider(`${pluginStorageDir}/${operatorStorageName}`);
@@ -133,20 +132,31 @@ export class PluginContextFactory {
       this.onPanelMeta,
       this.onPanelContributions,
     );
-    let ctx: PluginContext | undefined;
+    const contextRef: { current?: RuntimePluginContext } = {};
     const pluginLogger = this.createLogger(plugin.definition.name);
-    const operatorControl = this.createOperatorControl(plugin, operatorId, instanceScope, () => ctx);
-    const radioControl = this.createRadioControl(plugin);
+    const operatorSnapshot = this.createOperatorSnapshot(operatorId, instanceScope);
+    const operatorCommands = this.createOperatorCommandPort(
+      plugin,
+      operatorId,
+      instanceScope,
+      () => contextRef.current,
+    );
+    const radioContext = this.createRadioContext(plugin);
     const logbookAccess = this.createLogbookAccess(operatorId, instanceScope);
     const bandAccess = this.createBandAccess(operatorId);
     const settingsControl = this.createSettingsControl(plugin);
     const fileStore = new PluginFileStoreProvider(
       path.join(pluginStorageDir, 'files'),
     );
-    const networkControl = this.createNetworkControl(plugin);
-    const eventBusControl = this.createEventBusControl(plugin, operatorId, instanceScope);
+    const networkControl = this.createNetworkControl(plugin, invokeResourceCallback);
+    const eventBusControl = this.createEventBusControl(
+      plugin,
+      operatorId,
+      instanceScope,
+      invokeResourceCallback,
+    );
 
-    ctx = {
+    const baseContext: PluginContextBase = {
       get config() {
         return Object.freeze({ ...getPluginSettings() });
       },
@@ -162,28 +172,47 @@ export class PluginContextFactory {
       },
       log: pluginLogger,
       timers: timerManager,
-      operator: operatorControl,
-      radio: radioControl,
-      logbook: logbookAccess,
+      operator: operatorSnapshot,
+      radio: radioContext.radio,
       band: bandAccess,
       ui: uiBridge,
       files: fileStore,
+    };
+
+    const capabilityCandidates: Partial<RuntimePluginContext> = {
+      ...radioContext.capabilities,
+      ...(operatorCommands ? { operatorCommands } : {}),
+      ...(networkControl ? {
+        network: networkControl,
+        fetch: (url: string, init?: RequestInit) => globalThis.fetch(url, init),
+      } : {}),
+      ...(eventBusControl ? { eventBus: eventBusControl } : {}),
+      logbook: plugin.definition.permissions?.includes('logbook:write')
+        ? logbookAccess.full
+        : logbookAccess.read,
       settings: settingsControl,
-      hostDependencies: plugin.definition.permissions?.includes('host:hamlib')
-        ? { hamlib: HOST_HAMLIB_DEPENDENCY }
-        : {},
-      network: networkControl,
-      eventBus: eventBusControl,
       logbookSync: {
-        register: (provider) => {
+        register: (provider: LogbookSyncProvider) => {
           this.validateLogbookSyncProvider(plugin, provider);
           this.deps.registerLogbookSyncProvider?.(plugin.definition.name, provider);
         },
       },
-      fetch: plugin.definition.permissions?.includes('network')
-        ? (url, init) => globalThis.fetch(url, init)
-        : undefined,
+      hostDependencies: {
+        hamlib: createAllowedHamlibDependency(hostHamlib as unknown as HostHamlibModule),
+      },
     };
+    const declaredCapabilities: Record<string, unknown> = {};
+    for (const key of getPluginContextCapabilityKeys(plugin.definition.permissions)) {
+      const value = capabilityCandidates[key];
+      if (value !== undefined) {
+        declaredCapabilities[key] = value;
+      }
+    }
+
+    const ctx = Object.create(null) as RuntimePluginContext;
+    Object.defineProperties(ctx, Object.getOwnPropertyDescriptors(baseContext));
+    Object.assign(ctx, declaredCapabilities);
+    contextRef.current = ctx;
 
     return ctx;
   }
@@ -192,11 +221,8 @@ export class PluginContextFactory {
     plugin: LoadedPlugin,
     operatorId: string | undefined,
     instanceScope: 'operator' | 'global',
-  ): PluginContext['eventBus'] {
-    if (!plugin.definition.permissions?.includes('plugin:event-bus')) {
-      return undefined;
-    }
-
+    invokeResourceCallback?: <T>(operation: string, callback: () => T | Promise<T>) => Promise<T>,
+  ): RuntimePluginContext['eventBus'] {
     const host = this.deps.pluginEventBusHost;
     if (!host) {
       return undefined;
@@ -213,26 +239,28 @@ export class PluginContextFactory {
         host.publish(owner, topic, payload);
       },
       subscribe(topic, handler) {
-        return host.subscribe(owner, topic, handler);
+        return host.subscribe(owner, topic, (message) => {
+          if (!invokeResourceCallback) {
+            return handler(message);
+          }
+          return invokeResourceCallback('event-bus:message', () => handler(message));
+        });
       },
     };
   }
 
 
-  private createNetworkControl(plugin: LoadedPlugin) {
+  private createNetworkControl(
+    _plugin: LoadedPlugin,
+    invokeResourceCallback?: <T>(operation: string, callback: () => T | Promise<T>) => Promise<T>,
+  ): RuntimePluginContext['network'] {
     const sockets = new Set<Socket>();
-    const assertNetworkPermission = () => {
-      if (!plugin.definition.permissions?.includes('network')) {
-        throw new Error(`Plugin '${plugin.definition.name}' requires permission 'network' to use UDP sockets`);
-      }
-    };
 
     const toError = (error: unknown): Error => error instanceof Error ? error : new Error(String(error));
 
     return {
       udp: {
         createSocket: (options?: import('@tx5dr/plugin-api').PluginUdpSocketOptions) => {
-          assertNetworkPermission();
           const socket = createSocket({
             type: (options?.type ?? 'udp4') as SocketType,
             reuseAddr: options?.reuseAddr ?? false,
@@ -242,18 +270,44 @@ export class PluginContextFactory {
           let closed = false;
           let messageHandler: ((data: Uint8Array, remote: import('@tx5dr/plugin-api').PluginUdpRemoteInfo) => void | Promise<void>) | undefined;
           let errorHandler: ((error: Error) => void) | undefined;
+          let pendingMessages = 0;
+          let messageQueue = Promise.resolve();
+          const MAX_PENDING_MESSAGES = 100;
+          const reportError = (error: Error) => {
+            if (!errorHandler) return;
+            if (invokeResourceCallback) {
+              void invokeResourceCallback('network:udp-error', () => errorHandler!(error)).catch(() => undefined);
+            } else {
+              errorHandler(error);
+            }
+          };
 
           socket.on('message', (message: Buffer, remote: RemoteInfo) => {
             if (!messageHandler) return;
-            Promise.resolve(messageHandler(new Uint8Array(message), {
+            if (pendingMessages >= MAX_PENDING_MESSAGES) {
+              reportError(new Error('Plugin UDP receive queue is full'));
+              return;
+            }
+            pendingMessages += 1;
+            const payload = new Uint8Array(message);
+            const remoteInfo = {
               address: remote.address,
               port: remote.port,
               family: remote.family,
               size: remote.size,
-            })).catch((error) => errorHandler?.(toError(error)));
+            };
+            messageQueue = messageQueue.then(async () => {
+              if (invokeResourceCallback) {
+                await invokeResourceCallback('network:udp-message', () => messageHandler!(payload, remoteInfo));
+              } else {
+                await messageHandler!(payload, remoteInfo);
+              }
+            }).catch((error) => reportError(toError(error))).finally(() => {
+              pendingMessages -= 1;
+            });
           });
           socket.on('error', (error) => {
-            errorHandler?.(error);
+            reportError(error);
           });
           socket.on('close', () => {
             closed = true;
@@ -334,7 +388,7 @@ export class PluginContextFactory {
   }
 
 
-  private createSettingsControl(plugin: LoadedPlugin): HostSettingsControl {
+  private createSettingsControl(plugin: LoadedPlugin): Partial<HostSettingsControl> {
     const service = new HostSettingsService();
     const thisDeps = this.deps;
     const assertPermission = (permission: PluginPermission, action: string) => {
@@ -345,7 +399,7 @@ export class PluginContextFactory {
       }
     };
 
-    return {
+    const controls: HostSettingsControl = {
       ft8: {
         async get() {
           assertPermission('settings:ft8', 'read FT8 settings');
@@ -424,12 +478,25 @@ export class PluginContextFactory {
         },
       },
     };
+    const permissions = new Set(plugin.definition.permissions ?? []);
+    return Object.freeze({
+      ...(permissions.has('settings:ft8') ? { ft8: controls.ft8 } : {}),
+      ...(permissions.has('settings:decode-windows') ? { decodeWindows: controls.decodeWindows } : {}),
+      ...(permissions.has('settings:realtime') ? { realtime: controls.realtime } : {}),
+      ...(permissions.has('settings:frequency-presets') ? { frequencyPresets: controls.frequencyPresets } : {}),
+      ...(permissions.has('settings:station') ? { station: controls.station } : {}),
+      ...(permissions.has('settings:psk-reporter') ? { pskReporter: controls.pskReporter } : {}),
+      ...(permissions.has('settings:ntp') ? { ntp: controls.ntp } : {}),
+    });
   }
 
   private validateLogbookSyncProvider(
     plugin: LoadedPlugin,
     provider: LogbookSyncProvider,
   ): void {
+    if (!plugin.definition.permissions?.includes('logbook:sync')) {
+      throw new Error(`Plugin must declare logbook:sync to register a sync provider: ${plugin.definition.name}`);
+    }
     if (plugin.definition.type !== 'utility') {
       throw new Error(`Logbook sync provider must come from a utility plugin: ${plugin.definition.name}`);
     }
@@ -489,22 +556,30 @@ export class PluginContextFactory {
     };
   }
 
-  private createOperatorControl(
+  private createOperatorCommandPort(
     plugin: LoadedPlugin,
     operatorId: string | undefined,
     instanceScope: 'operator' | 'global',
-    getContext: () => PluginContext | undefined,
-  ) {
+    getContext: () => RuntimePluginContext | undefined,
+  ): RuntimePluginContext['operatorCommands'] {
+    if (instanceScope === 'global'
+        || !operatorId
+        || plugin.definition.apiVersion !== 2) {
+      return undefined;
+    }
+
     const deps = this.deps;
     const assertTransmitControlAllowed = (action: string): void => {
       if (!plugin.definition.permissions?.includes('operator:transmit-control')) {
         throw new Error(
-          `Plugin '${plugin.definition.name}' cannot ${action}. Add permissions: ['operator:transmit-control'] and implement isAutoCallEnabled(ctx) before using operator transmit-control APIs.`,
+          `Plugin '${plugin.definition.name}' cannot ${action}. Add permissions: ['operator:transmit-control'] and a transmit-control eligibility predicate before using operator commands.`,
         );
       }
-      if (typeof plugin.definition.isAutoCallEnabled !== 'function') {
+      const isTransmitControlEnabled = plugin.definition.isTransmitControlEnabled
+        ?? plugin.definition.isAutoCallEnabled;
+      if (typeof isTransmitControlEnabled !== 'function') {
         throw new Error(
-          `Plugin '${plugin.definition.name}' must implement isAutoCallEnabled(ctx): boolean before using operator transmit-control APIs.`,
+          `Plugin '${plugin.definition.name}' must implement isTransmitControlEnabled(ctx) or isAutoCallEnabled(ctx) before using operator commands.`,
         );
       }
 
@@ -521,21 +596,38 @@ export class PluginContextFactory {
 
       let enabled = false;
       try {
-        enabled = plugin.definition.isAutoCallEnabled(ctx) === true;
+        const eligibilityContext = Object.freeze({ config: ctx.config });
+        enabled = isTransmitControlEnabled(eligibilityContext) === true;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(
-          `Plugin '${plugin.definition.name}' failed to evaluate isAutoCallEnabled(ctx) before ${action}: ${message}`,
+          `Plugin '${plugin.definition.name}' failed to evaluate its transmit-control eligibility before ${action}: ${message}`,
         );
       }
 
       if (!enabled) {
         throw new Error(
-          `Plugin '${plugin.definition.name}' cannot ${action} because isAutoCallEnabled(ctx) returned false. Only call operator transmit-control APIs while your automatic calling feature is enabled, or update isAutoCallEnabled(ctx) to reflect the active state.`,
+          `Plugin '${plugin.definition.name}' cannot ${action} because its transmit-control eligibility predicate returned false.`,
         );
       }
     };
 
+    return {
+      async submit(command) {
+        assertTransmitControlAllowed(`submit operator command '${command.type}'`);
+        if (!deps.submitOperatorCommand) {
+          throw new Error('Host operator command coordinator is unavailable');
+        }
+        return deps.submitOperatorCommand(operatorId, command, plugin.definition.name);
+      },
+    };
+  }
+
+  private createOperatorSnapshot(
+    operatorId: string | undefined,
+    instanceScope: 'operator' | 'global',
+  ): PluginContextBase['operator'] {
+    const deps = this.deps;
     if (instanceScope === 'global' || !operatorId) {
       return {
         get id() { return '__global__'; },
@@ -547,22 +639,8 @@ export class PluginContextFactory {
         get transmitCycles() { return []; },
         get automation() { return null; },
         getOtherOperators: () => this.createOtherOperatorSnapshots(undefined),
-        startTransmitting() { assertTransmitControlAllowed('start transmitting'); },
-        stopTransmitting() { assertTransmitControlAllowed('stop transmitting'); },
-        call(_callsign: string, _lastMessage?: { message: import('@tx5dr/contracts').FrameMessage; slotInfo: import('@tx5dr/contracts').SlotInfo }) { assertTransmitControlAllowed('call a target station'); },
-        replyToDecode(_decode: { callsign: string; lastMessage: { message: import('@tx5dr/contracts').FrameMessage; slotInfo: import('@tx5dr/contracts').SlotInfo }; modifiers?: number }) { assertTransmitControlAllowed('reply to a decode'); },
-        setTransmitCycles(_cycles: number | number[]) {},
-        clearDecodes(_window?: number) {},
-        haltTransmission(_options?: { autoOnly?: boolean }) { assertTransmitControlAllowed('halt transmission'); },
-        setFreeText(_text: string) {},
-        sendFreeText(_text?: string) { assertTransmitControlAllowed('send free text'); },
-        setTemporaryLocation(_location: string) {},
-        highlightCallsign(_rule: { callsign: string; background?: string | null; foreground?: string | null; lastOnly?: boolean }) {},
         async hasWorkedCallsign(_callsign: string, _options?: { anyBand?: boolean }) { return false; },
         isTargetBeingWorkedByOthers(_targetCallsign: string) { return false; },
-        async recordQSO(record: import('@tx5dr/contracts').QSORecord) { return record; },
-        notifySlotsUpdated(_slots: import('@tx5dr/contracts').OperatorSlots) {},
-        notifyStateChanged(_state: string) {},
       };
     }
 
@@ -590,75 +668,11 @@ export class PluginContextFactory {
         return deps.getOperatorAutomationSnapshot(operatorId);
       },
       getOtherOperators: () => this.createOtherOperatorSnapshots(operatorId),
-      startTransmitting() {
-        assertTransmitControlAllowed('start transmitting');
-        deps.getOperatorById(operatorId)?.start();
-      },
-      stopTransmitting() {
-        assertTransmitControlAllowed('stop transmitting');
-        deps.getOperatorById(operatorId)?.stop();
-      },
-      call(callsign: string, lastMessage?: { message: import('@tx5dr/contracts').FrameMessage; slotInfo: import('@tx5dr/contracts').SlotInfo }) {
-        assertTransmitControlAllowed('call a target station');
-        // 未解码占位符呼号拒绝呼叫（收敛点 PluginManager.requestCall 亦会拒绝）
-        if (isUndecodedCallsignPlaceholder(callsign)) return;
-        deps.requestOperatorCall(operatorId, callsign, lastMessage);
-      },
-      replyToDecode(decode: { callsign: string; lastMessage: { message: import('@tx5dr/contracts').FrameMessage; slotInfo: import('@tx5dr/contracts').SlotInfo }; modifiers?: number }) {
-        assertTransmitControlAllowed('reply to a decode');
-        // 未解码占位符呼号拒绝回复（避免对远端产生副作用）
-        if (isUndecodedCallsignPlaceholder(decode.callsign)) return;
-        deps.eventEmitter.emit('pluginRemoteReplyToDecode', { operatorId, callsign: decode.callsign, modifiers: decode.modifiers });
-        deps.requestOperatorCall(operatorId, decode.callsign, decode.lastMessage);
-      },
-      setTransmitCycles(cycles: number | number[]) {
-        deps.getOperatorById(operatorId)?.setTransmitCycles(cycles);
-      },
-      clearDecodes(window?: number) {
-        deps.eventEmitter.emit('pluginRemoteClearDecodes', { operatorId, window });
-      },
-      haltTransmission(options?: { autoOnly?: boolean }) {
-        assertTransmitControlAllowed('halt transmission');
-        if (options?.autoOnly) {
-          deps.getOperatorById(operatorId)?.stop();
-        } else {
-          void deps.interruptOperatorTransmission(operatorId).catch(() => {
-            deps.getOperatorById(operatorId)?.stop();
-          });
-        }
-      },
-      setFreeText(text: string) {
-        deps.eventEmitter.emit('pluginRemoteFreeText', { operatorId, text, send: false });
-      },
-      sendFreeText(text?: string) {
-        assertTransmitControlAllowed('send free text');
-        deps.eventEmitter.emit('pluginRemoteFreeText', { operatorId, text, send: true });
-        if (text && text.trim()) {
-          deps.eventEmitter.emit('requestTransmit', { operatorId, transmission: text });
-        }
-      },
-      setTemporaryLocation(location: string) {
-        deps.eventEmitter.emit('pluginRemoteLocation', { operatorId, location });
-      },
-      highlightCallsign(rule: { callsign: string; background?: string | null; foreground?: string | null; lastOnly?: boolean }) {
-        deps.eventEmitter.emit('pluginRemoteHighlightCallsign', { operatorId, ...rule });
-      },
       async hasWorkedCallsign(callsign: string, options?: { anyBand?: boolean }) {
         return deps.hasWorkedCallsign(operatorId, callsign, options);
       },
       isTargetBeingWorkedByOthers(targetCallsign: string) {
         return deps.getOperatorById(operatorId)?.isTargetBeingWorkedByOthers(targetCallsign) ?? false;
-      },
-      recordQSO(record: import('@tx5dr/contracts').QSORecord) {
-        const operator = deps.getOperatorById(operatorId);
-        if (!operator) return Promise.reject(new Error(`Operator ${operatorId} is unavailable`));
-        return operator.recordQSOLog(record);
-      },
-      notifySlotsUpdated(slots: import('@tx5dr/contracts').OperatorSlots) {
-        deps.getOperatorById(operatorId)?.notifySlotsUpdated(slots);
-      },
-      notifyStateChanged(state: string) {
-        deps.getOperatorById(operatorId)?.notifyStateChanged(state);
       },
     };
   }
@@ -678,9 +692,15 @@ export class PluginContextFactory {
       }));
   }
 
-  private getOtherOperatorAudioFrequenciesHz(operatorId: string | undefined): number[] {
+  private getOtherOperatorAudioFrequenciesHz(
+    operatorId: string | undefined,
+    slotId?: string,
+  ): number[] {
+    const reservations = slotId
+      ? this.audioFrequencyReservationsBySlot.get(slotId)
+      : undefined;
     return this.createOtherOperatorSnapshots(operatorId)
-      .map((operator) => operator.audioFrequencyHz)
+      .map((operator) => reservations?.get(operator.id) ?? operator.audioFrequencyHz)
       .filter((frequency) => (
         typeof frequency === 'number'
         && Number.isFinite(frequency)
@@ -689,16 +709,36 @@ export class PluginContextFactory {
       ));
   }
 
-  private createRadioControl(plugin: LoadedPlugin) {
+  private reserveOperatorAudioFrequency(
+    operatorId: string | undefined,
+    slotId: string,
+    frequency: number,
+  ): void {
+    if (!operatorId) {
+      return;
+    }
+
+    let reservations = this.audioFrequencyReservationsBySlot.get(slotId);
+    if (!reservations) {
+      reservations = new Map();
+      this.audioFrequencyReservationsBySlot.set(slotId, reservations);
+      while (this.audioFrequencyReservationsBySlot.size > 4) {
+        const oldestSlotId = this.audioFrequencyReservationsBySlot.keys().next().value;
+        if (oldestSlotId === undefined) {
+          break;
+        }
+        this.audioFrequencyReservationsBySlot.delete(oldestSlotId);
+      }
+    }
+    reservations.set(operatorId, frequency);
+  }
+
+  private createRadioContext(plugin: LoadedPlugin): {
+    radio: PluginContextBase['radio'];
+    capabilities: Omit<RuntimePluginContext, keyof PluginContextBase>;
+  } {
     const deps = this.deps;
     const configManager = ConfigManager.getInstance();
-    const assertPermission = (permission: PluginPermission, action: string) => {
-      if (!plugin.definition.permissions?.includes(permission)) {
-        throw new Error(
-          `Plugin '${plugin.definition.name}' requires permission '${permission}' to ${action}`,
-        );
-      }
-    };
 
     const requireRadioCapabilitySnapshot = () => {
       if (!deps.getRadioCapabilitySnapshot) {
@@ -810,7 +850,7 @@ export class PluginContextFactory {
       }
     };
 
-    return {
+    const radio: PluginContextBase['radio'] = Object.freeze({
       get frequency() {
         return getEffectiveFrequency();
       },
@@ -828,58 +868,68 @@ export class PluginContextFactory {
       get isConnected() {
         return deps.getRadioConnected();
       },
-      async setFrequency(freq: number) {
-        assertPermission('radio:control', 'set radio frequency');
-        const result = await deps.setRadioFrequency(freq);
-        if (result === false) {
-          throw new Error('Failed to set radio frequency');
-        }
-      },
-      capabilities: {
+    });
+
+    const capabilities: Omit<RuntimePluginContext, keyof PluginContextBase> = {};
+    capabilities.radioCapabilities = {
         getSnapshot() {
-          assertPermission('radio:read', 'read radio capabilities');
           return requireRadioCapabilitySnapshot()();
         },
         getState(id: string) {
-          assertPermission('radio:read', 'read radio capability state');
           return requireRadioCapabilitySnapshot()().capabilities.find((capability) => capability.id === id) ?? null;
         },
         async refresh() {
-          assertPermission('radio:read', 'refresh radio capabilities');
           if (!deps.refreshRadioCapabilities) {
             throw new Error('Radio capability refresh API is unavailable in this host');
           }
           return deps.refreshRadioCapabilities();
         },
-        async write(payload: WriteCapabilityPayload) {
-          assertPermission('radio:control', 'write radio capabilities');
-          if (!deps.writeRadioCapability) {
-            throw new Error('Radio capability write API is unavailable in this host');
-          }
-          await deps.writeRadioCapability(WriteCapabilityPayloadSchema.parse(payload));
-        },
-      },
-      power: {
+    };
+    capabilities.radioPower = {
         async getSupport(profileId?: string) {
-          assertPermission('radio:read', 'read radio power support');
           if (!deps.getRadioPowerSupport) {
             throw new Error('Radio power support API is unavailable in this host');
           }
           return deps.getRadioPowerSupport(profileId);
         },
         getState(profileId?: string) {
-          assertPermission('radio:read', 'read radio power state');
           return resolvePowerStateGetter()(profileId);
         },
-        async set(state: RadioPowerTarget, options?: { profileId?: string; autoEngine?: boolean }) {
-          assertPermission('radio:power', 'control radio power');
+    };
+    capabilities.radioCommands = {
+        async submit(command) {
+          if (!deps.submitRadioMaintenanceCommand) {
+            throw new Error('Host radio maintenance coordinator is unavailable');
+          }
+          if (command.type === 'switch-band'
+              && command.autoTune === true
+              && !plugin.definition.permissions?.includes('radio:tuner-control')) {
+            throw new Error('switch-band autoTune requires radio:tuner-control');
+          }
+          await deps.submitRadioMaintenanceCommand(command);
+        },
+    };
+    capabilities.radioTunerCommands = {
+        async submit(command) {
+          if (!deps.submitRadioMaintenanceCommand) {
+            throw new Error('Host radio maintenance coordinator is unavailable');
+          }
+          await deps.submitRadioMaintenanceCommand(command);
+        },
+    };
+    capabilities.radioPowerCommands = {
+        async submit(command) {
           if (!deps.setRadioPower) {
             throw new Error('Radio power control API is unavailable in this host');
           }
-          return deps.setRadioPower(RadioPowerTargetSchema.parse(state), options);
+          return deps.setRadioPower(
+            RadioPowerTargetSchema.parse(command.state),
+            command.options,
+          );
         },
-      },
     };
+
+    return { radio, capabilities };
   }
 
   private createLogbookAccess(
@@ -993,7 +1043,7 @@ export class PluginContextFactory {
       return callsign?.trim() ? callsign : null;
     };
 
-    return {
+    const fullAccess = {
       // === Original read-only helpers ===
 
       async hasWorked(callsign: string, options?: { anyBand?: boolean }) {
@@ -1055,11 +1105,51 @@ export class PluginContextFactory {
         await createCallsignAccess(callsign).notifyUpdated(operatorId);
       },
     };
+
+    return {
+      full: fullAccess,
+      read: {
+        hasWorked: fullAccess.hasWorked,
+        hasWorkedDXCC: fullAccess.hasWorkedDXCC,
+        hasWorkedGrid: fullAccess.hasWorkedGrid,
+        queryQSOs: fullAccess.queryQSOs,
+        countQSOs: fullAccess.countQSOs,
+        forCallsign(callsign: string) {
+          const access = createCallsignAccess(callsign);
+          return {
+            callsign: access.callsign,
+            getLogBookId: access.getLogBookId,
+            queryQSOs: access.queryQSOs,
+            countQSOs: access.countQSOs,
+            getStatistics: access.getStatistics,
+          };
+        },
+      },
+      commands: {
+        addQSO: fullAccess.addQSO,
+        updateQSO: fullAccess.updateQSO,
+        notifyUpdated: fullAccess.notifyUpdated,
+        forCallsign(callsign: string) {
+          const access = createCallsignAccess(callsign);
+          return {
+            callsign: access.callsign,
+            addQSO: access.addQSO,
+            updateQSO: access.updateQSO,
+            notifyUpdated: access.notifyUpdated,
+          };
+        },
+      },
+    };
   }
 
   private createBandAccess(operatorId: string | undefined) {
     const deps = this.deps;
-    const getOtherOperatorAudioFrequenciesHz = () => this.getOtherOperatorAudioFrequenciesHz(operatorId);
+    const getOtherOperatorAudioFrequenciesHz = (slotId: string) => (
+      this.getOtherOperatorAudioFrequenciesHz(operatorId, slotId)
+    );
+    const reserveOperatorAudioFrequency = (slotId: string, frequency: number) => {
+      this.reserveOperatorAudioFrequency(operatorId, slotId, frequency);
+    };
     return {
       getActiveCallers() {
         // 从最新 SlotPack 中提取 CQ 消息
@@ -1091,9 +1181,13 @@ export class PluginContextFactory {
           options?.minHz,
           options?.maxHz,
           options?.guardHz,
-          getOtherOperatorAudioFrequenciesHz(),
+          getOtherOperatorAudioFrequenciesHz(slotId),
         );
-        return typeof result === 'number' && Number.isFinite(result) ? result : null;
+        if (typeof result !== 'number' || !Number.isFinite(result)) {
+          return null;
+        }
+        reserveOperatorAudioFrequency(slotId, result);
+        return result;
       },
       evaluateAutoTargetEligibility(message: import('@tx5dr/contracts').ParsedFT8Message) {
         const operatorCallsign = operatorId

--- a/packages/server/src/plugin/PluginHookDispatcher.ts
+++ b/packages/server/src/plugin/PluginHookDispatcher.ts
@@ -4,30 +4,29 @@ import type {
   AutoCallExecutionPlan,
   AutoCallExecutionRequest,
   AutoCallProposal,
-  PluginContext,
+  RuntimePluginContext,
   PluginHooks,
   ScoredCandidate,
 } from '@tx5dr/plugin-api';
 import type { PluginInstance } from './types.js';
 import { PluginErrorTracker } from './PluginErrorTracker.js';
 import { createLogger } from '../utils/logger.js';
+import { PluginInvocationExpiredError, PluginInvocationGuard } from './PluginInvocationGuard.js';
 
 const logger = createLogger('PluginHookDispatcher');
 
-const HOOK_TIMEOUT_MS = 200;
+const DECISION_HOOK_TIMEOUT_MS = 200;
+// Observation hooks may legitimately flush network telemetry. They remain
+// revocable, but their I/O must not inherit the decision-path latency budget.
+const BROADCAST_HOOK_TIMEOUT_MS = 5_000;
+
+function isExpectedInvocationCancellation(error: unknown): boolean {
+  return error instanceof PluginInvocationExpiredError
+    || (error instanceof Error && error.message.startsWith('PLUGIN_INVOCATION_EXPIRED:'));
+}
 
 /** Extracts the non-undefined hook function type for a given hook name. */
 type HookFn<K extends keyof PluginHooks> = NonNullable<PluginHooks[K]>;
-
-function withTimeout<T>(promise: Promise<T> | T, ms: number): Promise<T> {
-  if (!(promise instanceof Promise)) return Promise.resolve(promise);
-  return Promise.race([
-    promise,
-    new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error(`Hook timeout after ${ms}ms`)), ms)
-    ),
-  ]);
-}
 
 export interface AutoCallProposalResult {
   pluginName: string;
@@ -49,6 +48,7 @@ export class PluginHookDispatcher {
     private getActiveInstances: (operatorId: string) => PluginInstance[],
     private getStrategyInstance: (operatorId: string) => PluginInstance | undefined,
     onAutoDisable: (pluginName: string, reason: string) => void,
+    private readonly invocationGuard = new PluginInvocationGuard(),
   ) {
     this.errorTracker = new PluginErrorTracker(onAutoDisable);
   }
@@ -59,7 +59,7 @@ export class PluginHookDispatcher {
     operatorId: string,
     slotInfo: import('@tx5dr/contracts').SlotInfo,
     messages: ParsedFT8Message[],
-    getCtx: (instance: PluginInstance) => PluginContext,
+    getCtx: (instance: PluginInstance) => RuntimePluginContext,
   ): Promise<AutoCallProposalResult[]> {
     const proposals: AutoCallProposalResult[] = [];
 
@@ -75,9 +75,11 @@ export class PluginHookDispatcher {
 
       try {
         const ctx = getCtx(instance);
-        const proposal = await withTimeout(
-          Promise.resolve(hook(slotInfo, messages, ctx)),
-          HOOK_TIMEOUT_MS,
+        const proposal = await this.invocationGuard.invoke(
+          instance,
+          'onAutoCallCandidate',
+          () => hook(slotInfo, messages, ctx as never),
+          { timeoutMs: DECISION_HOOK_TIMEOUT_MS },
         );
 
         if (proposal == null) {
@@ -113,7 +115,7 @@ export class PluginHookDispatcher {
     operatorId: string,
     request: AutoCallExecutionRequest,
     initialPlan: AutoCallExecutionPlan,
-    getCtx: (instance: PluginInstance) => PluginContext,
+    getCtx: (instance: PluginInstance) => RuntimePluginContext,
   ): Promise<AutoCallExecutionPlan> {
     let plan = initialPlan;
 
@@ -129,9 +131,11 @@ export class PluginHookDispatcher {
 
       try {
         const ctx = getCtx(instance);
-        const output = await withTimeout(
-          Promise.resolve(hook(request, plan, ctx)),
-          HOOK_TIMEOUT_MS,
+        const output = await this.invocationGuard.invoke(
+          instance,
+          'onConfigureAutoCallExecution',
+          () => hook(request, plan, ctx as never),
+          { timeoutMs: DECISION_HOOK_TIMEOUT_MS },
         );
 
         if (output == null) {
@@ -158,7 +162,7 @@ export class PluginHookDispatcher {
   async dispatchFilterCandidates(
     operatorId: string,
     candidates: ParsedFT8Message[],
-    getCtx: (instance: PluginInstance) => PluginContext,
+    getCtx: (instance: PluginInstance) => RuntimePluginContext,
   ): Promise<ParsedFT8Message[]> {
     let result = candidates;
     for (const instance of this.getActiveInstances(operatorId)) {
@@ -166,9 +170,11 @@ export class PluginHookDispatcher {
       if (!hook || this.errorTracker.isDisabled(instance)) continue;
       try {
         const ctx = getCtx(instance);
-        const output = await withTimeout(
-          Promise.resolve(hook(result, ctx)),
-          HOOK_TIMEOUT_MS,
+        const output = await this.invocationGuard.invoke(
+          instance,
+          'onFilterCandidates',
+          () => hook(result, ctx as never),
+          { timeoutMs: DECISION_HOOK_TIMEOUT_MS },
         );
         if (!Array.isArray(output)) {
           logger.warn(`Plugin ${instance.plugin.definition.name} onFilterCandidates returned a non-array value, keeping previous candidates`);
@@ -189,7 +195,7 @@ export class PluginHookDispatcher {
   async dispatchScoreCandidates(
     operatorId: string,
     candidates: ScoredCandidate[],
-    getCtx: (instance: PluginInstance) => PluginContext,
+    getCtx: (instance: PluginInstance) => RuntimePluginContext,
   ): Promise<ScoredCandidate[]> {
     let result = candidates;
     for (const instance of this.getActiveInstances(operatorId)) {
@@ -197,9 +203,11 @@ export class PluginHookDispatcher {
       if (!hook || this.errorTracker.isDisabled(instance)) continue;
       try {
         const ctx = getCtx(instance);
-        const output = await withTimeout(
-          Promise.resolve(hook(result, ctx)),
-          HOOK_TIMEOUT_MS,
+        const output = await this.invocationGuard.invoke(
+          instance,
+          'onScoreCandidates',
+          () => hook(result, ctx as never),
+          { timeoutMs: DECISION_HOOK_TIMEOUT_MS },
         );
         if (Array.isArray(output)) {
           result = output;
@@ -217,8 +225,8 @@ export class PluginHookDispatcher {
   async dispatchExclusive<K extends keyof PluginHooks, R>(
     operatorId: string,
     hookName: K,
-    executor: (hook: HookFn<K>, ctx: PluginContext) => Promise<R>,
-    getCtx: (instance: PluginInstance) => PluginContext,
+    executor: (hook: HookFn<K>, ctx: RuntimePluginContext) => Promise<R>,
+    getCtx: (instance: PluginInstance) => RuntimePluginContext,
   ): Promise<R | null> {
     const instance = this.getStrategyInstance(operatorId);
     if (!instance || this.errorTracker.isDisabled(instance)) return null;
@@ -228,7 +236,12 @@ export class PluginHookDispatcher {
 
     try {
       const ctx = getCtx(instance);
-      const result = await withTimeout(executor(hook, ctx), HOOK_TIMEOUT_MS);
+      const result = await this.invocationGuard.invoke(
+        instance,
+        String(hookName),
+        () => executor(hook, ctx),
+        { timeoutMs: DECISION_HOOK_TIMEOUT_MS },
+      );
       this.errorTracker.resetErrors(instance, hookName as string);
       return result;
     } catch (err) {
@@ -242,8 +255,8 @@ export class PluginHookDispatcher {
   async dispatchBroadcast<K extends keyof PluginHooks>(
     operatorId: string,
     hookName: K,
-    executor: (hook: HookFn<K>, ctx: PluginContext) => void | Promise<void>,
-    getCtx: (instance: PluginInstance) => PluginContext,
+    executor: (hook: HookFn<K>, ctx: RuntimePluginContext) => void | Promise<void>,
+    getCtx: (instance: PluginInstance) => RuntimePluginContext,
   ): Promise<void> {
     const instances = this.getActiveInstances(operatorId);
     await Promise.allSettled(
@@ -253,12 +266,44 @@ export class PluginHookDispatcher {
         if (!hook) return;
         try {
           const ctx = getCtx(instance);
-          await withTimeout(Promise.resolve(executor(hook, ctx)), HOOK_TIMEOUT_MS);
+          await this.invocationGuard.invoke(
+            instance,
+            String(hookName),
+            () => executor(hook, ctx),
+            { timeoutMs: BROADCAST_HOOK_TIMEOUT_MS },
+          );
           this.errorTracker.resetErrors(instance, hookName as string);
         } catch (err) {
-          this.errorTracker.recordError(instance, hookName as string, err);
+          if (!isExpectedInvocationCancellation(err)) {
+            this.errorTracker.recordError(instance, hookName as string, err);
+          }
         }
       }),
     );
+  }
+
+  async dispatchInstance<K extends keyof PluginHooks, R>(
+    instance: PluginInstance,
+    hookName: K,
+    executor: (hook: HookFn<K>, ctx: RuntimePluginContext) => R | Promise<R>,
+  ): Promise<R | null> {
+    if (instance.lifecycle !== 'active' || this.errorTracker.isDisabled(instance)) return null;
+    const hook = instance.plugin.definition.hooks?.[hookName] as HookFn<K> | undefined;
+    if (!hook) return null;
+    try {
+      const result = await this.invocationGuard.invoke(
+        instance,
+        String(hookName),
+        () => executor(hook, instance.ctx),
+        { timeoutMs: BROADCAST_HOOK_TIMEOUT_MS },
+      );
+      this.errorTracker.resetErrors(instance, String(hookName));
+      return result;
+    } catch (error) {
+      if (!isExpectedInvocationCancellation(error)) {
+        this.errorTracker.recordError(instance, String(hookName), error);
+      }
+      return null;
+    }
   }
 }

--- a/packages/server/src/plugin/PluginInvocationGuard.ts
+++ b/packages/server/src/plugin/PluginInvocationGuard.ts
@@ -1,0 +1,388 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { RuntimePluginContext } from '@tx5dr/plugin-api';
+import type { PluginInstance } from './types.js';
+
+export class PluginInvocationExpiredError extends Error {
+  readonly code = 'PLUGIN_INVOCATION_EXPIRED';
+
+  constructor(message = 'Plugin invocation is no longer allowed to perform host operations') {
+    super(message);
+    this.name = 'PluginInvocationExpiredError';
+  }
+}
+
+interface InvocationState {
+  invocationId: number;
+  instanceGeneration: number;
+  pluginName: string;
+  operation: string;
+  controller: AbortController;
+  active: boolean;
+  allowedContextRoots?: ReadonlySet<keyof RuntimePluginContext>;
+}
+
+interface InvocationOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  abortGraceMs?: number;
+  drainOnExternalAbortMs?: number;
+  allowedContextRoots?: ReadonlySet<keyof RuntimePluginContext>;
+}
+
+export interface HungPluginInvocation {
+  instance: PluginInstance;
+  invocationId: number;
+  operation: string;
+  elapsedAfterAbortMs: number;
+}
+
+export interface CurrentPluginInvocation {
+  invocationId: number;
+  instanceGeneration: number;
+  signal: AbortSignal;
+}
+
+const PROTECTED_CONTEXT_KEYS = new Set<keyof RuntimePluginContext>([
+  'updateConfig',
+  'store',
+  'timers',
+  'operator',
+  'operatorCommands',
+  'radio',
+  'radioCapabilities',
+  'radioCommands',
+  'radioTunerCommands',
+  'radioPower',
+  'radioPowerCommands',
+  'logbook',
+  'ui',
+  'files',
+  'settings',
+  'network',
+  'eventBus',
+  'logbookSync',
+  'fetch',
+  'hostDependencies',
+]);
+
+/** Revokes host capabilities when a hook/runtime continuation outlives its invocation. */
+export class PluginInvocationGuard {
+  private readonly storage = new AsyncLocalStorage<InvocationState>();
+  private nextInvocationId = 0;
+  private readonly activeByInstance = new Map<number, Set<InvocationState>>();
+  private readonly proxyCacheByInstance = new WeakMap<
+    PluginInstance,
+    WeakMap<object, Map<string, object>>
+  >();
+
+  constructor(
+    private readonly onHungInvocation?: (details: HungPluginInvocation) => void,
+  ) {}
+
+  wrapContext(context: RuntimePluginContext, instance: PluginInstance): RuntimePluginContext {
+    const cached = this.getCachedProxy(instance, context, '__context__');
+    if (cached) return cached as RuntimePluginContext;
+
+    const proxy = new Proxy(context, {
+      get: (target, property, receiver) => {
+        const value = Reflect.get(target, property, receiver);
+        if (!PROTECTED_CONTEXT_KEYS.has(property as keyof RuntimePluginContext) || value == null) {
+          return value;
+        }
+        return this.wrapProtectedValue(value, instance, property as keyof RuntimePluginContext);
+      },
+      getOwnPropertyDescriptor: (target, property) => this.wrapProtectedDescriptor(
+        Reflect.getOwnPropertyDescriptor(target, property),
+        instance,
+        property as keyof RuntimePluginContext,
+      ),
+    });
+    this.cacheProxy(instance, context, '__context__', proxy);
+    return proxy;
+  }
+
+  async invoke<T>(
+    instance: PluginInstance,
+    operation: string,
+    callback: (signal: AbortSignal) => T | Promise<T>,
+    options: InvocationOptions = {},
+  ): Promise<T> {
+    const state: InvocationState = {
+      invocationId: ++this.nextInvocationId,
+      instanceGeneration: instance.generation,
+      pluginName: instance.plugin.definition.name,
+      operation,
+      controller: new AbortController(),
+      active: true,
+      allowedContextRoots: options.allowedContextRoots,
+    };
+    const active = this.activeByInstance.get(instance.generation) ?? new Set<InvocationState>();
+    active.add(state);
+    this.activeByInstance.set(instance.generation, active);
+
+    let timeout: NodeJS.Timeout | undefined;
+    let abortWatchdog: NodeJS.Timeout | undefined;
+    let removeExternalAbort: (() => void) | undefined;
+    let executionSettled = false;
+    const revoke = (reason: unknown) => {
+      if (!state.active) return;
+      state.active = false;
+      state.controller.abort(reason);
+      const abortGraceMs = options.abortGraceMs ?? 1_000;
+      if (!executionSettled && this.onHungInvocation && abortGraceMs >= 0) {
+        abortWatchdog = setTimeout(() => {
+          if (!executionSettled) {
+            this.onHungInvocation?.({
+              instance,
+              invocationId: state.invocationId,
+              operation,
+              elapsedAfterAbortMs: abortGraceMs,
+            });
+          }
+        }, abortGraceMs);
+      }
+    };
+    if (options.signal) {
+      const onAbort = () => revoke(options.signal?.reason ?? 'external invocation abort');
+      if (options.signal.aborted) {
+        onAbort();
+      } else {
+        options.signal.addEventListener('abort', onAbort, { once: true });
+        removeExternalAbort = () => options.signal?.removeEventListener('abort', onAbort);
+      }
+    }
+
+    try {
+      const execution = this.storage.run(state, async () => callback(state.controller.signal));
+      void execution.finally(() => {
+        executionSettled = true;
+        if (abortWatchdog) clearTimeout(abortWatchdog);
+      }).catch(() => undefined);
+      const revoked = new Promise<never>((_, reject) => {
+        state.controller.signal.addEventListener('abort', () => {
+          const rejectRevoked = () => reject(state.controller.signal.reason instanceof Error
+            ? state.controller.signal.reason
+            : new PluginInvocationExpiredError(String(state.controller.signal.reason ?? 'Plugin invocation revoked')));
+          if (options.signal?.aborted && options.drainOnExternalAbortMs !== undefined) {
+            setTimeout(rejectRevoked, options.drainOnExternalAbortMs);
+          } else {
+            rejectRevoked();
+          }
+        }, { once: true });
+      });
+      if (options.timeoutMs === undefined) {
+        return await Promise.race([execution, revoked]);
+      }
+
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          const error = new PluginInvocationExpiredError(
+            `${state.pluginName} ${operation} timed out after ${options.timeoutMs}ms`,
+          );
+          revoke(error);
+          reject(error);
+        }, options.timeoutMs);
+      });
+      return await Promise.race([execution, revoked, timeoutPromise]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      removeExternalAbort?.();
+      revoke('plugin invocation completed');
+      active.delete(state);
+      if (active.size === 0) this.activeByInstance.delete(instance.generation);
+    }
+  }
+
+  invokeSync<T>(instance: PluginInstance, operation: string, callback: () => T): T {
+    const state: InvocationState = {
+      invocationId: ++this.nextInvocationId,
+      instanceGeneration: instance.generation,
+      pluginName: instance.plugin.definition.name,
+      operation,
+      controller: new AbortController(),
+      active: true,
+    };
+    const active = this.activeByInstance.get(instance.generation) ?? new Set<InvocationState>();
+    active.add(state);
+    this.activeByInstance.set(instance.generation, active);
+    try {
+      const result = this.storage.run(state, callback);
+      if (result instanceof Promise) {
+        throw new Error(`Plugin invocation ${operation} unexpectedly returned a Promise from a synchronous host entry point`);
+      }
+      return result;
+    } finally {
+      state.active = false;
+      state.controller.abort('plugin invocation completed');
+      active.delete(state);
+      if (active.size === 0) this.activeByInstance.delete(instance.generation);
+    }
+  }
+
+  revokeInstance(instance: PluginInstance, reason: string): void {
+    for (const state of this.activeByInstance.get(instance.generation) ?? []) {
+      state.active = false;
+      state.controller.abort(reason);
+    }
+    this.activeByInstance.delete(instance.generation);
+  }
+
+  assertCurrent(instance: PluginInstance, root?: keyof RuntimePluginContext): void {
+    const state = this.storage.getStore();
+    if (!state
+        || !state.active
+        || state.controller.signal.aborted
+        || state.instanceGeneration !== instance.generation) {
+      throw new PluginInvocationExpiredError();
+    }
+    if (root && state.allowedContextRoots && !state.allowedContextRoots.has(root)) {
+      throw new PluginInvocationExpiredError(
+        `Plugin invocation cannot use '${String(root)}' during ${state.operation}`,
+      );
+    }
+  }
+
+  captureCurrent(instance: PluginInstance): CurrentPluginInvocation {
+    this.assertCurrent(instance);
+    const state = this.storage.getStore()!;
+    return {
+      invocationId: state.invocationId,
+      instanceGeneration: state.instanceGeneration,
+      signal: state.controller.signal,
+    };
+  }
+
+  assertCaptured(instance: PluginInstance, invocation: CurrentPluginInvocation): void {
+    this.assertCurrent(instance);
+    const state = this.storage.getStore()!;
+    if (state.invocationId !== invocation.invocationId
+        || state.instanceGeneration !== invocation.instanceGeneration
+        || invocation.signal.aborted) {
+      throw new PluginInvocationExpiredError('Plugin invocation-scoped capability has expired');
+    }
+  }
+
+  private wrapProtectedValue<T>(
+    value: T,
+    instance: PluginInstance,
+    root: keyof RuntimePluginContext,
+  ): T {
+    if ((typeof value !== 'object' || value === null) && typeof value !== 'function') {
+      return value;
+    }
+    if (typeof value === 'function') {
+      return ((...args: unknown[]) => {
+        this.assertCurrent(instance, root);
+        return this.wrapProtectedResult(
+          Reflect.apply(value as (...values: unknown[]) => unknown, undefined, args),
+          instance,
+          root,
+        );
+      }) as T;
+    }
+
+    const object = value as object;
+    const cached = this.getCachedProxy(instance, object, String(root));
+    if (cached) return cached as T;
+    const proxy = new Proxy(object, {
+      get: (target, property, receiver) => {
+        this.assertCurrent(instance, root);
+        const child = Reflect.get(target, property, receiver);
+        if (typeof child === 'function') {
+          return (...args: unknown[]) => {
+            this.assertCurrent(instance, root);
+            const result = Reflect.apply(child, target, args);
+            return this.wrapProtectedResult(result, instance, root);
+          };
+        }
+        if (child && typeof child === 'object') {
+          return this.wrapProtectedValue(child, instance, root);
+        }
+        return child;
+      },
+      getOwnPropertyDescriptor: (target, property) => this.wrapProtectedDescriptor(
+        Reflect.getOwnPropertyDescriptor(target, property),
+        instance,
+        root,
+      ),
+    });
+    this.cacheProxy(instance, object, String(root), proxy);
+    return proxy as T;
+  }
+
+  private wrapProtectedResult<T>(
+    result: T,
+    instance: PluginInstance,
+    root: keyof RuntimePluginContext,
+  ): T {
+    if (result instanceof Promise) {
+      return result.then((value) => (
+        value && (typeof value === 'object' || typeof value === 'function')
+          ? this.wrapProtectedValue(value, instance, root)
+          : value
+      )) as T;
+    }
+    if (result && (typeof result === 'object' || typeof result === 'function')) {
+      return this.wrapProtectedValue(result, instance, root);
+    }
+    return result;
+  }
+
+  private wrapProtectedDescriptor(
+    descriptor: PropertyDescriptor | undefined,
+    instance: PluginInstance,
+    root: keyof RuntimePluginContext,
+  ): PropertyDescriptor | undefined {
+    if (!descriptor) return descriptor;
+    // Proxy invariants require immutable descriptors to be reported verbatim.
+    // Sensitive command ports are intentionally left configurable on their
+    // host-owned wrapper objects so they still pass through the guarded path.
+    if (descriptor.configurable === false
+        && ('value' in descriptor ? descriptor.writable === false : true)) {
+      return descriptor;
+    }
+    const wrapped = { ...descriptor };
+    if ('value' in wrapped) {
+      wrapped.value = this.wrapProtectedValue(wrapped.value, instance, root);
+    }
+    if (wrapped.get) {
+      const getter = wrapped.get;
+      wrapped.get = () => {
+        this.assertCurrent(instance, root);
+        return this.wrapProtectedResult(getter(), instance, root);
+      };
+    }
+    if (wrapped.set) {
+      const setter = wrapped.set;
+      wrapped.set = (value) => {
+        this.assertCurrent(instance, root);
+        setter(value);
+      };
+    }
+    return wrapped;
+  }
+
+  private getCachedProxy(
+    instance: PluginInstance,
+    target: object,
+    root: string,
+  ): object | undefined {
+    return this.proxyCacheByInstance.get(instance)?.get(target)?.get(root);
+  }
+
+  private cacheProxy(
+    instance: PluginInstance,
+    target: object,
+    root: string,
+    proxy: object,
+  ): void {
+    let targets = this.proxyCacheByInstance.get(instance);
+    if (!targets) {
+      targets = new WeakMap<object, Map<string, object>>();
+      this.proxyCacheByInstance.set(instance, targets);
+    }
+    const roots = targets.get(target) ?? new Map<string, object>();
+    roots.set(root, proxy);
+    targets.set(target, roots);
+  }
+}

--- a/packages/server/src/plugin/PluginLoader.ts
+++ b/packages/server/src/plugin/PluginLoader.ts
@@ -1,4 +1,7 @@
-import type { PluginDefinition } from '@tx5dr/plugin-api';
+import {
+  PLUGIN_COMMAND_CAPABILITY_PERMISSIONS,
+  type AnyPluginDefinition,
+} from '@tx5dr/plugin-api';
 import type { PluginPanelDescriptor, PluginRuntimeLogEntry, PluginUIPageDescriptor } from '@tx5dr/contracts';
 import { PluginManifestSchema } from '@tx5dr/contracts';
 import type { LoadedPlugin } from './types.js';
@@ -38,8 +41,9 @@ class PluginLoadError extends Error {
   }
 }
 
-export function validatePluginDefinition(def: PluginDefinition): void {
+export function validatePluginDefinition(def: AnyPluginDefinition): void {
   const manifest = PluginManifestSchema.parse({
+    apiVersion: def.apiVersion,
     name: def.name,
     version: def.version,
     type: def.type,
@@ -57,6 +61,15 @@ export function validatePluginDefinition(def: PluginDefinition): void {
   if (manifest.type === 'strategy' && typeof def.createStrategyRuntime !== 'function') {
     throw new Error('Strategy plugins must provide createStrategyRuntime(ctx)');
   }
+  const requiresCapabilityApiV2 = manifest.permissions?.some((permission) => (
+    PLUGIN_COMMAND_CAPABILITY_PERMISSIONS.includes(
+      permission as (typeof PLUGIN_COMMAND_CAPABILITY_PERMISSIONS)[number],
+    )
+  )) === true;
+  if ((manifest.type === 'strategy' || requiresCapabilityApiV2)
+      && manifest.apiVersion !== 2) {
+    throw new Error('PLUGIN_API_INCOMPATIBLE: strategy and privileged command plugins require apiVersion: 2');
+  }
   if (manifest.type === 'utility' && def.createStrategyRuntime !== undefined) {
     throw new Error('Utility plugins must not provide createStrategyRuntime(ctx)');
   }
@@ -64,8 +77,9 @@ export function validatePluginDefinition(def: PluginDefinition): void {
     if (manifest.instanceScope === 'global') {
       throw new Error('Plugins with permission "operator:transmit-control" must use operator instance scope');
     }
-    if (typeof def.isAutoCallEnabled !== 'function') {
-      throw new Error('Plugins with permission "operator:transmit-control" must implement isAutoCallEnabled(ctx): boolean');
+    if (typeof def.isTransmitControlEnabled !== 'function'
+        && typeof def.isAutoCallEnabled !== 'function') {
+      throw new Error('Plugins with permission "operator:transmit-control" must implement isTransmitControlEnabled(ctx) or isAutoCallEnabled(ctx)');
     }
   }
 
@@ -116,7 +130,7 @@ export function validatePluginDefinition(def: PluginDefinition): void {
     }
 
     const hooks = def.hooks;
-    const unsupportedGlobalHooks: Array<keyof NonNullable<PluginDefinition['hooks']>> = [
+    const unsupportedGlobalHooks: Array<keyof NonNullable<AnyPluginDefinition['hooks']>> = [
       'onAutoCallCandidate',
       'onConfigureAutoCallExecution',
       'onFilterCandidates',
@@ -134,6 +148,50 @@ export function validatePluginDefinition(def: PluginDefinition): void {
       throw new Error(`Global plugin instances must not implement hook "${activeUnsupportedGlobalHook}"`);
     }
   }
+}
+
+function deepFreezeDefinition<T>(value: T, seen = new WeakSet<object>()): T {
+  if (!value || typeof value !== 'object' || seen.has(value as object)) {
+    return value;
+  }
+  seen.add(value as object);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreezeDefinition(child, seen);
+  }
+  return Object.freeze(value);
+}
+
+/** Creates the immutable, host-owned definition used after validation. */
+export function canonicalizePluginDefinition(def: AnyPluginDefinition): AnyPluginDefinition {
+  validatePluginDefinition(def);
+  const manifest = PluginManifestSchema.parse({
+    apiVersion: def.apiVersion,
+    name: def.name,
+    version: def.version,
+    type: def.type,
+    instanceScope: def.instanceScope,
+    description: def.description,
+    permissions: def.permissions,
+    settings: def.settings,
+    quickActions: def.quickActions,
+    quickSettings: def.quickSettings,
+    panels: def.panels,
+    storage: def.storage,
+    ui: def.ui,
+  });
+  const canonical: AnyPluginDefinition = {
+    ...manifest,
+    permissions: manifest.permissions
+      ? [...new Set(manifest.permissions)]
+      : undefined,
+    createStrategyRuntime: def.createStrategyRuntime,
+    onLoad: def.onLoad,
+    onUnload: def.onUnload,
+    hooks: def.hooks ? { ...def.hooks } : undefined,
+    isTransmitControlEnabled: def.isTransmitControlEnabled,
+    isAutoCallEnabled: def.isAutoCallEnabled,
+  };
+  return deepFreezeDefinition(canonical);
 }
 
 function validatePluginUiPaths(manifest: ReturnType<typeof PluginManifestSchema.parse>): void {
@@ -312,12 +370,12 @@ export class PluginLoader {
         },
       );
     }
-    const definition: PluginDefinition = mod.default ?? mod;
-    const definitionName = definition && typeof definition === 'object' && typeof (definition as { name?: unknown }).name === 'string'
-      ? (definition as { name: string }).name
+    const exportedDefinition: AnyPluginDefinition = mod.default ?? mod;
+    const definitionName = exportedDefinition && typeof exportedDefinition === 'object' && typeof (exportedDefinition as { name?: unknown }).name === 'string'
+      ? (exportedDefinition as { name: string }).name
       : undefined;
 
-    if (!definition || typeof definition !== 'object') {
+    if (!exportedDefinition || typeof exportedDefinition !== 'object') {
       throw new PluginLoadError(
         'invalid_export',
         'Plugin entry must export a default PluginDefinition object',
@@ -329,8 +387,9 @@ export class PluginLoader {
       );
     }
 
+    let definition: AnyPluginDefinition;
     try {
-      validatePluginDefinition(definition);
+      definition = canonicalizePluginDefinition(exportedDefinition);
     } catch (err) {
       throw new PluginLoadError(
         'validate_error',
@@ -409,7 +468,7 @@ export class PluginLoader {
   }
 
   private async validatePluginUiAssets(
-    definition: PluginDefinition,
+    definition: AnyPluginDefinition,
     dirPath: string,
   ): Promise<void> {
     const pages = definition.ui?.pages ?? [];

--- a/packages/server/src/plugin/PluginManager.ts
+++ b/packages/server/src/plugin/PluginManager.ts
@@ -16,7 +16,10 @@ import type {
   StrategyRuntimeContext,
 } from '@tx5dr/contracts';
 import type {
-  PluginContext,
+  RuntimePluginContext,
+  StrategyPluginContext,
+  PluginOperatorCommand,
+  PluginOperatorCommandResult,
   PluginUIRequestContext,
   PluginUIInstanceTarget,
   QSOFailureInfo,
@@ -27,13 +30,14 @@ import type {
 import type { EventEmitter } from 'eventemitter3';
 import {
   PluginLoader,
+  canonicalizePluginDefinition,
   type PluginLoaderRuntimeLogEvent,
-  validatePluginDefinition,
 } from './PluginLoader.js';
 import { ConfigManager } from '../config/config-manager.js';
 import { isUndecodedCallsignPlaceholder } from '@tx5dr/core';
 import { PluginDevWatcher } from './PluginDevWatcher.js';
 import { PluginHookDispatcher } from './PluginHookDispatcher.js';
+import { PluginInvocationGuard } from './PluginInvocationGuard.js';
 import { DecisionOrchestrator } from './DecisionOrchestrator.js';
 import { PluginContextFactory } from './PluginContextFactory.js';
 import { PluginEventBusHost } from './PluginEventBusHost.js';
@@ -54,6 +58,7 @@ import { readPluginSource } from './plugin-source.js';
 import { createLogger } from '../utils/logger.js';
 import { resolvePluginPaths } from './paths.js';
 import path from 'path';
+import { OperatorIntentCoordinator } from '../transmission/OperatorIntentCoordinator.js';
 
 const logger = createLogger('PluginManager');
 const GLOBAL_PLUGIN_SCOPE_ID = '__global__';
@@ -72,11 +77,14 @@ const PLUGIN_RUNTIME_LOG_HISTORY_LIMIT = 1000;
  */
 export class PluginManager {
   private static readonly MAX_PAGE_PUSH_QUEUE = 500;
+  private nextInstanceGeneration = 0;
   private loadedPlugins = new Map<string, LoadedPlugin>();
   // operatorId → Map<pluginName, PluginInstance>
   private instances = new Map<string, Map<string, PluginInstance>>();
   private globalInstances = new Map<string, PluginInstance>();
   private dispatcher!: PluginHookDispatcher;
+  private readonly invocationGuard: PluginInvocationGuard;
+  private readonly intentCoordinator: OperatorIntentCoordinator;
   private orchestrator!: DecisionOrchestrator;
   private contextFactory: PluginContextFactory;
   private loader: PluginLoader;
@@ -114,6 +122,15 @@ export class PluginManager {
   };
 
   constructor(private deps: PluginManagerDeps) {
+    this.intentCoordinator = deps.intentCoordinator ?? new OperatorIntentCoordinator({
+      abortGraceMs: 1_000,
+      onAbortTimeout: (token) => {
+        logger.error('Operator command did not stop after abort; automation remains blocked', token);
+      },
+    });
+    this.invocationGuard = new PluginInvocationGuard(({ instance, operation, elapsedAfterAbortMs }) => {
+      this.quarantineHungPluginInstance(instance, operation, elapsedAfterAbortMs);
+    });
     this.loader = new PluginLoader((event) => this.emitPluginRuntimeLog(event));
     this._logbookSyncHost = new LogbookSyncHost();
     this.pluginEventBusHost = new PluginEventBusHost(({ subscriber, message, error }) => {
@@ -130,10 +147,31 @@ export class PluginManager {
       });
     });
     deps.pluginEventBusHost = this.pluginEventBusHost;
+    deps.submitOperatorCommand = (operatorId, command, pluginName) => {
+      const instance = this.instances.get(operatorId)?.get(pluginName);
+      if (!instance
+          || instance.lifecycle !== 'active'
+          || instance.desiredLifecycle !== 'active') {
+        throw new Error('PLUGIN_INVOCATION_EXPIRED: plugin instance is not active');
+      }
+      return this.submitPluginOperatorCommand(instance, operatorId, command);
+    };
     // Wire the logbook sync registration callback so plugins can register
     // providers via ctx.logbookSync.register().
     deps.registerLogbookSyncProvider = (pluginName, provider) => {
-      this._logbookSyncHost.register(pluginName, provider);
+      const instance = this.globalInstances.get(pluginName);
+      if (!instance || instance.scope.kind !== 'global') {
+        throw new Error('PLUGIN_INVOCATION_EXPIRED: sync provider owner is unavailable');
+      }
+      this.invocationGuard.assertCurrent(instance, 'logbookSync');
+      this._logbookSyncHost.register(pluginName, provider, {
+        generation: instance.generation,
+        isCurrent: () => this.globalInstances.get(pluginName) === instance
+          && instance.desiredLifecycle === 'active'
+          && (instance.lifecycle === 'starting' || instance.lifecycle === 'active'),
+        invoke: (operation, callback) => this.invocationGuard.invoke(instance, operation, callback),
+        invokeSync: (operation, callback) => this.invocationGuard.invokeSync(instance, operation, callback),
+      });
     };
     deps.listPluginPageSessions = (pluginName, instanceTarget, pageId) =>
       this.pageSessions.listByPluginInstance(pluginName, instanceTarget, pageId);
@@ -149,6 +187,7 @@ export class PluginManager {
       (operatorId) => this.getActiveInstances(operatorId),
       (operatorId) => this.getStrategyInstance(operatorId),
       (pluginName, reason) => this.handleAutoDisable(pluginName, reason),
+      this.invocationGuard,
     );
     this.orchestrator = new DecisionOrchestrator({
       getOperators: deps.getOperators,
@@ -156,23 +195,72 @@ export class PluginManager {
       getCurrentMode: deps.getCurrentMode,
       getOperatorAutomationSnapshot: deps.getOperatorAutomationSnapshot,
       interruptOperatorTransmission: deps.interruptOperatorTransmission,
+      requestOperatorStrategyStop: deps.requestOperatorStrategyStop ?? (() => undefined),
+      transitionTargetReservation: deps.transitionTargetReservation,
+      releaseTargetReservation: deps.releaseTargetReservation,
       analyzeCallsignForOperator: deps.analyzeCallsignForOperator,
       resolveGrid: deps.resolveGrid,
       setOperatorAudioFrequency: deps.setOperatorAudioFrequency,
       isSnrPriorityEnabled: (operatorId) => this.isSnrPriorityEnabled(operatorId),
       isStoppedDirectCallAutoReplyEnabled: (operatorId) => this.isStoppedDirectCallAutoReplyEnabled(operatorId),
       getStrategyRuntime: (operatorId) => this.getStrategyRuntime(operatorId),
+      getStrategyRuntimeGeneration: (operatorId) => this.getStrategyInstance(operatorId)?.generation,
+      invokeStrategyRuntime: (operatorId, operation, callback, options) =>
+        this.invokeStrategyRuntime(operatorId, operation, callback, options),
+      invokeStrategyRuntimeSync: (operatorId, operation, callback) =>
+        this.invokeStrategyRuntimeSync(operatorId, operation, callback),
       getCtxForInstance: (instance) => this.getCtxForInstance(instance),
       dispatcher: this.dispatcher,
       eventEmitter: deps.eventEmitter,
-      requestCall: (operatorId, callsign, lastMessage) => this.requestCall(operatorId, callsign, lastMessage),
+      requestCall: (operatorId, callsign, lastMessage, options) => this.requestCall(
+        operatorId,
+        callsign,
+        lastMessage,
+        { commandToken: options?.commandToken },
+      ),
       notifyQSOFail: (operatorId, info) => this.notifyQSOFail(operatorId, info),
       triggerReEncode: deps.triggerReEncode,
+      intentCoordinator: this.intentCoordinator,
     });
   }
 
   private get eventEmitter(): EventEmitter<DigitalRadioEngineEvents> {
     return this.deps.eventEmitter;
+  }
+
+  private quarantineHungPluginInstance(
+    instance: PluginInstance,
+    operation: string,
+    elapsedAfterAbortMs: number,
+  ): void {
+    if (instance.autoDisabled) return;
+    instance.autoDisabled = true;
+    instance.desiredLifecycle = 'inactive';
+    instance.lifecycleRevision += 1;
+    instance.lifecycle = 'quarantined';
+    instance.lastError = `Invocation ${operation} did not stop within ${elapsedAfterAbortMs}ms after abort`;
+    this.closeInstanceIngress(instance);
+    this.invocationGuard.revokeInstance(instance, 'plugin instance quarantined after abort timeout');
+    void instance.rawCtx.network?.udp.closeAll().catch(() => undefined);
+    if (instance.scope.kind === 'operator') {
+      this.deps.requestOperatorStrategyStop?.(
+        instance.scope.operatorId,
+        `plugin ${instance.plugin.definition.name} ignored abort`,
+      );
+    }
+    this.emitPluginRuntimeLog({
+      stage: 'activate',
+      level: 'error',
+      message: 'Plugin instance quarantined after ignoring AbortSignal',
+      pluginName: instance.plugin.definition.name,
+      details: {
+        operatorId: instance.scope.kind === 'operator' ? instance.scope.operatorId : undefined,
+        operation,
+        elapsedAfterAbortMs,
+        generation: instance.generation,
+      },
+    });
+    this.broadcastPluginList();
   }
 
   /** 允许在 initialize() 阶段设置正确的数据目录 */
@@ -264,8 +352,14 @@ export class PluginManager {
       const instance: PluginInstance = {
         plugin,
         scope: { kind: 'operator', operatorId },
-        ctx: null as unknown as PluginContext, // 先占位，下面赋值
+        ctx: null as unknown as RuntimePluginContext, // 先占位，下面赋值
+        rawCtx: null as unknown as RuntimePluginContext,
         runtime: undefined,
+        generation: ++this.nextInstanceGeneration,
+        lifecycle: 'inactive',
+        lifecycleTail: Promise.resolve(),
+        desiredLifecycle: 'inactive',
+        lifecycleRevision: 0,
         enabled,
         errorCounts: new Map(),
         autoDisabled: false,
@@ -277,8 +371,12 @@ export class PluginManager {
         'operator',
         pluginStorageDir,
         (timerId) => {
-          if (instance.ctx && !this.isInstancePaused(instance)) {
-            plugin.definition.hooks?.onTimer?.(timerId, instance.ctx);
+          if (instance.ctx && instance.lifecycle === 'active' && !this.isInstancePaused(instance)) {
+            void this.dispatcher.dispatchInstance(
+              instance,
+              'onTimer',
+              (hook, guardedCtx) => hook(timerId, guardedCtx),
+            );
           }
         },
         () => this.buildMergedSettings(plugin, pluginName, operatorId),
@@ -288,16 +386,54 @@ export class PluginManager {
           this.setOperatorPluginSettings(operatorId, pluginName, mergedSettings);
           await ConfigManager.getInstance().setOperatorPluginSettings(operatorId, pluginName, mergedSettings);
         },
+        (operation, callback) => {
+          if (!instance.enabled
+              || instance.autoDisabled
+              || instance.desiredLifecycle !== 'active'
+              || (instance.lifecycle !== 'active' && instance.lifecycle !== 'starting')) {
+            return Promise.reject(new Error('PLUGIN_INVOCATION_EXPIRED: plugin instance is not active'));
+          }
+          return this.invocationGuard.invoke(instance, operation, callback);
+        },
       );
-      instance.ctx = ctx;
+      instance.rawCtx = ctx;
+      instance.ctx = this.invocationGuard.wrapContext(ctx, instance);
       if (plugin.definition.type === 'strategy') {
-        instance.runtime = plugin.definition.createStrategyRuntime?.(ctx);
+        try {
+          const runtime = this.invocationGuard.invokeSync(
+            instance,
+            'createStrategyRuntime',
+            () => {
+              const candidate = plugin.definition.createStrategyRuntime?.(
+                this.createStrategyPluginContext(instance.ctx),
+              );
+              this.assertStrategyRuntimeV2(pluginName, candidate);
+              return candidate;
+            },
+          );
+          instance.runtime = runtime;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          instance.enabled = false;
+          instance.autoDisabled = true;
+          instance.lastError = message;
+          logger.error(`Strategy runtime rejected: plugin=${pluginName}, operator=${operatorId}`, error);
+          this.emitPluginRuntimeLog({
+            stage: 'validate',
+            level: 'error',
+            message: `PLUGIN_API_INCOMPATIBLE: ${message}`,
+            pluginName,
+            details: { operatorId },
+          });
+        }
       }
       operatorInstances.set(pluginName, instance);
 
       // 调用 onLoad（仅 enabled 的插件）
-      if (enabled) {
+      if (instance.enabled && !instance.autoDisabled) {
         await this.activateInstance(operatorId, instance);
+      } else {
+        instance.lifecycle = 'inactive';
       }
     }
   }
@@ -317,8 +453,14 @@ export class PluginManager {
       const instance: PluginInstance = {
         plugin,
         scope: { kind: 'global' },
-        ctx: null as unknown as PluginContext,
+        ctx: null as unknown as RuntimePluginContext,
+        rawCtx: null as unknown as RuntimePluginContext,
         runtime: undefined,
+        generation: ++this.nextInstanceGeneration,
+        lifecycle: 'inactive',
+        lifecycleTail: Promise.resolve(),
+        desiredLifecycle: 'inactive',
+        lifecycleRevision: 0,
         enabled,
         errorCounts: new Map(),
         autoDisabled: false,
@@ -330,8 +472,12 @@ export class PluginManager {
         'global',
         pluginStorageDir,
         (timerId) => {
-          if (instance.ctx && !this.isInstancePaused(instance)) {
-            plugin.definition.hooks?.onTimer?.(timerId, instance.ctx);
+          if (instance.ctx && instance.lifecycle === 'active' && !this.isInstancePaused(instance)) {
+            void this.dispatcher.dispatchInstance(
+              instance,
+              'onTimer',
+              (hook, guardedCtx) => hook(timerId, guardedCtx),
+            );
           }
         },
         () => this.buildMergedSettings(plugin, pluginName, GLOBAL_PLUGIN_SCOPE_ID),
@@ -344,18 +490,34 @@ export class PluginManager {
           this.pluginsConfig.configs[pluginName] = mergedConfig;
           const globalInstance = this.globalInstances.get(pluginName);
           if (globalInstance?.enabled) {
-            globalInstance.plugin.definition.hooks?.onConfigChange?.(mergedSettings, globalInstance.ctx);
+            void this.dispatcher.dispatchInstance(
+              globalInstance,
+              'onConfigChange',
+              (hook, guardedCtx) => hook(mergedSettings, guardedCtx),
+            );
           }
           this.bumpGeneration();
           this.broadcastStatusChanged(pluginName);
           await ConfigManager.getInstance().setPluginConfig(pluginName, mergedConfig);
         },
+        (operation, callback) => {
+          if (!instance.enabled
+              || instance.autoDisabled
+              || instance.desiredLifecycle !== 'active'
+              || (instance.lifecycle !== 'active' && instance.lifecycle !== 'starting')) {
+            return Promise.reject(new Error('PLUGIN_INVOCATION_EXPIRED: plugin instance is not active'));
+          }
+          return this.invocationGuard.invoke(instance, operation, callback);
+        },
       );
-      instance.ctx = ctx;
+      instance.rawCtx = ctx;
+      instance.ctx = this.invocationGuard.wrapContext(ctx, instance);
       this.globalInstances.set(pluginName, instance);
 
-      if (enabled) {
+      if (instance.enabled && !instance.autoDisabled) {
         await this.activateInstance(GLOBAL_PLUGIN_SCOPE_ID, instance);
+      } else {
+        instance.lifecycle = 'inactive';
       }
     }
   }
@@ -367,8 +529,7 @@ export class PluginManager {
     }
 
     for (const instance of operatorInstances.values()) {
-      if (!instance.enabled) continue;
-      void this.deactivateInstance(operatorId, instance);
+      void this.deactivateInstance(operatorId, instance, true);
     }
     this.instances.delete(operatorId);
     this.orchestrator.removeDecisionState(operatorId);
@@ -384,8 +545,18 @@ export class PluginManager {
     return this.getStrategyInstance(operatorId);
   }
 
-  getCtxForInstance(instance: PluginInstance): PluginContext {
+  getCtxForInstance(instance: PluginInstance): RuntimePluginContext {
     return instance.ctx;
+  }
+
+  private createStrategyPluginContext(ctx: RuntimePluginContext): StrategyPluginContext {
+    return Object.freeze({
+      get config() {
+        return ctx.config;
+      },
+      log: ctx.log,
+      operator: ctx.operator,
+    });
   }
 
   getOperatorRuntimeStatus(operatorId: string): {
@@ -420,13 +591,12 @@ export class PluginManager {
   }
 
   getOperatorAutomationSnapshot(operatorId: string): StrategyRuntimeSnapshot | null {
-    const runtime = this.getStrategyRuntime(operatorId);
-    if (!runtime) {
-      return null;
-    }
-
     try {
-      return runtime.getSnapshot();
+      return this.invokeStrategyRuntimeSync(
+        operatorId,
+        'getSnapshot',
+        (runtime) => runtime.getSnapshot(),
+      ) ?? null;
     } catch (err) {
       logger.error(`Failed to read strategy snapshot: operator=${operatorId}`, err);
       return null;
@@ -437,18 +607,23 @@ export class PluginManager {
     operatorId: string,
     patch: Partial<StrategyRuntimeContext>,
   ): void {
-    const runtime = this.getStrategyRuntime(operatorId);
-    if (!runtime) return;
-    runtime.patchContext(patch);
+    this.invokeStrategyRuntimeSync(
+      operatorId,
+      'patchContext',
+      (runtime) => runtime.patchContext(patch),
+    );
   }
 
   setOperatorRuntimeState(operatorId: string, state: StrategyRuntimeSlot): void {
-    const runtime = this.getStrategyRuntime(operatorId);
-    if (!runtime) return;
     let beforeState: string = 'unknown';
     let beforeTargetCallsign: string | undefined;
     try {
-      const snapshot = runtime.getSnapshot();
+      const snapshot = this.invokeStrategyRuntimeSync(
+        operatorId,
+        'getSnapshot:before-set-state',
+        (runtime) => runtime.getSnapshot(),
+      );
+      if (!snapshot) return;
       beforeState = snapshot.currentState;
       beforeTargetCallsign = snapshot.context?.targetCallsign;
     } catch {
@@ -460,7 +635,7 @@ export class PluginManager {
       after: state,
       beforeTargetCallsign: beforeTargetCallsign ?? null,
     });
-    runtime.setState(state);
+    this.invokeStrategyRuntimeSync(operatorId, 'setState', (runtime) => runtime.setState(state));
     this.orchestrator.invalidateDecisionMessageSet(operatorId);
     this.eventEmitter.emit('operatorSlotChanged', { operatorId, slot: state });
   }
@@ -470,14 +645,17 @@ export class PluginManager {
     slot: StrategyRuntimeSlot,
     content: string,
   ): Record<string, unknown> | undefined {
-    const runtime = this.getStrategyRuntime(operatorId);
-    if (!runtime) return undefined;
+    if (!this.getStrategyRuntime(operatorId)) return undefined;
     const activeStrategy = this.pluginsConfig.operatorStrategies?.[operatorId] ?? BUILTIN_STANDARD_QSO_PLUGIN_NAME;
     let persistedSettings: Record<string, unknown> | undefined;
     if (activeStrategy === BUILTIN_STANDARD_QSO_PLUGIN_NAME && slot === 'TX6') {
       persistedSettings = this.updateStandardQSOTx6OverrideSetting(operatorId, content);
     }
-    runtime.setSlotContent({ slot, content });
+    this.invokeStrategyRuntimeSync(
+      operatorId,
+      'setSlotContent',
+      (runtime) => runtime.setSlotContent({ slot, content }),
+    );
     this.orchestrator.invalidateDecisionMessageSet(operatorId);
     this.eventEmitter.emit('operatorSlotContentChanged', { operatorId, slot, content });
     return persistedSettings;
@@ -502,17 +680,23 @@ export class PluginManager {
       throw new Error(`Plugin action is paused for operator: plugin=${pluginName}${pausedOperatorId ? `, operator=${pausedOperatorId}` : ''}`);
     }
 
-    const hook = instance.plugin.definition.hooks?.onUserAction;
-    if (!hook) {
-      return;
-    }
-    hook(actionId, payload, instance.ctx);
+    void this.dispatcher.dispatchInstance(
+      instance,
+      'onUserAction',
+      (hook, guardedCtx) => hook(actionId, payload, guardedCtx),
+    );
   }
 
   requestCall(
     operatorId: string,
     callsign: string,
     lastMessage?: { message: FrameMessage; slotInfo: SlotInfo },
+    options?: {
+      submitCurrentFrame?: boolean;
+      source?: 'operator-edit' | 'plugin';
+      reason?: string;
+      commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken;
+    },
   ): void {
     // 呼叫收敛点：autocall / WS 命令 / ctx.operator.call / replyToDecode 全部汇入此处，
     // 未解码占位符呼号（`<...>`/`...`）一律拒绝，避免向占位符发起呼叫。
@@ -520,25 +704,212 @@ export class PluginManager {
       logger.warn('Refusing requestCall with undecoded placeholder callsign', { operatorId, callsign });
       return;
     }
+    const apply = (token: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken) => {
+      if (!this.intentCoordinator.isCurrent(token)) return;
+      this.applyRequestCall(operatorId, callsign, lastMessage, options, token);
+    };
+    if (options?.commandToken) {
+      apply(options.commandToken);
+      return;
+    }
+    const source = options?.source === 'plugin' ? 'plugin' : 'manual';
+    void this.intentCoordinator.submit(operatorId, source, (token, signal) => {
+      if (!signal.aborted) apply(token);
+    }).catch((error) => {
+      logger.warn('Operator requestCall command failed', {
+        operatorId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }
+
+  private async submitPluginOperatorCommand(
+    instance: PluginInstance,
+    operatorId: string,
+    command: PluginOperatorCommand,
+  ): Promise<PluginOperatorCommandResult> {
+    const invocation = this.invocationGuard.captureCurrent(instance);
+    const isInvocationCurrent = () => (
+      !invocation.signal.aborted
+      && instance.generation === invocation.instanceGeneration
+      && instance.lifecycle === 'active'
+      && this.instances.get(operatorId)?.get(instance.plugin.definition.name) === instance
+    );
+    const outcome = await this.intentCoordinator.submit(
+      operatorId,
+      'plugin',
+      async (token, signal) => {
+        if (signal.aborted || !this.intentCoordinator.isCurrent(token) || !isInvocationCurrent()) return;
+        const operator = this.deps.getOperatorById(operatorId);
+        if (!operator) throw new Error(`Operator not found: ${operatorId}`);
+
+        switch (command.type) {
+          case 'start-automation':
+            operator.start();
+            break;
+          case 'stop-automation':
+            operator.stop();
+            this.deps.requestOperatorStrategyStop?.(operatorId, 'plugin automation stop');
+            break;
+          case 'request-call':
+            this.applyRequestCall(operatorId, command.callsign, command.lastMessage, {
+              source: 'plugin',
+            }, token);
+            break;
+          case 'reply-to-decode':
+            this.eventEmitter.emit('pluginRemoteReplyToDecode', {
+              operatorId,
+              callsign: command.callsign,
+              modifiers: command.modifiers,
+            });
+            this.applyRequestCall(operatorId, command.callsign, command.lastMessage, {
+              source: 'plugin',
+            }, token);
+            break;
+          case 'set-transmit-cycles':
+            operator.setTransmitCycles(command.cycles, {
+              commandEpoch: token.epoch,
+              source: 'plugin',
+              reason: `plugin ${instance.plugin.definition.name} changed transmit cycles`,
+            });
+            break;
+          case 'remove-contribution':
+            operator.stop();
+            this.deps.releaseTargetReservation?.(operatorId);
+            if (!this.deps.removeOperatorContribution) {
+              throw new Error('Host participant-removal coordinator is unavailable');
+            }
+            await this.deps.removeOperatorContribution(operatorId, {
+              signal: AbortSignal.any([signal, invocation.signal]),
+              commandToken: token,
+            });
+            break;
+          case 'clear-decodes':
+            this.eventEmitter.emit('pluginRemoteClearDecodes', { operatorId, window: command.window });
+            break;
+          case 'set-free-text':
+            this.eventEmitter.emit('pluginRemoteFreeText', { operatorId, text: command.text, send: false });
+            break;
+          case 'send-free-text':
+            this.eventEmitter.emit('pluginRemoteFreeText', { operatorId, text: command.text, send: true });
+            if (command.text?.trim()) {
+              this.eventEmitter.emit('requestTransmit', {
+                operatorId,
+                transmission: command.text,
+                decisionEpoch: token.epoch,
+              });
+            }
+            break;
+          case 'set-temporary-location':
+            this.eventEmitter.emit('pluginRemoteLocation', { operatorId, location: command.location });
+            break;
+          case 'highlight-callsign':
+            this.eventEmitter.emit('pluginRemoteHighlightCallsign', {
+              operatorId,
+              callsign: command.callsign,
+              background: command.background,
+              foreground: command.foreground,
+              lastOnly: command.lastOnly,
+            });
+            break;
+        }
+        if (signal.aborted || !this.intentCoordinator.isCurrent(token) || !isInvocationCurrent()) {
+          return;
+        }
+      },
+    );
+    return {
+      epoch: outcome.token.epoch,
+      outcome: outcome.status,
+    };
+  }
+
+  private applyRequestCall(
+    operatorId: string,
+    callsign: string,
+    lastMessage: { message: FrameMessage; slotInfo: SlotInfo } | undefined,
+    options: {
+      submitCurrentFrame?: boolean;
+      source?: 'operator-edit' | 'plugin';
+      reason?: string;
+    } | undefined,
+    token: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken,
+  ): void {
     const operator = this.deps.getOperatorById(operatorId);
-    const runtime = this.getStrategyRuntime(operatorId);
-    if (!operator || !runtime) return;
+    if (!operator || !this.getStrategyRuntime(operatorId)) return;
 
     this.orchestrator.invalidateDecisionMessageSet(operatorId);
-    const accepted = runtime.requestCall(callsign, lastMessage);
+    const checkpoint = this.invokeStrategyRuntimeSync(
+      operatorId,
+      'checkpoint:request-call',
+      (runtime) => structuredClone(runtime.checkpoint()),
+    );
+    const accepted = this.invokeStrategyRuntimeSync(
+      operatorId,
+      'requestCall',
+      (runtime) => runtime.requestCall(callsign, lastMessage),
+    );
     if (accepted === false) {
       logger.warn('Strategy rejected requestCall without starting the operator', { operatorId, callsign });
       return;
     }
+    const nextSnapshot = this.invokeStrategyRuntimeSync(
+      operatorId,
+      'getSnapshot:request-call',
+      (runtime) => runtime.getSnapshot(),
+    );
+    const nextTarget = nextSnapshot?.context?.targetCallsign;
+    if (this.deps.transitionTargetReservation
+        && !this.deps.transitionTargetReservation(operatorId, token.epoch, nextTarget)) {
+      if (checkpoint !== undefined) {
+        this.invokeStrategyRuntimeSync(
+          operatorId,
+          'restore:request-call-target-conflict',
+          (runtime) => runtime.restore(checkpoint),
+        );
+      }
+      logger.warn('Manual/plugin requestCall target is reserved by another same-station operator', {
+        operatorId,
+        callsign,
+        epoch: token.epoch,
+      });
+      return;
+    }
+    if (nextSnapshot?.qsoLifecycleEpoch !== undefined) {
+      this.eventEmitter.emit('qsoLifecycleChanged', {
+        operatorId,
+        lifecycleEpoch: nextSnapshot.qsoLifecycleEpoch,
+        runtimeGeneration: this.getStrategyInstance(operatorId)?.generation,
+      });
+    }
     operator.start();
     if (lastMessage) {
-      operator.setTransmitCycles((lastMessage.slotInfo.cycleNumber + 1) % 2);
+      operator.setTransmitCycles((lastMessage.slotInfo.cycleNumber + 1) % 2, {
+        commandEpoch: token.epoch,
+        source: options?.source === 'plugin' ? 'plugin' : 'manual',
+        reason: options?.reason ?? 'requestCall selected transmit cycle',
+      });
+    }
+    if (options?.submitCurrentFrame && !lastMessage) {
+      // Manual in-slot edits must enter the frame coordinator immediately.
+      // A selected frame already causes setTransmitCycles() to emit the
+      // authoritative refresh event, so only the no-frame path needs this
+      // explicit bridge. Automatic requestCall paths still wait for the normal
+      // encode boundary.
+      this.deps.triggerReEncode?.(operatorId, {
+        source: options.source ?? 'operator-edit',
+        reason: options.reason ?? 'requestCall updated operator context',
+        decisionEpoch: token.epoch,
+      });
     }
   }
 
   notifyTransmissionQueued(operatorId: string, transmission: string): void {
-    const runtime = this.getStrategyRuntime(operatorId);
-    runtime?.onTransmissionQueued?.(transmission);
+    this.invokeStrategyRuntimeSync(
+      operatorId,
+      'onTransmissionQueued',
+      (runtime) => runtime.onTransmissionQueued?.(transmission),
+    );
   }
 
   async interruptOperatorTransmission(operatorId: string): Promise<void> {
@@ -686,13 +1057,21 @@ export class PluginManager {
     this.pluginsConfig.configs[name] = { ...existing, settings };
     const globalInstance = this.globalInstances.get(name);
     if (globalInstance?.enabled) {
-      globalInstance.plugin.definition.hooks?.onConfigChange?.(settings, globalInstance.ctx);
+      void this.dispatcher.dispatchInstance(
+        globalInstance,
+        'onConfigChange',
+        (hook, guardedCtx) => hook(settings, guardedCtx),
+      );
     }
     // 通知所有操作员实例配置变更（仅 global scope 键）
     for (const operatorInstances of this.instances.values()) {
       const instance = operatorInstances.get(name);
       if (instance?.enabled) {
-        instance.plugin.definition.hooks?.onConfigChange?.(settings, instance.ctx);
+        void this.dispatcher.dispatchInstance(
+          instance,
+          'onConfigChange',
+          (hook, guardedCtx) => hook(settings, guardedCtx),
+        );
       }
     }
     this.bumpGeneration();
@@ -705,7 +1084,8 @@ export class PluginManager {
   }
 
   isOperatorPluginPaused(operatorId: string, pluginName: string): boolean {
-    return this.pluginsConfig.operatorPluginPauses?.[operatorId]?.includes(pluginName) ?? false;
+    return this.isTransmitControlOperatorPlugin(pluginName)
+      && (this.pluginsConfig.operatorPluginPauses?.[operatorId]?.includes(pluginName) ?? false);
   }
 
   async setOperatorPluginPaused(operatorId: string, pluginName: string, paused: boolean): Promise<string[]> {
@@ -897,16 +1277,75 @@ export class PluginManager {
       ? this.globalInstances.get(pluginName)
       : this.instances.get(requestContext.instanceTarget.operatorId)?.get(pluginName);
 
-    if (!instance) {
+    if (!instance || instance.lifecycle !== 'active') {
       throw new Error(`Plugin instance not found: ${pluginName}`);
     }
 
-    const bridge = instance.ctx.ui as import('./PluginUIBridge.js').PluginUIBridge;
+    const bridge = instance.rawCtx.ui as import('./PluginUIBridge.js').PluginUIBridge;
     if (bridge.hasPageHandler()) {
-      return bridge.handlePageInvoke(pageId, action, data, requestContext);
+      return this.invocationGuard.invoke(
+        instance,
+        'ui:onMessage',
+        () => bridge.handlePageInvoke(
+          pageId,
+          action,
+          data,
+          this.createInvocationScopedPageContext(instance, requestContext),
+        ),
+      );
     }
 
     throw new Error(`No page handler registered for plugin: ${pluginName}`);
+  }
+
+  private createInvocationScopedPageContext(
+    instance: PluginInstance,
+    requestContext: PluginUIRequestContext,
+  ): PluginUIRequestContext {
+    const invocation = this.invocationGuard.captureCurrent(instance);
+    const assertCurrent = () => this.invocationGuard.assertCaptured(instance, invocation);
+    const files = requestContext.files;
+    const page = requestContext.page;
+
+    return Object.freeze({
+      pageSessionId: requestContext.pageSessionId,
+      user: Object.freeze({
+        ...requestContext.user,
+        operatorIds: [...requestContext.user.operatorIds],
+        permissionGrants: requestContext.user.permissionGrants
+          ? structuredClone(requestContext.user.permissionGrants)
+          : undefined,
+      }),
+      resource: requestContext.resource ? Object.freeze({ ...requestContext.resource }) : undefined,
+      instanceTarget: Object.freeze({ ...requestContext.instanceTarget }),
+      files: Object.freeze({
+        async write(filePath: string, contents: Buffer) {
+          assertCurrent();
+          return files.write(filePath, contents);
+        },
+        async read(filePath: string) {
+          assertCurrent();
+          return files.read(filePath);
+        },
+        async delete(filePath: string) {
+          assertCurrent();
+          return files.delete(filePath);
+        },
+        async list(prefix?: string) {
+          assertCurrent();
+          return files.list(prefix);
+        },
+      }),
+      page: Object.freeze({
+        sessionId: page.sessionId,
+        pageId: page.pageId,
+        resource: page.resource ? Object.freeze({ ...page.resource }) : undefined,
+        push(action: string, payload?: unknown) {
+          assertCurrent();
+          page.push(action, payload);
+        },
+      }),
+    });
   }
 
   /** 更新 operator scope 插件设置，并通知相关实例 */
@@ -925,7 +1364,11 @@ export class PluginManager {
     // 通知该操作员的实例配置变更
     const instance = this.instances.get(operatorId)?.get(pluginName);
     if (instance?.enabled) {
-      instance.plugin.definition.hooks?.onConfigChange?.(mergedSettings, instance.ctx);
+      void this.dispatcher.dispatchInstance(
+        instance,
+        'onConfigChange',
+        (hook, guardedCtx) => hook(mergedSettings, guardedCtx),
+      );
     }
     this.bumpGeneration();
     this.broadcastStatusChanged(pluginName);
@@ -1100,7 +1543,8 @@ export class PluginManager {
     return Boolean(
       plugin
       && (plugin.definition.instanceScope ?? 'operator') === 'operator'
-      && plugin.definition.permissions?.includes('operator:transmit-control'),
+      && plugin.definition.permissions?.includes('operator:transmit-control')
+      && typeof plugin.definition.isAutoCallEnabled === 'function',
     );
   }
 
@@ -1115,6 +1559,9 @@ export class PluginManager {
     }
     if (!plugin.definition.permissions?.includes('operator:transmit-control')) {
       throw new Error(`Plugin does not declare operator:transmit-control: ${pluginName}`);
+    }
+    if (typeof plugin.definition.isAutoCallEnabled !== 'function') {
+      throw new Error(`Plugin is not an automatic calling controller: ${pluginName}`);
     }
     if (!this.instances.get(operatorId)?.has(pluginName)) {
       throw new Error(`Plugin instance not found for operator: plugin=${pluginName}, operator=${operatorId}`);
@@ -1171,32 +1618,92 @@ export class PluginManager {
     const operatorInstances = this.instances.get(operatorId);
     const scopedInstances = operatorInstances ? Array.from(operatorInstances.values()) : [];
     const globalInstances = Array.from(this.globalInstances.values()).filter(
-      (instance) => instance.enabled && !instance.autoDisabled,
+      (instance) => instance.enabled && !instance.autoDisabled && instance.lifecycle === 'active',
     );
     return [...globalInstances, ...scopedInstances].filter(
       (instance) => instance.plugin.definition.type === 'strategy'
         ? instance === this.getStrategyInstance(operatorId)
-        : instance.enabled && !instance.autoDisabled && !this.isInstancePaused(instance),
+        : instance.enabled
+          && !instance.autoDisabled
+          && instance.lifecycle === 'active'
+          && !this.isInstancePaused(instance),
     );
   }
 
   private getStrategyInstance(operatorId: string): PluginInstance | undefined {
     const strategyName = this.getResolvedStrategyName(operatorId);
     const instance = this.instances.get(operatorId)?.get(strategyName);
-    if (instance?.enabled && !instance.autoDisabled && !this.isInstancePaused(instance)) {
+    if (instance?.enabled
+        && !instance.autoDisabled
+        && instance.lifecycle === 'active'
+        && !this.isInstancePaused(instance)) {
       return instance;
-    }
-
-    const fallback = this.instances.get(operatorId)?.get(BUILTIN_STANDARD_QSO_PLUGIN_NAME);
-    if (fallback?.enabled && !fallback.autoDisabled && !this.isInstancePaused(fallback)) {
-      return fallback;
     }
 
     return undefined;
   }
 
+  private assertStrategyRuntimeV2(pluginName: string, runtime: StrategyRuntime | undefined): asserts runtime is StrategyRuntime {
+    if (!runtime) {
+      throw new Error(`${pluginName} did not create a strategy runtime`);
+    }
+    const requiredMethods: Array<keyof StrategyRuntime> = [
+      'checkpoint',
+      'restore',
+      'decide',
+      'getTransmitText',
+      'getSnapshot',
+      'requestCall',
+      'patchContext',
+      'setState',
+      'setSlotContent',
+      'reset',
+    ];
+    const missing = requiredMethods.filter((name) => typeof runtime[name] !== 'function');
+    if (missing.length > 0) {
+      throw new Error(`${pluginName} strategy runtime is missing v2 methods: ${missing.join(', ')}`);
+    }
+    try {
+      structuredClone(runtime.checkpoint());
+    } catch (error) {
+      throw new Error(
+        `${pluginName} strategy checkpoint is not structured-cloneable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   private getStrategyRuntime(operatorId: string): StrategyRuntime | undefined {
     return this.getStrategyInstance(operatorId)?.runtime;
+  }
+
+  private async invokeStrategyRuntime<T>(
+    operatorId: string,
+    operation: string,
+    callback: (runtime: StrategyRuntime) => T | Promise<T>,
+    options?: { signal?: AbortSignal },
+  ): Promise<T | undefined> {
+    const instance = this.getStrategyInstance(operatorId);
+    if (!instance?.runtime) return undefined;
+    return this.invocationGuard.invoke(
+      instance,
+      operation,
+      () => callback(instance.runtime!),
+      { signal: options?.signal, drainOnExternalAbortMs: 1_000 },
+    );
+  }
+
+  private invokeStrategyRuntimeSync<T>(
+    operatorId: string,
+    operation: string,
+    callback: (runtime: StrategyRuntime) => T,
+  ): T | undefined {
+    const instance = this.getStrategyInstance(operatorId);
+    if (!instance?.runtime) return undefined;
+    return this.invocationGuard.invokeSync(
+      instance,
+      operation,
+      () => callback(instance.runtime!),
+    );
   }
 
   private getRepresentativeInstance(pluginName: string): PluginInstance | undefined {
@@ -1261,7 +1768,7 @@ export class PluginManager {
 
   private getAutoCallEnabledOperatorIds(pluginName: string): string[] | undefined {
     const plugin = this.loadedPlugins.get(pluginName);
-    if (!plugin?.definition.permissions?.includes('operator:transmit-control')) {
+    if (!this.isTransmitControlOperatorPlugin(pluginName) || !plugin) {
       return undefined;
     }
 
@@ -1271,11 +1778,9 @@ export class PluginManager {
       if (!instance?.enabled || instance.autoDisabled) {
         continue;
       }
-      if (typeof plugin.definition.isAutoCallEnabled !== 'function') {
-        continue;
-      }
       try {
-        if (plugin.definition.isAutoCallEnabled(instance.ctx) === true) {
+        const eligibilityContext = Object.freeze({ config: instance.rawCtx.config });
+        if (plugin.definition.isAutoCallEnabled!(eligibilityContext) === true) {
           ids.push(operatorId);
         }
       } catch (err) {
@@ -1341,9 +1846,9 @@ export class PluginManager {
 
     const discoveredPlugins = new Map<string, LoadedPlugin>();
     for (const builtin of BUILTIN_PLUGINS) {
-      validatePluginDefinition(builtin.definition);
-      discoveredPlugins.set(builtin.definition.name, {
-        definition: builtin.definition,
+      const definition = canonicalizePluginDefinition(builtin.definition);
+      discoveredPlugins.set(definition.name, {
+        definition,
         isBuiltIn: true,
         locales: builtin.locales,
         dirPath: builtin.dirPath,
@@ -1386,15 +1891,13 @@ export class PluginManager {
   private async teardownAllInstances(): Promise<void> {
     for (const [operatorId, operatorInstances] of this.instances) {
       for (const [pluginName, instance] of operatorInstances) {
-        if (!instance.enabled) continue;
-        await this.deactivateInstance(operatorId, instance).catch((err) => {
+        await this.deactivateInstance(operatorId, instance, true).catch((err) => {
           logger.warn(`Failed to deactivate plugin instance: plugin=${pluginName}, operator=${operatorId}`, err);
         });
       }
     }
     for (const [pluginName, instance] of this.globalInstances) {
-      if (!instance.enabled) continue;
-      await this.deactivateInstance(GLOBAL_PLUGIN_SCOPE_ID, instance).catch((err) => {
+      await this.deactivateInstance(GLOBAL_PLUGIN_SCOPE_ID, instance, true).catch((err) => {
         logger.warn(`Failed to deactivate global plugin instance: plugin=${pluginName}`, err);
       });
     }
@@ -1473,13 +1976,15 @@ export class PluginManager {
   }
 
   resetOperatorPluginRuntime(operatorId: string, reason: string): void {
-    const runtime = this.getStrategyRuntime(operatorId);
-    if (runtime) {
-      try {
-        runtime.reset(reason);
-      } catch (err) {
-        logger.warn(`Failed to reset strategy runtime: operator=${operatorId}`, err);
-      }
+    this.deps.releaseTargetReservation?.(operatorId);
+    try {
+      this.invokeStrategyRuntimeSync(
+        operatorId,
+        'reset',
+        (runtime) => runtime.reset(reason),
+      );
+    } catch (err) {
+      logger.warn(`Failed to reset strategy runtime: operator=${operatorId}`, err);
     }
     this.orchestrator.clearDecisionState(operatorId);
     this.deps.resetOperatorRuntime(operatorId, reason);
@@ -1491,6 +1996,18 @@ export class PluginManager {
     }
     const existing = this.pluginsConfig.configs[pluginName] ?? { enabled: true, settings: {} };
     this.pluginsConfig.configs[pluginName] = { ...existing, enabled: false };
+    const affectedInstances = [
+      this.globalInstances.get(pluginName),
+      ...Array.from(this.instances.values()).map((entries) => entries.get(pluginName)),
+    ].filter((instance): instance is PluginInstance => Boolean(instance));
+    for (const instance of affectedInstances) {
+      instance.enabled = false;
+      instance.autoDisabled = true;
+      const operatorId = instance.scope.kind === 'operator'
+        ? instance.scope.operatorId
+        : GLOBAL_PLUGIN_SCOPE_ID;
+      void this.deactivateInstance(operatorId, instance);
+    }
     logger.warn(`Plugin auto-disabled: ${pluginName}, reason: ${reason}`);
     this.bumpGeneration();
     this.broadcastStatusChanged(pluginName);
@@ -1738,10 +2255,75 @@ export class PluginManager {
     });
   }
 
-  private async activateInstance(operatorId: string, instance: PluginInstance): Promise<void> {
+  private activateInstance(operatorId: string, instance: PluginInstance): Promise<void> {
+    if (instance.lifecycle === 'disposed' || instance.desiredLifecycle === 'disposed') {
+      return Promise.reject(new Error(
+        `Cannot reactivate disposed plugin instance: ${instance.plugin.definition.name}`,
+      ));
+    }
+    instance.desiredLifecycle = 'active';
+    const revision = ++instance.lifecycleRevision;
+    const transition = instance.lifecycleTail.then(() => (
+      this.reconcileInstanceLifecycle(operatorId, instance, revision)
+    ));
+    instance.lifecycleTail = transition.catch(() => undefined);
+    return transition;
+  }
+
+  private async reconcileInstanceLifecycle(
+    operatorId: string,
+    instance: PluginInstance,
+    revision: number,
+  ): Promise<void> {
+    if (revision !== instance.lifecycleRevision) {
+      return;
+    }
+    if (instance.desiredLifecycle === 'active') {
+      if (!instance.enabled || instance.autoDisabled) {
+        return;
+      }
+      await this.activateInstanceNow(operatorId, instance, revision);
+      return;
+    }
+    await this.deactivateInstanceNow(operatorId, instance);
+  }
+
+  private isCurrentActivation(instance: PluginInstance, revision: number): boolean {
+    return instance.lifecycleRevision === revision
+      && instance.desiredLifecycle === 'active'
+      && instance.enabled
+      && !instance.autoDisabled;
+  }
+
+  private async activateInstanceNow(
+    operatorId: string,
+    instance: PluginInstance,
+    revision: number,
+  ): Promise<void> {
+    if (!this.isCurrentActivation(instance, revision)) {
+      return;
+    }
+    if (instance.lifecycle === 'active') {
+      return;
+    }
+    if (instance.lifecycle === 'disposed') {
+      throw new Error(`Cannot activate disposed plugin: ${instance.plugin.definition.name}`);
+    }
+    if (instance.lifecycle === 'stopping' || instance.lifecycle === 'quarantined') {
+      await this.deactivateInstanceNow(operatorId, instance);
+      if (!this.isCurrentActivation(instance, revision)) {
+        return;
+      }
+    }
+    instance.lifecycle = 'starting';
     const hook = instance.plugin.definition.onLoad;
     this.clearRuntimePanelContributionsForInstance(instance);
-    if (!hook) return;
+    if (!hook) {
+      if (this.isCurrentActivation(instance, revision)) {
+        instance.lifecycle = 'active';
+      }
+      return;
+    }
     try {
       this.clearPanelMetaForInstance(instance);
       this._logbookSyncHost.unregisterByPlugin(instance.plugin.definition.name);
@@ -1749,11 +2331,35 @@ export class PluginManager {
       if (instance.plugin.isBuiltIn) {
         const migrationFn = BUILTIN_MIGRATIONS[instance.plugin.definition.name];
         if (migrationFn) {
-          await migrationFn(instance.ctx);
+          await this.invocationGuard.invoke(
+            instance,
+            'builtin:migration',
+            () => migrationFn(instance.ctx),
+          );
+          if (!this.isCurrentActivation(instance, revision)) {
+            await this.deactivateInstanceNow(operatorId, instance);
+            return;
+          }
         }
       }
-      await hook(instance.ctx);
+      await this.invocationGuard.invoke(instance, 'onLoad', () => hook(instance.ctx as never));
+      if (!this.isCurrentActivation(instance, revision)) {
+        await this.deactivateInstanceNow(operatorId, instance);
+        return;
+      }
+      instance.lifecycle = 'active';
     } catch (err) {
+      if (!this.isCurrentActivation(instance, revision)) {
+        await this.deactivateInstanceNow(operatorId, instance);
+        return;
+      }
+      instance.desiredLifecycle = 'inactive';
+      instance.lifecycleRevision += 1;
+      instance.lifecycle = 'quarantined';
+      instance.autoDisabled = true;
+      this.closeInstanceIngress(instance);
+      this.invocationGuard.revokeInstance(instance, 'plugin onLoad failed');
+      await instance.rawCtx.network?.udp.closeAll().catch(() => undefined);
       this.emitPluginRuntimeLog({
         stage: 'activate',
         level: 'error',
@@ -1769,11 +2375,53 @@ export class PluginManager {
     }
   }
 
-  private async deactivateInstance(operatorId: string, instance: PluginInstance): Promise<void> {
+  private deactivateInstance(
+    operatorId: string,
+    instance: PluginInstance,
+    dispose = false,
+  ): Promise<void> {
+    if (instance.lifecycle === 'disposed') {
+      return Promise.resolve();
+    }
+    instance.desiredLifecycle = dispose ? 'disposed' : 'inactive';
+    const revision = ++instance.lifecycleRevision;
+    // Revoke ingress synchronously; queued or hung onLoad work must not gain a
+    // command-capable window after disable has already been requested.
+    if (instance.lifecycle !== 'inactive') {
+      instance.lifecycle = 'stopping';
+    }
+    this.closeInstanceIngress(instance);
+    this.invocationGuard.revokeInstance(instance, 'plugin instance deactivation requested');
+    const transition = instance.lifecycleTail.then(() => (
+      this.reconcileInstanceLifecycle(operatorId, instance, revision)
+    ));
+    instance.lifecycleTail = transition.catch(() => undefined);
+    return transition;
+  }
+
+  private async deactivateInstanceNow(
+    operatorId: string,
+    instance: PluginInstance,
+  ): Promise<void> {
+    if (instance.lifecycle === 'disposed') {
+      return;
+    }
+    const wasLoaded = instance.lifecycle !== 'inactive';
+    if (!wasLoaded && instance.desiredLifecycle !== 'disposed') return;
+    instance.lifecycle = 'stopping';
+    this.closeInstanceIngress(instance);
+    await instance.rawCtx.network?.udp.closeAll().catch(() => undefined);
+    this.invocationGuard.revokeInstance(instance, 'plugin instance stopping');
+
     const hook = instance.plugin.definition.onUnload;
-    if (hook) {
+    if (wasLoaded && hook) {
       try {
-        await hook(instance.ctx);
+        await this.invocationGuard.invoke(
+          instance,
+          'onUnload',
+          () => hook(instance.ctx as never),
+          { allowedContextRoots: new Set(['store', 'timers', 'files']) },
+        );
       } catch (err) {
         this.emitPluginRuntimeLog({
           stage: 'activate',
@@ -1789,23 +2437,43 @@ export class PluginManager {
         logger.warn(`onUnload error: plugin=${instance.plugin.definition.name}, operator=${operatorId}`, err);
       }
     }
+    this.closeInstanceIngress(instance);
+    this.invocationGuard.revokeInstance(instance, 'plugin instance unloaded');
     this.clearPanelMetaForInstance(instance);
     this.clearRuntimePanelContributionsForInstance(instance);
+    this._logbookSyncHost.unregisterByPlugin(instance.plugin.definition.name, instance.generation);
+    // PluginContextFactory 总是创建 PluginStorageProvider 实例（实现 FlushableKVStore）
+    const globalStore = instance.rawCtx.store.global as FlushableKVStore;
+    const operatorStore = instance.rawCtx.store.operator as FlushableKVStore;
+    await globalStore.flush().catch(() => {});
+    await operatorStore.flush().catch(() => {});
+    if (instance.desiredLifecycle === 'disposed') {
+      globalStore.dispose?.();
+      operatorStore.dispose?.();
+      instance.lifecycle = 'disposed';
+    } else {
+      instance.lifecycle = 'inactive';
+    }
+  }
+
+  private closeInstanceIngress(instance: PluginInstance): void {
+    instance.rawCtx.timers.clearAll();
+    const bridge = instance.rawCtx.ui as import('./PluginUIBridge.js').PluginUIBridge;
+    bridge.clearPageHandler();
+    const instanceTarget: PluginUIInstanceTarget = instance.scope.kind === 'global'
+      ? { kind: 'global' }
+      : { kind: 'operator', operatorId: instance.scope.operatorId };
+    for (const sessionId of this.pageSessions.deleteByPluginInstance(
+      instance.plugin.definition.name,
+      instanceTarget,
+    )) {
+      this.pageSessionPushQueues.delete(sessionId);
+    }
     this.pluginEventBusHost.unsubscribeAll({
       pluginName: instance.plugin.definition.name,
       instanceScope: instance.scope.kind,
       operatorId: instance.scope.kind === 'operator' ? instance.scope.operatorId : undefined,
     });
-    this._logbookSyncHost.unregisterByPlugin(instance.plugin.definition.name);
-    instance.ctx.timers.clearAll();
-    await instance.ctx.network?.udp.closeAll().catch(() => {});
-    // PluginContextFactory 总是创建 PluginStorageProvider 实例（实现 FlushableKVStore）
-    const globalStore = instance.ctx.store.global as FlushableKVStore;
-    const operatorStore = instance.ctx.store.operator as FlushableKVStore;
-    await globalStore.flush().catch(() => {});
-    await operatorStore.flush().catch(() => {});
-    globalStore.dispose?.();
-    operatorStore.dispose?.();
   }
 
   private registerEngineListeners(): void {

--- a/packages/server/src/plugin/PluginPageSessionStore.ts
+++ b/packages/server/src/plugin/PluginPageSessionStore.ts
@@ -73,6 +73,21 @@ export class PluginPageSessionStore {
     this.sessions.delete(sessionId);
   }
 
+  deleteByPluginInstance(
+    pluginName: string,
+    instanceTarget: PluginUIInstanceTarget,
+  ): string[] {
+    const deleted: string[] = [];
+    for (const [sessionId, session] of this.sessions) {
+      if (session.pluginName === pluginName
+          && sameInstanceTarget(session.instanceTarget, instanceTarget)) {
+        this.sessions.delete(sessionId);
+        deleted.push(sessionId);
+      }
+    }
+    return deleted;
+  }
+
   private pruneExpired(): void {
     const now = Date.now();
     for (const [sessionId, session] of this.sessions.entries()) {

--- a/packages/server/src/plugin/PluginUIBridge.ts
+++ b/packages/server/src/plugin/PluginUIBridge.ts
@@ -147,4 +147,9 @@ export class PluginUIBridge implements UIBridge {
   hasPageHandler(): boolean {
     return this.pageHandler !== null;
   }
+
+  /** @internal Stops accepting page messages before plugin teardown begins. */
+  clearPageHandler(): void {
+    this.pageHandler = null;
+  }
 }

--- a/packages/server/src/plugin/__tests__/DecisionOrchestrator.qso-generation.test.ts
+++ b/packages/server/src/plugin/__tests__/DecisionOrchestrator.qso-generation.test.ts
@@ -1,0 +1,51 @@
+import EventEmitter from 'eventemitter3';
+import { describe, expect, it, vi } from 'vitest';
+import type { DigitalRadioEngineEvents, QSORecord } from '@tx5dr/contracts';
+import { DecisionOrchestrator } from '../DecisionOrchestrator.js';
+
+function qsoRecord(): QSORecord {
+  return {
+    id: 'qso-1',
+    callsign: 'JA1AAA',
+    frequency: 14_074_000,
+    mode: 'FT8',
+    startTime: Date.parse('2026-08-19T12:00:00.000Z'),
+    messageHistory: [],
+    myCallsign: 'BG5DRB',
+  };
+}
+
+describe('DecisionOrchestrator QSO runtime identity', () => {
+  it('does not settle a completion into a replacement runtime with the same lifecycle epoch', async () => {
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const invokeStrategyRuntimeSync = vi.fn();
+    let runtimeGeneration = 10;
+    let request: Parameters<DigitalRadioEngineEvents['recordQSO']>[0] | undefined;
+    eventEmitter.on('recordQSO', (data) => {
+      request = data;
+    });
+    const orchestrator = new DecisionOrchestrator({
+      eventEmitter,
+      getStrategyRuntimeGeneration: () => runtimeGeneration,
+      invokeStrategyRuntimeSync,
+    } as any);
+    const record = qsoRecord();
+
+    (orchestrator as any).commitQSOCompletionEffect('op1', 10, {
+      lifecycleEpoch: 1,
+      record,
+    });
+
+    expect(request).toMatchObject({
+      qsoLifecycleId: 'op1:runtime:10:qso:1:qso-1',
+      qsoLifecycleEpoch: 1,
+      qsoRuntimeGeneration: 10,
+    });
+    runtimeGeneration = 11;
+    request?.resolve?.(record);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeStrategyRuntimeSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/plugin/__tests__/LogbookSyncHost.test.ts
+++ b/packages/server/src/plugin/__tests__/LogbookSyncHost.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { QSORecord } from '@tx5dr/contracts';
 import type { LogbookSyncProvider, SyncUploadOptions, SyncUploadResult } from '@tx5dr/plugin-api';
-import { LogbookSyncHost } from '../LogbookSyncHost.js';
+import { LogbookSyncHost, type LogbookSyncProviderOwner } from '../LogbookSyncHost.js';
 
 function createQso(id: string): QSORecord {
   return {
@@ -51,6 +51,24 @@ function createProvider(
   } as LogbookSyncProvider & { upload: ReturnType<typeof vi.fn> };
 }
 
+function createOwner(generation = 1): LogbookSyncProviderOwner & { active: boolean } {
+  return {
+    generation,
+    active: true,
+    isCurrent() {
+      return this.active;
+    },
+    async invoke(_operation, callback) {
+      if (!this.active) throw new Error('PLUGIN_INVOCATION_EXPIRED');
+      return callback();
+    },
+    invokeSync(_operation, callback) {
+      if (!this.active) throw new Error('PLUGIN_INVOCATION_EXPIRED');
+      return callback();
+    },
+  };
+}
+
 describe('LogbookSyncHost', () => {
   it('returns structured failures when a provider is not registered', async () => {
     const host = new LogbookSyncHost();
@@ -79,7 +97,7 @@ describe('LogbookSyncHost', () => {
   it('passes only the completed QSO record to auto-upload providers', async () => {
     const host = new LogbookSyncHost();
     const provider = createProvider();
-    host.register('wavelog-sync', provider);
+    host.register('wavelog-sync', provider, createOwner());
 
     const qso = createQso('qso-1');
     host.onQSOComplete('BG5DRB', qso);
@@ -105,7 +123,7 @@ describe('LogbookSyncHost', () => {
         failed: 0,
       };
     });
-    host.register('wavelog-sync', provider);
+    host.register('wavelog-sync', provider, createOwner());
 
     const qso1 = createQso('qso-1');
     const qso2 = createQso('qso-2');
@@ -138,7 +156,7 @@ describe('LogbookSyncHost', () => {
       }
       return { uploaded: 0, skipped: 0, failed: 0 };
     });
-    host.register('wavelog-sync', provider);
+    host.register('wavelog-sync', provider, createOwner());
 
     host.onQSOComplete('BG5DRB', createQso('qso-1'));
     await flushAsyncWork();
@@ -154,5 +172,27 @@ describe('LogbookSyncHost', () => {
 
     expect(provider.upload).toHaveBeenCalledTimes(2);
     expect(provider.upload.mock.calls[1]?.[1]).toEqual({ trigger: 'manual' });
+  });
+
+  it('does not run queued provider work after its plugin generation is revoked', async () => {
+    const host = new LogbookSyncHost();
+    const firstUpload = deferred<SyncUploadResult>();
+    const provider = createProvider(async () => firstUpload.promise);
+    const owner = createOwner(7);
+    host.register('wavelog-sync', provider, owner);
+
+    host.onQSOComplete('BG5DRB', createQso('qso-1'));
+    await flushAsyncWork();
+    host.onQSOComplete('BG5DRB', createQso('qso-2'));
+    await flushAsyncWork();
+    expect(provider.upload).toHaveBeenCalledTimes(1);
+
+    owner.active = false;
+    host.unregisterByPlugin('wavelog-sync', 7);
+    firstUpload.resolve({ uploaded: 1, skipped: 0, failed: 0 });
+    await flushAsyncWork();
+
+    expect(provider.upload).toHaveBeenCalledTimes(1);
+    expect(host.getProviderInfo('wavelog')).toBeNull();
   });
 });

--- a/packages/server/src/plugin/__tests__/PluginContextFactory.event-bus.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginContextFactory.event-bus.test.ts
@@ -61,7 +61,7 @@ async function createContext(
 describe('PluginContextFactory event bus access', () => {
   it('does not expose ctx.eventBus without permission', async () => {
     const ctx = await createContext(createPlugin());
-    expect(ctx.eventBus).toBeUndefined();
+    expect('eventBus' in ctx).toBe(false);
   });
 
   it('exposes ctx.eventBus with permission and forwards publisher metadata', async () => {

--- a/packages/server/src/plugin/__tests__/PluginContextFactory.logbook.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginContextFactory.logbook.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import type { DigitalRadioEngineEvents, QSORecord } from '@tx5dr/contracts';
 import { MODES } from '@tx5dr/contracts';
 import type { LoadedPlugin, PluginManagerDeps } from '../types.js';
+import type { LogbookAccess } from '@tx5dr/plugin-api';
 import { PluginContextFactory } from '../PluginContextFactory.js';
 import { LogManager } from '../../log/LogManager.js';
 
@@ -55,18 +56,50 @@ function createDeps(eventEmitter: EventEmitter<DigitalRadioEngineEvents>): Plugi
   };
 }
 
-function createPlugin(): LoadedPlugin {
+function createPlugin(permissions: LoadedPlugin['definition']['permissions'] = ['logbook:write']): LoadedPlugin {
   return {
     definition: {
       name: 'test-plugin',
       version: '1.0.0',
       type: 'utility',
+      permissions,
     },
     isBuiltIn: false,
   };
 }
 
 describe('PluginContextFactory logbook access', () => {
+  it('only exposes the declared logbook projection', async () => {
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const factory = new PluginContextFactory(createDeps(eventEmitter));
+    const storageDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-ctx-projection-'));
+    tempDirs.push(storageDir);
+
+    const noAccess = await factory.create(
+      createPlugin([]),
+      'operator-1',
+      'operator',
+      storageDir,
+      () => {},
+      () => ({}),
+    );
+    expect('logbook' in noAccess).toBe(false);
+
+    const readOnly = await factory.create(
+      createPlugin(['logbook:read']),
+      'operator-1',
+      'operator',
+      storageDir,
+      () => {},
+      () => ({}),
+    );
+    expect(readOnly.logbook).toBeDefined();
+    expect('queryQSOs' in readOnly.logbook!).toBe(true);
+    expect('addQSO' in readOnly.logbook!).toBe(false);
+    expect('updateQSO' in readOnly.logbook!).toBe(false);
+    expect('notifyUpdated' in readOnly.logbook!).toBe(false);
+  });
+
   it('returns the provider committed record for operator-bound add and update', async () => {
     const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
     const committedAdd: QSORecord = {
@@ -120,8 +153,9 @@ describe('PluginContextFactory logbook access', () => {
       messageHistory: ['caller update'],
     };
 
-    await expect(ctx.logbook.addQSO(input)).resolves.toEqual(committedAdd);
-    await expect(ctx.logbook.updateQSO(input.id, updates)).resolves.toEqual(committedUpdate);
+    const logbook = ctx.logbook as LogbookAccess;
+    await expect(logbook.addQSO(input)).resolves.toEqual(committedAdd);
+    await expect(logbook.updateQSO(input.id, updates)).resolves.toEqual(committedUpdate);
     expect(addQSO).toHaveBeenCalledWith(input, 'operator-1');
     expect(updateQSO).toHaveBeenCalledWith(input.id, updates);
   });
@@ -171,7 +205,7 @@ describe('PluginContextFactory logbook access', () => {
       () => ({}),
     );
 
-    await ctx.logbook.notifyUpdated();
+    await (ctx.logbook as LogbookAccess).notifyUpdated();
 
     expect(events).toHaveLength(1);
     expect(events[0]).toEqual({
@@ -236,7 +270,7 @@ describe('PluginContextFactory logbook access', () => {
       () => ({}),
     );
 
-    await ctx.logbook.forCallsign('bg5drb').notifyUpdated();
+    await (ctx.logbook as LogbookAccess).forCallsign('bg5drb').notifyUpdated();
 
     expect(getOrCreateLogBookByCallsign).not.toHaveBeenCalled();
     expect(events).toHaveLength(1);
@@ -275,7 +309,7 @@ describe('PluginContextFactory logbook access', () => {
       () => {},
       () => ({}),
     );
-    const logbook = ctx.logbook.forCallsign('bg5drb');
+    const logbook = (ctx.logbook as LogbookAccess).forCallsign('bg5drb');
     const record: QSORecord = {
       id: 'qso-1',
       callsign: 'N0CALL',

--- a/packages/server/src/plugin/__tests__/PluginContextFactory.operator.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginContextFactory.operator.test.ts
@@ -17,6 +17,7 @@ afterEach(async () => {
 function createPlugin(definition: Partial<LoadedPlugin['definition']> = {}): LoadedPlugin {
   return {
     definition: {
+      apiVersion: 2,
       name: 'test-plugin',
       version: '1.0.0',
       type: 'utility',
@@ -150,10 +151,34 @@ describe('PluginContextFactory operator access', () => {
     }]);
   });
 
-  it('rejects transmit-control APIs when permission is missing', async () => {
+  it('omits the command capability when permission is missing', async () => {
     const { ctx } = await createOperatorContext(createPlugin());
 
-    expect(() => ctx.operator.startTransmitting()).toThrow("permissions: ['operator:transmit-control']");
+    expect('operatorCommands' in ctx).toBe(false);
+    expect('startTransmitting' in ctx.operator).toBe(false);
+  });
+
+  it('exposes only host-arbitrated command ports when transmit capabilities are declared', async () => {
+    const { ctx } = await createOperatorContext(createPlugin({
+      apiVersion: 2,
+      permissions: [
+        'operator:transmit-control',
+        'radio:read',
+        'radio:control',
+        'radio:power',
+      ],
+      isTransmitControlEnabled: () => true,
+    }));
+
+    expect(ctx.operatorCommands).toBeDefined();
+    expect(Object.keys(ctx.operatorCommands!)).toEqual(['submit']);
+    expect('setPTT' in ctx).toBe(false);
+    expect('playAudio' in ctx).toBe(false);
+    expect('audioMixer' in ctx).toBe(false);
+    expect('encoder' in ctx).toBe(false);
+    expect('forceStopTransmission' in ctx).toBe(false);
+    expect('setPTT' in ctx.radio).toBe(false);
+    expect('stopPlayback' in ctx.radio).toBe(false);
   });
 
   it('rejects transmit-control APIs while auto-call state is disabled', async () => {
@@ -163,18 +188,9 @@ describe('PluginContextFactory operator access', () => {
     }));
     const lastMessage = { message: { type: 'CQ', raw: 'CQ TEST PM00' }, slotInfo: { id: 'slot-1', startMs: 0, window: 0 } } as any;
 
-    const actions = [
-      () => ctx.operator.startTransmitting(),
-      () => ctx.operator.stopTransmitting(),
-      () => ctx.operator.haltTransmission(),
-      () => ctx.operator.call('BG4IAK', lastMessage),
-      () => ctx.operator.replyToDecode({ callsign: 'BG4IAK', lastMessage }),
-      () => ctx.operator.sendFreeText('CQ TEST PM00'),
-    ];
-
-    for (const action of actions) {
-      expect(action).toThrow('isAutoCallEnabled(ctx) returned false');
-    }
+    expect(ctx.operatorCommands).toBeDefined();
+    await expect(ctx.operatorCommands!.submit({ type: 'request-call', callsign: 'BG4IAK', lastMessage }))
+      .rejects.toThrow('transmit-control eligibility predicate returned false');
   });
 
   it('rejects transmit-control APIs while the operator plugin is paused by the host', async () => {
@@ -200,29 +216,73 @@ describe('PluginContextFactory operator access', () => {
       () => ({}),
     );
 
-    expect(() => ctx.operator.startTransmitting()).toThrow('automatic calling is paused');
+    await expect(ctx.operatorCommands!.submit({ type: 'start-automation' }))
+      .rejects.toThrow('automatic calling is paused');
   });
 
   it('allows transmit-control APIs when permission and auto-call state are enabled', async () => {
-    const deps = createDeps();
+    const submitOperatorCommand = vi.fn(async (_operatorId, command) => ({
+      epoch: 1,
+      outcome: 'completed' as const,
+      command,
+    }));
+    const deps = createDeps({ submitOperatorCommand });
     const { ctx } = await createOperatorContext(createPlugin({
       permissions: ['operator:transmit-control'],
       isAutoCallEnabled: () => true,
     }), deps);
     const lastMessage = { message: { type: 'CQ', raw: 'CQ TEST PM00' }, slotInfo: { id: 'slot-1', startMs: 0, window: 0 } } as any;
-    const requestTransmit = vi.fn();
-    deps.eventEmitter.on('requestTransmit', requestTransmit);
+    await ctx.operatorCommands!.submit({ type: 'start-automation' });
+    await ctx.operatorCommands!.submit({ type: 'stop-automation' });
+    await ctx.operatorCommands!.submit({ type: 'request-call', callsign: 'BG4IAK', lastMessage });
+    await ctx.operatorCommands!.submit({ type: 'reply-to-decode', callsign: 'BG4IAK', lastMessage });
+    await ctx.operatorCommands!.submit({ type: 'send-free-text', text: 'CQ TEST PM00' });
+    await ctx.operatorCommands!.submit({ type: 'remove-contribution' });
 
-    expect(() => ctx.operator.startTransmitting()).not.toThrow();
-    expect(() => ctx.operator.stopTransmitting()).not.toThrow();
-    expect(() => ctx.operator.call('BG4IAK', lastMessage)).not.toThrow();
-    expect(() => ctx.operator.replyToDecode({ callsign: 'BG4IAK', lastMessage })).not.toThrow();
-    expect(() => ctx.operator.sendFreeText('CQ TEST PM00')).not.toThrow();
-    expect(() => ctx.operator.haltTransmission({ autoOnly: true })).not.toThrow();
+    expect(submitOperatorCommand.mock.calls.map(([, command]) => command.type)).toEqual([
+      'start-automation',
+      'stop-automation',
+      'request-call',
+      'reply-to-decode',
+      'send-free-text',
+      'remove-contribution',
+    ]);
+    expect(submitOperatorCommand).toHaveBeenCalledWith('operator-1', {
+      type: 'request-call',
+      callsign: 'BG4IAK',
+      lastMessage,
+    }, 'test-plugin');
+  });
 
-    expect(deps.getOperatorById('operator-1')?.start).toHaveBeenCalled();
-    expect(deps.getOperatorById('operator-1')?.stop).toHaveBeenCalled();
-    expect(deps.requestOperatorCall).toHaveBeenCalledWith('operator-1', 'BG4IAK', lastMessage);
-    expect(requestTransmit).toHaveBeenCalledWith({ operatorId: 'operator-1', transmission: 'CQ TEST PM00' });
+  it('uses the latest config when checking transmit-control eligibility', async () => {
+    let enabled = true;
+    const submitOperatorCommand = vi.fn(async (_operatorId, command) => ({
+      epoch: 1,
+      outcome: 'completed' as const,
+      command,
+    }));
+    const deps = createDeps({ submitOperatorCommand });
+    const plugin = createPlugin({
+      permissions: ['operator:transmit-control'],
+      isAutoCallEnabled: (ctx) => ctx.config.enabled === true,
+    });
+    const factory = new PluginContextFactory(deps);
+    const storageDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-ctx-config-'));
+    tempDirs.push(storageDir);
+    const ctx = await factory.create(
+      plugin,
+      'operator-1',
+      'operator',
+      storageDir,
+      () => {},
+      () => ({ enabled }),
+    );
+
+    await expect(ctx.operatorCommands!.submit({ type: 'start-automation' })).resolves.toBeDefined();
+    enabled = false;
+    await expect(ctx.operatorCommands!.submit({ type: 'start-automation' }))
+      .rejects.toThrow('transmit-control eligibility predicate returned false');
+    enabled = true;
+    await expect(ctx.operatorCommands!.submit({ type: 'start-automation' })).resolves.toBeDefined();
   });
 });

--- a/packages/server/src/plugin/__tests__/PluginContextFactory.radio.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginContextFactory.radio.test.ts
@@ -239,26 +239,65 @@ describe('PluginContextFactory radio access', () => {
     });
   });
 
-  it('rejects protected radio APIs when plugin permissions are missing', async () => {
+  it('omits protected radio capabilities when permissions are missing', async () => {
     const ctx = await createContext(createPlugin(), createDeps());
 
-    expect(() => ctx.radio.capabilities.getSnapshot()).toThrow("requires permission 'radio:read'");
-    await expect(ctx.radio.setFrequency(14_074_000)).rejects.toThrow("requires permission 'radio:control'");
-    await expect(ctx.radio.power.set('off')).rejects.toThrow("requires permission 'radio:power'");
+    expect('radioCapabilities' in ctx).toBe(false);
+    expect('radioCommands' in ctx).toBe(false);
+    expect('radioTunerCommands' in ctx).toBe(false);
+    expect('radioPower' in ctx).toBe(false);
+    expect('radioPowerCommands' in ctx).toBe(false);
+    expect('setFrequency' in ctx.radio).toBe(false);
   });
 
-  it('awaits host radio frequency writes and reports rejected writes', async () => {
-    const setRadioFrequency = vi.fn(async () => false);
+  it('routes radio frequency writes through the host maintenance coordinator', async () => {
+    const submitRadioMaintenanceCommand = vi.fn(async () => {
+      throw new Error('Failed to set radio frequency');
+    });
     const ctx = await createContext(
       createPlugin(['radio:control']),
-      createDeps({ setRadioFrequency }),
+      createDeps({ submitRadioMaintenanceCommand }),
     );
 
-    await expect(ctx.radio.setFrequency(7_074_000)).rejects.toThrow('Failed to set radio frequency');
-    expect(setRadioFrequency).toHaveBeenCalledWith(7_074_000);
+    await expect(ctx.radioCommands!.submit({ type: 'set-frequency', frequency: 7_074_000 }))
+      .rejects.toThrow('Failed to set radio frequency');
+    expect(submitRadioMaintenanceCommand).toHaveBeenCalledWith({
+      type: 'set-frequency',
+      frequency: 7_074_000,
+    });
   });
 
-  it('exposes capability read/write APIs with radio permissions', async () => {
+  it('requires tuner permission before requesting an auto-tuned band switch', async () => {
+    const submitRadioMaintenanceCommand = vi.fn(async () => undefined);
+    const ctx = await createContext(
+      createPlugin(['radio:control']),
+      createDeps({ submitRadioMaintenanceCommand }),
+    );
+
+    await expect(ctx.radioCommands!.submit({
+      type: 'switch-band',
+      frequency: 14_074_000,
+      autoTune: true,
+    })).rejects.toThrow('requires radio:tuner-control');
+    expect(submitRadioMaintenanceCommand).not.toHaveBeenCalled();
+
+    const tunerCtx = await createContext(
+      createPlugin(['radio:control', 'radio:tuner-control']),
+      createDeps({ submitRadioMaintenanceCommand }),
+    );
+    await tunerCtx.radioCommands!.submit({
+      type: 'switch-band',
+      frequency: 14_074_000,
+      autoTune: true,
+    });
+    expect(submitRadioMaintenanceCommand).toHaveBeenCalledWith({
+      type: 'switch-band',
+      frequency: 14_074_000,
+      autoTune: true,
+    });
+  });
+
+  it('keeps generic radio control separate from explicit tuner control', async () => {
     const snapshot: CapabilityList = {
       descriptors: [],
       capabilities: [{
@@ -269,24 +308,36 @@ describe('PluginContextFactory radio access', () => {
         updatedAt: 123,
       }],
     };
-    const writeRadioCapability = vi.fn(async () => undefined);
+    const submitRadioMaintenanceCommand = vi.fn(async () => undefined);
     const ctx = await createContext(
       createPlugin(['radio:read', 'radio:control']),
       createDeps({
         getRadioCapabilitySnapshot: () => snapshot,
         refreshRadioCapabilities: async () => snapshot,
-        writeRadioCapability,
+        submitRadioMaintenanceCommand,
       }),
     );
 
-    expect(ctx.radio.capabilities.getSnapshot()).toBe(snapshot);
-    expect(ctx.radio.capabilities.getState('agc_mode')).toEqual(snapshot.capabilities[0]);
-    await expect(ctx.radio.capabilities.refresh()).resolves.toBe(snapshot);
+    expect(ctx.radioCapabilities!.getSnapshot()).toBe(snapshot);
+    expect(ctx.radioCapabilities!.getState('agc_mode')).toEqual(snapshot.capabilities[0]);
+    await expect(ctx.radioCapabilities!.refresh()).resolves.toBe(snapshot);
 
-    await ctx.radio.capabilities.write({ id: 'agc_mode', value: 'fast' });
-    await ctx.radio.capabilities.write({ id: 'tuner_tune', action: true });
-    expect(writeRadioCapability).toHaveBeenNthCalledWith(1, { id: 'agc_mode', value: 'fast' });
-    expect(writeRadioCapability).toHaveBeenNthCalledWith(2, { id: 'tuner_tune', action: true });
+    expect('radioTunerCommands' in ctx).toBe(false);
+    expect(submitRadioMaintenanceCommand).not.toHaveBeenCalled();
+
+    const tunerCtx = await createContext(
+      createPlugin(['radio:tuner-control']),
+      createDeps({ submitRadioMaintenanceCommand }),
+    );
+    await tunerCtx.radioTunerCommands!.submit({ type: 'set-enabled', enabled: true });
+    await tunerCtx.radioTunerCommands!.submit({ type: 'start-manual-tune' });
+    expect(submitRadioMaintenanceCommand).toHaveBeenNthCalledWith(1, {
+      type: 'set-enabled',
+      enabled: true,
+    });
+    expect(submitRadioMaintenanceCommand).toHaveBeenNthCalledWith(2, {
+      type: 'start-manual-tune',
+    });
   });
 
   it('exposes power support/state/set APIs with defaults and overrides', async () => {
@@ -303,10 +354,14 @@ describe('PluginContextFactory radio access', () => {
       createDeps({ getRadioPowerSupport, getRadioPowerState, setRadioPower }),
     );
 
-    await expect(ctx.radio.power.getSupport()).resolves.toMatchObject({ profileId: 'active-profile' });
-    expect(ctx.radio.power.getState()).toMatchObject({ state: 'awake' });
-    await ctx.radio.power.set('on');
-    await ctx.radio.power.set('standby', { profileId: 'profile-2', autoEngine: false });
+    await expect(ctx.radioPower!.getSupport()).resolves.toMatchObject({ profileId: 'active-profile' });
+    expect(ctx.radioPower!.getState()).toMatchObject({ state: 'awake' });
+    await ctx.radioPowerCommands!.submit({ type: 'set-power', state: 'on' });
+    await ctx.radioPowerCommands!.submit({
+      type: 'set-power',
+      state: 'standby',
+      options: { profileId: 'profile-2', autoEngine: false },
+    });
 
     expect(setRadioPower).toHaveBeenNthCalledWith(1, 'on', undefined);
     expect(setRadioPower).toHaveBeenNthCalledWith(2, 'standby', { profileId: 'profile-2', autoEngine: false });
@@ -316,17 +371,17 @@ describe('PluginContextFactory radio access', () => {
   it('does not expose host-owned hamlib dependency without host permission', async () => {
     const ctx = await createContext(createPlugin(), createDeps());
 
-    expect(ctx.hostDependencies.hamlib).toBeUndefined();
+    expect('hostDependencies' in ctx).toBe(false);
   });
 
   it('exposes allow-listed host-owned hamlib dependency to permitted plugins', async () => {
     const ctx = await createContext(createPlugin(['host:hamlib']), createDeps());
 
-    expect(ctx.hostDependencies.hamlib).toBeDefined();
-    expect(typeof ctx.hostDependencies.hamlib?.Rotator).toBe('function');
-    expect(typeof ctx.hostDependencies.hamlib?.Rotator.getSupportedRotators).toBe('function');
-    expect(typeof ctx.hostDependencies.hamlib?.Rotator.getHamlibVersion()).toBe('string');
-    expect(ctx.hostDependencies.hamlib).not.toHaveProperty('HamLib');
-    expect(ctx.hostDependencies.hamlib).not.toHaveProperty('default');
+    expect(ctx.hostDependencies?.hamlib).toBeDefined();
+    expect(typeof ctx.hostDependencies?.hamlib?.Rotator).toBe('function');
+    expect(typeof ctx.hostDependencies?.hamlib?.Rotator.getSupportedRotators).toBe('function');
+    expect(typeof ctx.hostDependencies?.hamlib?.Rotator.getHamlibVersion()).toBe('string');
+    expect(ctx.hostDependencies?.hamlib).not.toHaveProperty('HamLib');
+    expect(ctx.hostDependencies?.hamlib).not.toHaveProperty('default');
   });
 });

--- a/packages/server/src/plugin/__tests__/PluginContextFactory.settings.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginContextFactory.settings.test.ts
@@ -115,20 +115,20 @@ async function createContext(plugin: LoadedPlugin, deps: PluginManagerDeps = cre
 }
 
 describe('PluginContextFactory host settings access', () => {
-  it('rejects settings namespaces when plugin permissions are missing', async () => {
+  it('does not expose settings when plugin permissions are missing', async () => {
     mockConfigManager();
     const ctx = await createContext(createPlugin());
 
-    await expect(ctx.settings.ft8.get()).rejects.toThrow("requires permission 'settings:ft8'");
-    await expect(ctx.settings.ntp.update({ servers: ['time.cloudflare.com'] })).rejects.toThrow("requires permission 'settings:ntp'");
+    expect(ctx.settings).toBeUndefined();
+    expect('settings' in ctx).toBe(false);
   });
 
   it('allows an ft8-permitted plugin to set guard backdoor values', async () => {
     const configManager = mockConfigManager();
     const ctx = await createContext(createPlugin(['settings:ft8']));
 
-    await expect(ctx.settings.ft8.update({ maxSameTransmissionCount: 0 })).resolves.toMatchObject({ maxSameTransmissionCount: 0 });
-    await expect(ctx.settings.ft8.update({ maxSameTransmissionCount: 999 })).resolves.toMatchObject({ maxSameTransmissionCount: 999 });
+    await expect(ctx.settings!.ft8!.update({ maxSameTransmissionCount: 0 })).resolves.toMatchObject({ maxSameTransmissionCount: 0 });
+    await expect(ctx.settings!.ft8!.update({ maxSameTransmissionCount: 999 })).resolves.toMatchObject({ maxSameTransmissionCount: 999 });
     expect(configManager.updateFT8Config).toHaveBeenCalledWith({ maxSameTransmissionCount: 0 });
     expect(configManager.updateFT8Config).toHaveBeenCalledWith({ maxSameTransmissionCount: 999 });
   });
@@ -137,10 +137,10 @@ describe('PluginContextFactory host settings access', () => {
     mockConfigManager();
     const ctx = await createContext(createPlugin(['settings:decode-windows', 'settings:ntp']));
 
-    await expect(ctx.settings.decodeWindows.update({ ft8: { preset: 'custom', customWindowTiming: [-1000] } })).resolves.toBeDefined();
-    await expect(ctx.settings.decodeWindows.update({ ft8: { preset: 'custom', customWindowTiming: [-99999] } })).rejects.toThrow();
-    await expect(ctx.settings.ntp.update({ servers: ['time.cloudflare.com'] })).resolves.toMatchObject({ servers: ['time.cloudflare.com'] });
-    await expect(ctx.settings.ntp.update({ servers: [] })).rejects.toThrow();
+    await expect(ctx.settings!.decodeWindows!.update({ ft8: { preset: 'custom', customWindowTiming: [-1000] } })).resolves.toBeDefined();
+    await expect(ctx.settings!.decodeWindows!.update({ ft8: { preset: 'custom', customWindowTiming: [-99999] } })).rejects.toThrow();
+    await expect(ctx.settings!.ntp!.update({ servers: ['time.cloudflare.com'] })).resolves.toMatchObject({ servers: ['time.cloudflare.com'] });
+    await expect(ctx.settings!.ntp!.update({ servers: [] })).rejects.toThrow();
   });
 
   it('emits realtimeSettingsChanged after realtime updates', async () => {
@@ -150,7 +150,7 @@ describe('PluginContextFactory host settings access', () => {
     deps.eventEmitter.on('realtimeSettingsChanged', realtimeSpy);
     const ctx = await createContext(createPlugin(['settings:realtime']), deps);
 
-    await ctx.settings.realtime.update({
+    await ctx.settings!.realtime!.update({
       transportPolicy: 'force-compat',
       rtcDataAudioPublicHost: 'radio.example.com',
       rtcDataAudioPublicUdpPort: 50110,

--- a/packages/server/src/plugin/__tests__/PluginInvocationGuard.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginInvocationGuard.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RuntimePluginContext } from '@tx5dr/plugin-api';
+import { PluginInvocationGuard } from '../PluginInvocationGuard.js';
+import type { PluginInstance } from '../types.js';
+
+function createInstance(context: RuntimePluginContext): PluginInstance {
+  return {
+    plugin: {
+      definition: {
+        apiVersion: 2,
+        name: 'guard-test',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['operator:transmit-control'],
+        isAutoCallEnabled: () => true,
+      },
+      isBuiltIn: false,
+    },
+    scope: { kind: 'operator', operatorId: 'operator-1' },
+    ctx: context,
+    rawCtx: context,
+    generation: 1,
+    lifecycle: 'active',
+    lifecycleTail: Promise.resolve(),
+    desiredLifecycle: 'active',
+    lifecycleRevision: 1,
+    enabled: true,
+    errorCounts: new Map(),
+    autoDisabled: false,
+  };
+}
+
+describe('PluginInvocationGuard', () => {
+  it('revokes methods retained through property descriptors', async () => {
+    const submit = vi.fn(async () => ({ epoch: 1, outcome: 'completed' as const }));
+    const raw = {
+      operatorCommands: { submit },
+    } as unknown as RuntimePluginContext;
+    const instance = createInstance(raw);
+    const guard = new PluginInvocationGuard();
+    const ctx = guard.wrapContext(raw, instance);
+    let retainedSubmit: (() => Promise<unknown>) | undefined;
+
+    await guard.invoke(instance, 'test:descriptor', async () => {
+      const commands = Object.getOwnPropertyDescriptor(ctx, 'operatorCommands')?.value;
+      retainedSubmit = Object.getOwnPropertyDescriptor(commands, 'submit')?.value;
+      await retainedSubmit?.();
+    });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(() => retainedSubmit?.()).toThrow('Plugin invocation is no longer allowed');
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks invocation state when nested scalar properties are read', async () => {
+    const raw = {
+      radioPower: { state: 'awake' },
+    } as unknown as RuntimePluginContext;
+    const instance = createInstance(raw);
+    const guard = new PluginInvocationGuard();
+    const ctx = guard.wrapContext(raw, instance);
+    let retainedPower: Record<string, unknown> | undefined;
+
+    await guard.invoke(instance, 'test:nested-read', () => {
+      retainedPower = ctx.radioPower as unknown as Record<string, unknown>;
+      expect(retainedPower.state).toBe('awake');
+    });
+
+    expect(() => retainedPower?.state).toThrow('Plugin invocation is no longer allowed');
+  });
+});

--- a/packages/server/src/plugin/__tests__/PluginLoader.runtime-log.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginLoader.runtime-log.test.ts
@@ -17,6 +17,29 @@ async function createPluginRoot(): Promise<string> {
 }
 
 describe('PluginLoader runtime logs', () => {
+  it('canonicalizes and freezes loaded permission declarations', async () => {
+    const pluginRoot = await createPluginRoot();
+    const pluginDir = join(pluginRoot, 'frozen-plugin');
+    await mkdir(pluginDir, { recursive: true });
+    await writeFile(join(pluginDir, 'index.mjs'), `
+      export default {
+        apiVersion: 2,
+        name: 'frozen-plugin',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['radio:read', 'radio:read'],
+      };
+    `, 'utf8');
+
+    const [loaded] = await new PluginLoader().scanAndLoad(pluginRoot);
+
+    expect(loaded?.definition.permissions).toEqual(['radio:read']);
+    expect(Object.isFrozen(loaded?.definition)).toBe(true);
+    expect(Object.isFrozen(loaded?.definition.permissions)).toBe(true);
+    expect(() => loaded?.definition.permissions?.push('radio:control')).toThrow();
+    expect(loaded?.definition.permissions).toEqual(['radio:read']);
+  });
+
   it('emits load attempt and success logs for a valid plugin', async () => {
     const pluginRoot = await createPluginRoot();
     const pluginDir = join(pluginRoot, 'hello-plugin');
@@ -144,12 +167,13 @@ describe('PluginLoader runtime logs', () => {
     expect(errorLog?.message).toContain('Plugin definition validation failed');
   });
 
-  it('rejects transmit-control plugins without auto-call state declaration', async () => {
+  it('rejects transmit-control plugins without an eligibility declaration', async () => {
     const pluginRoot = await createPluginRoot();
     const pluginDir = join(pluginRoot, 'missing-autocall-state');
     await mkdir(pluginDir, { recursive: true });
     await writeFile(join(pluginDir, 'index.mjs'), `
       export default {
+        apiVersion: 2,
         name: 'missing-autocall-state',
         version: '1.0.0',
         type: 'utility',
@@ -167,7 +191,7 @@ describe('PluginLoader runtime logs', () => {
       && entry.level === 'error'
       && entry.directoryName === 'missing-autocall-state');
     expect(errorLog).toBeDefined();
-    expect(JSON.stringify(errorLog?.details)).toContain('isAutoCallEnabled');
+    expect(JSON.stringify(errorLog?.details)).toContain('isTransmitControlEnabled');
   });
 
   it('rejects global transmit-control plugins', async () => {
@@ -176,6 +200,7 @@ describe('PluginLoader runtime logs', () => {
     await mkdir(pluginDir, { recursive: true });
     await writeFile(join(pluginDir, 'index.mjs'), `
       export default {
+        apiVersion: 2,
         name: 'global-transmit-control',
         version: '1.0.0',
         type: 'utility',
@@ -198,17 +223,18 @@ describe('PluginLoader runtime logs', () => {
     expect(JSON.stringify(errorLog?.details)).toContain('operator instance scope');
   });
 
-  it('loads operator-scoped transmit-control plugins with auto-call state declaration', async () => {
+  it('loads operator-scoped transmit-control integrations without classifying them as auto-call', async () => {
     const pluginRoot = await createPluginRoot();
     const pluginDir = join(pluginRoot, 'valid-transmit-control');
     await mkdir(pluginDir, { recursive: true });
     await writeFile(join(pluginDir, 'index.mjs'), `
       export default {
+        apiVersion: 2,
         name: 'valid-transmit-control',
         version: '1.0.0',
         type: 'utility',
         permissions: ['operator:transmit-control'],
-        isAutoCallEnabled() { return true; },
+        isTransmitControlEnabled() { return true; },
       };
     `, 'utf8');
 
@@ -217,6 +243,8 @@ describe('PluginLoader runtime logs', () => {
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0]?.definition.name).toBe('valid-transmit-control');
+    expect(loaded[0]?.definition.isAutoCallEnabled).toBeUndefined();
+    expect(loaded[0]?.definition.isTransmitControlEnabled?.({ config: {} })).toBe(true);
   });
 
   it('rejects global plugins that implement the frequency-change hook', async () => {

--- a/packages/server/src/plugin/__tests__/PluginManager.global-instance.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.global-instance.test.ts
@@ -307,8 +307,10 @@ describe('PluginManager global instance scope', () => {
       export default {
         name: 'global-sync-test',
         version: '1.0.0',
+        apiVersion: 2,
         type: 'utility',
         instanceScope: 'global',
+        permissions: ['logbook:sync'],
         ui: {
           pages: [
             {

--- a/packages/server/src/plugin/__tests__/PluginManager.lifecycle.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.lifecycle.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'eventemitter3';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { DigitalRadioEngineEvents } from '@tx5dr/contracts';
+import { MODES } from '@tx5dr/contracts';
+import { RadioOperator } from '@tx5dr/core';
+import type { RuntimePluginContext } from '@tx5dr/plugin-api';
+import { PluginManager } from '../PluginManager.js';
+
+const tempDirs: string[] = [];
+const lifecycleProbeKey = '__tx5drPluginLifecycleProbe';
+
+interface LifecycleProbe {
+  onLoad?: (ctx: RuntimePluginContext) => void | Promise<void>;
+  onUnload?: (ctx: RuntimePluginContext) => void | Promise<void>;
+}
+
+function getLifecycleProbe(): LifecycleProbe {
+  return (globalThis as typeof globalThis & Record<typeof lifecycleProbeKey, LifecycleProbe>)[lifecycleProbeKey];
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  delete (globalThis as typeof globalThis & Partial<Record<typeof lifecycleProbeKey, LifecycleProbe>>)[lifecycleProbeKey];
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function createOperator(eventEmitter: EventEmitter<DigitalRadioEngineEvents>): RadioOperator {
+  eventEmitter.on('checkHasWorkedCallsign' as any, (data: { requestId: string }) => {
+    eventEmitter.emit('hasWorkedCallsignResponse' as any, {
+      requestId: data.requestId,
+      hasWorked: false,
+    });
+  });
+  return new RadioOperator({
+    id: 'operator-1',
+    mode: MODES.FT8,
+    myCallsign: 'BG4IAJ',
+    myGrid: 'OM96',
+    frequency: 7_074_000,
+    transmitCycles: [0],
+    maxQSOTimeoutCycles: 6,
+    maxCallAttempts: 5,
+    autoReplyToCQ: false,
+    autoResumeCQAfterFail: false,
+    autoResumeCQAfterSuccess: false,
+    replyToWorkedStations: false,
+    prioritizeNewCalls: true,
+    targetSelectionPriorityMode: 'dxcc_first',
+  }, eventEmitter);
+}
+
+async function createManager(): Promise<{
+  manager: PluginManager;
+  operator: RadioOperator;
+}> {
+  const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-lifecycle-'));
+  tempDirs.push(dataDir);
+  const pluginDir = join(dataDir, 'plugins', 'lifecycle-probe');
+  await mkdir(pluginDir, { recursive: true });
+  (globalThis as typeof globalThis & Record<typeof lifecycleProbeKey, LifecycleProbe>)[lifecycleProbeKey] = {};
+  await writeFile(join(pluginDir, 'index.mjs'), `
+    export default {
+      apiVersion: 2,
+      name: 'lifecycle-probe',
+      version: '1.0.0',
+      type: 'utility',
+      permissions: ['operator:transmit-control'],
+      isAutoCallEnabled() { return true; },
+      onLoad(ctx) {
+        return globalThis.${lifecycleProbeKey}?.onLoad?.(ctx);
+      },
+      onUnload(ctx) {
+        return globalThis.${lifecycleProbeKey}?.onUnload?.(ctx);
+      },
+    };
+  `, 'utf8');
+
+  const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+  const operator = createOperator(eventEmitter);
+  let manager!: PluginManager;
+  manager = new PluginManager({
+    eventEmitter,
+    getOperators: () => [operator],
+    getOperatorById: (id) => (id === operator.config.id ? operator : undefined),
+    getCurrentMode: () => operator.config.mode,
+    getOperatorAutomationSnapshot: (id) => manager.getOperatorAutomationSnapshot(id),
+    requestOperatorCall: (operatorId, callsign, lastMessage) => {
+      manager.requestCall(operatorId, callsign, lastMessage);
+    },
+    getRadioFrequency: async () => operator.config.frequency,
+    setRadioFrequency: () => {},
+    getRadioBand: () => '40m',
+    getRadioConnected: () => true,
+    getLatestSlotPack: () => null,
+    interruptOperatorTransmission: async () => {},
+    hasWorkedCallsign: async () => false,
+    resetOperatorRuntime: () => {},
+    dataDir,
+  });
+  manager.loadConfig({
+    configs: {
+      'lifecycle-probe': { enabled: false, settings: {} },
+    },
+    operatorStrategies: {
+      [operator.config.id]: 'standard-qso',
+    },
+    operatorSettings: {},
+  });
+  await manager.start();
+  return { manager, operator };
+}
+
+function getProbeInstance(manager: PluginManager, operatorId: string): any {
+  return (manager as any).instances.get(operatorId).get('lifecycle-probe');
+}
+
+describe('PluginManager instance lifecycle reconciliation', () => {
+  it('tombstones an obsolete activation when enable and disable race in one turn', async () => {
+    const { manager, operator } = await createManager();
+    const instance = getProbeInstance(manager, operator.config.id);
+    const onLoad = vi.fn();
+    getLifecycleProbe().onLoad = onLoad;
+
+    manager.setPluginEnabled('lifecycle-probe', true);
+    manager.setPluginEnabled('lifecycle-probe', false);
+    await instance.lifecycleTail;
+
+    expect(onLoad).not.toHaveBeenCalled();
+    expect(instance.lifecycle).toBe('inactive');
+    expect(instance.desiredLifecycle).toBe('inactive');
+    await manager.shutdown();
+  });
+
+  it('revokes a suspended onLoad before its late continuation can submit a command', async () => {
+    const { manager, operator } = await createManager();
+    const instance = getProbeInstance(manager, operator.config.id);
+    let releaseLoad!: () => void;
+    let markStarted!: () => void;
+    const loadGate = new Promise<void>((resolve) => { releaseLoad = resolve; });
+    const started = new Promise<void>((resolve) => { markStarted = resolve; });
+    let lateCommandError: unknown;
+    let markLateDone!: () => void;
+    const lateDone = new Promise<void>((resolve) => { markLateDone = resolve; });
+    const onUnload = vi.fn();
+
+    getLifecycleProbe().onLoad = async (ctx: RuntimePluginContext) => {
+      markStarted();
+      await loadGate;
+      try {
+        await ctx.operatorCommands?.submit({ type: 'start-automation' });
+      } catch (error) {
+        lateCommandError = error;
+      } finally {
+        markLateDone();
+      }
+    };
+    getLifecycleProbe().onUnload = onUnload;
+
+    manager.setPluginEnabled('lifecycle-probe', true);
+    await started;
+    manager.setPluginEnabled('lifecycle-probe', false);
+    releaseLoad();
+    await Promise.all([instance.lifecycleTail, lateDone]);
+
+    expect(lateCommandError).toMatchObject({ code: 'PLUGIN_INVOCATION_EXPIRED' });
+    expect(onUnload).toHaveBeenCalledOnce();
+    expect(instance.lifecycle).toBe('inactive');
+    await manager.shutdown();
+  });
+
+  it('rebuilds ingress when a queued deactivate is superseded by re-enable', async () => {
+    const { manager, operator } = await createManager();
+    const instance = getProbeInstance(manager, operator.config.id);
+    const onLoad = vi.fn();
+    const onUnload = vi.fn();
+    getLifecycleProbe().onLoad = onLoad;
+    getLifecycleProbe().onUnload = onUnload;
+
+    manager.setPluginEnabled('lifecycle-probe', true);
+    await instance.lifecycleTail;
+    expect(instance.lifecycle).toBe('active');
+
+    manager.setPluginEnabled('lifecycle-probe', false);
+    manager.setPluginEnabled('lifecycle-probe', true);
+    await instance.lifecycleTail;
+
+    expect(onUnload).toHaveBeenCalledOnce();
+    expect(onLoad).toHaveBeenCalledTimes(2);
+    expect(instance.lifecycle).toBe('active');
+    expect(instance.desiredLifecycle).toBe('active');
+    await manager.shutdown();
+  });
+});

--- a/packages/server/src/plugin/__tests__/PluginManager.page-handler-routing.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.page-handler-routing.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'eventemitter3';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -168,5 +168,92 @@ describe('PluginManager page handler routing', () => {
     await expect(invoke('operator-2')).resolves.toEqual({ operatorId: 'operator-2' });
 
     await pluginManager.shutdown();
+  });
+
+  it('revokes page files and push capabilities after their request invocation ends', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-page-revoke-'));
+    tempDirs.push(dataDir);
+    await writeUserPlugin(dataDir, 'page-revoke-test', `
+      let retained;
+      export default {
+        name: 'page-revoke-test',
+        version: '1.0.0',
+        type: 'utility',
+        instanceScope: 'global',
+        ui: { pages: [{ id: 'settings', title: 'Settings', entry: 'settings.html' }] },
+        onLoad(ctx) {
+          ctx.ui.registerPageHandler({
+            async onMessage(_pageId, action, _data, requestContext) {
+              if (action === 'retain') {
+                retained = requestContext;
+                return 'retained';
+              }
+              if (action === 'reuse-files') {
+                await retained.files.write('late.bin', Buffer.from('late'));
+              }
+              if (action === 'reuse-push') {
+                retained.page.push('late');
+              }
+              return 'ok';
+            },
+          });
+        },
+      };
+    `);
+    await mkdir(join(dataDir, 'plugins', 'page-revoke-test', 'ui'), { recursive: true });
+    await writeFile(
+      join(dataDir, 'plugins', 'page-revoke-test', 'ui', 'settings.html'),
+      '<!doctype html><html><body>settings</body></html>',
+      'utf8',
+    );
+
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const manager = new PluginManager({
+      eventEmitter,
+      getOperators: () => [],
+      getOperatorById: () => undefined,
+      getCurrentMode: () => MODES.FT8,
+      getOperatorAutomationSnapshot: () => null,
+      requestOperatorCall: () => {},
+      getRadioFrequency: async () => null,
+      setRadioFrequency: () => {},
+      getRadioBand: () => '40m',
+      getRadioConnected: () => true,
+      getLatestSlotPack: () => null,
+      interruptOperatorTransmission: async () => {},
+      hasWorkedCallsign: async () => false,
+      resetOperatorRuntime: () => {},
+      dataDir,
+    });
+    manager.loadConfig({
+      configs: { 'page-revoke-test': { enabled: true, settings: {} } },
+      operatorStrategies: {},
+      operatorSettings: {},
+    });
+    await manager.start();
+
+    const write = vi.fn(async () => undefined);
+    const push = vi.fn();
+    const context = {
+      pageSessionId: 'session-1',
+      user: { tokenId: 'token-1', role: 'admin' as const, operatorIds: [] },
+      instanceTarget: { kind: 'global' as const },
+      files: { write, read: async () => null, delete: async () => false, list: async () => [] },
+      page: { sessionId: 'session-1', pageId: 'settings', push },
+    };
+
+    await expect(manager.invokePluginPageHandler(
+      'page-revoke-test', 'settings', 'retain', null, context,
+    )).resolves.toBe('retained');
+    await expect(manager.invokePluginPageHandler(
+      'page-revoke-test', 'settings', 'reuse-files', null, context,
+    )).rejects.toThrow('Plugin invocation-scoped capability has expired');
+    await expect(manager.invokePluginPageHandler(
+      'page-revoke-test', 'settings', 'reuse-push', null, context,
+    )).rejects.toThrow('Plugin invocation-scoped capability has expired');
+    expect(write).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+
+    await manager.shutdown();
   });
 });

--- a/packages/server/src/plugin/__tests__/PluginManager.runtime-log.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.runtime-log.test.ts
@@ -187,6 +187,7 @@ describe('PluginManager runtime logs', () => {
 
     await writeUserPlugin(dataDir, 'tx-control-test', `
       export default {
+        apiVersion: 2,
         name: 'tx-control-test',
         version: '1.0.0',
         type: 'utility',
@@ -242,12 +243,90 @@ describe('PluginManager runtime logs', () => {
     await pluginManager.shutdown();
   });
 
+  it('does not expose generic operator-command integrations as auto-call controllers', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-runtime-log-'));
+    tempDirs.push(dataDir);
+
+    await writeUserPlugin(dataDir, 'remote-control-integration', `
+      export default {
+        apiVersion: 2,
+        name: 'remote-control-integration',
+        version: '1.0.0',
+        type: 'utility',
+        permissions: ['operator:transmit-control'],
+        isTransmitControlEnabled() { return true; },
+      };
+    `);
+
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const operator = createOperator(eventEmitter);
+    const pluginManager = createPluginManager(dataDir, eventEmitter, operator);
+    pluginManager.loadConfig({
+      configs: {
+        'remote-control-integration': { enabled: true, settings: {} },
+      },
+      operatorStrategies: {
+        [operator.config.id]: 'standard-qso',
+      },
+      operatorSettings: {},
+    });
+
+    await pluginManager.start();
+    const status = pluginManager.getSnapshot().plugins.find((plugin) => (
+      plugin.name === 'remote-control-integration'
+    ));
+    expect(status?.permissions).toContain('operator:transmit-control');
+    expect(status?.capabilities ?? []).not.toContain('auto_call_control');
+    expect(status?.autoCallEnabledOperatorIds).toBeUndefined();
+    expect(status?.pausedOperatorIds).toBeUndefined();
+    await expect(pluginManager.setOperatorPluginPaused(
+      operator.config.id,
+      'remote-control-integration',
+      true,
+    )).rejects.toThrow('not an automatic calling controller');
+
+    await pluginManager.shutdown();
+  });
+
+  it('does not expose QSO UDP broadcast as an auto-call controller', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-runtime-log-'));
+    tempDirs.push(dataDir);
+
+    const eventEmitter = new EventEmitter<DigitalRadioEngineEvents>();
+    const operator = createOperator(eventEmitter);
+    const pluginManager = createPluginManager(dataDir, eventEmitter, operator);
+    pluginManager.loadConfig({
+      configs: {
+        'qso-udp-broadcast': { enabled: false, settings: {} },
+      },
+      operatorStrategies: {
+        [operator.config.id]: 'standard-qso',
+      },
+      operatorSettings: {},
+      operatorPluginPauses: {
+        [operator.config.id]: ['qso-udp-broadcast'],
+      },
+    });
+
+    await pluginManager.start();
+    const status = pluginManager.getSnapshot().plugins.find((plugin) => (
+      plugin.name === 'qso-udp-broadcast'
+    ));
+    expect(status?.permissions).toContain('operator:transmit-control');
+    expect(status?.capabilities ?? []).not.toContain('auto_call_control');
+    expect(status?.autoCallEnabledOperatorIds).toBeUndefined();
+    expect(status?.pausedOperatorIds).toBeUndefined();
+
+    await pluginManager.shutdown();
+  });
+
   it('persists operator plugin pauses and gates transmit-control hooks and actions', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'tx5dr-plugin-pause-'));
     tempDirs.push(dataDir);
 
     await writeUserPlugin(dataDir, 'pausable-tx-control', `
       export default {
+        apiVersion: 2,
         name: 'pausable-tx-control',
         version: '1.0.0',
         type: 'utility',
@@ -304,7 +383,7 @@ describe('PluginManager runtime logs', () => {
     vi.spyOn(ConfigManager, 'getInstance').mockReturnValue({
       setOperatorPluginPauses,
     } as unknown as ConfigManager);
-    const timerManager = (pluginManager as any).instances.get(operator.config.id).get('pausable-tx-control').ctx.timers;
+    const timerManager = (pluginManager as any).instances.get(operator.config.id).get('pausable-tx-control').rawCtx.timers;
     timerManager.onTimerFired('poll');
     await (pluginManager as any).handleSlotStart({ id: 'slot-1', startMs: 0, window: 0 }, null);
     pluginManager.handlePluginUserAction('pausable-tx-control', 'ping', operator.config.id);
@@ -449,20 +528,10 @@ describe('PluginManager runtime logs', () => {
     tempDirs.push(dataDir);
     await writeUserPlugin(dataDir, 'user-standard-qso', `
       export default {
+        apiVersion: 2,
         name: 'standard-qso',
         version: '9.9.9',
-        type: 'strategy',
-        createStrategyRuntime() {
-          return {
-            getCurrentTransmission() { return null; },
-            onSlotStart() { return null; },
-            getStatus() { return { currentSlot: 'TX1', context: {}, slots: {} }; },
-            reset() {},
-            setContext() {},
-            setCurrentSlot() {},
-            setCurrentSlotContent() {},
-          };
-        },
+        type: 'utility',
       };
     `);
 

--- a/packages/server/src/plugin/__tests__/PluginManager.standard-qso.test.ts
+++ b/packages/server/src/plugin/__tests__/PluginManager.standard-qso.test.ts
@@ -10,6 +10,7 @@ import type { ScoredCandidate } from '@tx5dr/plugin-api';
 import { STANDARD_QSO_TX6_MESSAGE_OVERRIDE_SETTING } from '@tx5dr/builtin-plugins';
 import { PluginManager } from '../PluginManager.js';
 import { LogManager } from '../../log/LogManager.js';
+import { TargetReservationCoordinator } from '../../transmission/TargetReservationCoordinator.js';
 
 type RecordQSORequest = Parameters<DigitalRadioEngineEvents['recordQSO']>[0];
 
@@ -133,6 +134,10 @@ describe('PluginManager standard-qso late re-decision', () => {
     pluginConfigs?: Record<string, { enabled: boolean; settings: Record<string, unknown> }>;
     operatorPluginSettings?: Record<string, Record<string, unknown>>;
     interruptOperatorTransmission?: (operatorId: string) => Promise<void>;
+    triggerReEncode?: (
+      operatorId: string,
+      options?: { source?: 'late-decode' | 'operator-edit' | 'plugin'; reason?: string },
+    ) => void;
     radioBand?: string;
     recordQSOHandler?: (data: RecordQSORequest) => void;
   }) {
@@ -170,6 +175,7 @@ describe('PluginManager standard-qso late re-decision', () => {
     tempDirs.push(dataDir);
     const interruptOperatorTransmission = options?.interruptOperatorTransmission
       ?? (async () => undefined);
+    const requestOperatorStrategyStop = vi.fn();
 
     // This unit harness intentionally omits RadioOperatorManager. Acknowledge
     // persistence requests so protocol tests do not hang on the production
@@ -198,6 +204,7 @@ describe('PluginManager standard-qso late re-decision', () => {
       getRadioConnected: () => true,
       getLatestSlotPack: () => null,
       interruptOperatorTransmission,
+      requestOperatorStrategyStop,
       hasWorkedCallsign: async (_operatorId, callsign, hasWorkedOptions) => {
         if (typeof options?.hasWorkedCallsign === 'function') {
           return options.hasWorkedCallsign(callsign, hasWorkedOptions);
@@ -205,6 +212,7 @@ describe('PluginManager standard-qso late re-decision', () => {
         return options?.hasWorkedCallsign ?? false;
       },
       resetOperatorRuntime: () => {},
+      triggerReEncode: options?.triggerReEncode,
       dataDir,
     });
     // This harness omits RadioOperatorManager, so emulate its post-validation acceptance callback.
@@ -255,6 +263,7 @@ describe('PluginManager standard-qso late re-decision', () => {
       dataDir,
       eventEmitter,
       interruptOperatorTransmission,
+      requestOperatorStrategyStop,
       operator,
       pluginManager,
     };
@@ -284,6 +293,7 @@ describe('PluginManager standard-qso late re-decision', () => {
 
     let pluginManager!: PluginManager;
     const operators: RadioOperator[] = [];
+    const targetReservations = new TargetReservationCoordinator();
     const isTargetBeingWorkedByOtherOperators = (
       myCallsign: string,
       targetCallsign: string,
@@ -291,6 +301,9 @@ describe('PluginManager standard-qso late re-decision', () => {
     ): boolean => {
       const normalizedMyCall = myCallsign.toUpperCase();
       const normalizedTarget = targetCallsign.toUpperCase();
+      if (targetReservations.isReservedByOther(normalizedMyCall, normalizedTarget, currentOperatorId)) {
+        return true;
+      }
       return operators.some((operator) => {
         if (operator.config.id === currentOperatorId) return false;
         if (operator.config.myCallsign.toUpperCase() !== normalizedMyCall) return false;
@@ -337,6 +350,17 @@ describe('PluginManager standard-qso late re-decision', () => {
       getRadioConnected: () => true,
       getLatestSlotPack: () => null,
       interruptOperatorTransmission: async () => undefined,
+      transitionTargetReservation: (operatorId, epoch, targetCallsign) => {
+        const operator = operators.find((candidate) => candidate.config.id === operatorId);
+        if (!operator) return false;
+        return targetReservations.tryTransition({
+          stationCallsign: operator.config.myCallsign,
+          targetCallsign,
+          operatorId,
+          epoch,
+        });
+      },
+      releaseTargetReservation: (operatorId, epoch) => targetReservations.releaseOperator(operatorId, epoch),
       hasWorkedCallsign: async (_operatorId, callsign, hasWorkedOptions) => {
         if (typeof options?.hasWorkedCallsign === 'function') {
           return options.hasWorkedCallsign(callsign, hasWorkedOptions);
@@ -472,45 +496,65 @@ describe('PluginManager standard-qso late re-decision', () => {
   });
 
   it('starts manual CQ calls at TX2 when skipTx1 is enabled', async () => {
+    const triggerReEncode = vi.fn();
     const { operator, pluginManager } = await createRuntimeHarness({
       myCallsign: 'BG5DRB',
       myGrid: 'PM01',
       skipTx1: true,
+      triggerReEncode,
     });
 
-    pluginManager.requestCall(operator.config.id, 'JA1AAA', {
-      message: {
-        message: 'CQ JA1AAA PM95',
-        snr: -7,
-        dt: 0,
-        freq: 1300,
-        confidence: 0.9,
+    pluginManager.requestCall(
+      operator.config.id,
+      'JA1AAA',
+      {
+        message: {
+          message: 'CQ JA1AAA PM95',
+          snr: -7,
+          dt: 0,
+          freq: 1300,
+          confidence: 0.9,
+        },
+        slotInfo: createSlotInfo(45_000),
       },
-      slotInfo: createSlotInfo(45_000),
-    });
+      { submitCurrentFrame: true, source: 'operator-edit' },
+    );
 
     const status = pluginManager.getOperatorRuntimeStatus(operator.config.id);
     expect(status.currentSlot).toBe('TX2');
     expect(status.context?.targetCallsign).toBe('JA1AAA');
     expect(status.slots?.TX1).toBe('JA1AAA BG5DRB PM01');
     expect(getCurrentTransmission(pluginManager, operator.config.id)).toBe('JA1AAA BG5DRB -07');
+    expect(triggerReEncode).not.toHaveBeenCalled();
 
     await pluginManager.shutdown();
   });
 
   it('starts calls without a source message at TX2 with the default report when skipTx1 is enabled', async () => {
+    const triggerReEncode = vi.fn();
     const { operator, pluginManager } = await createRuntimeHarness({
       myCallsign: 'BG5DRB',
       myGrid: 'PM01',
       skipTx1: true,
+      triggerReEncode,
     });
 
-    pluginManager.requestCall(operator.config.id, 'JA1AAA');
+    pluginManager.requestCall(
+      operator.config.id,
+      'JA1AAA',
+      undefined,
+      { submitCurrentFrame: true, source: 'operator-edit' },
+    );
 
     const status = pluginManager.getOperatorRuntimeStatus(operator.config.id);
     expect(status.currentSlot).toBe('TX2');
     expect(status.context?.targetCallsign).toBe('JA1AAA');
     expect(getCurrentTransmission(pluginManager, operator.config.id)).toBe('JA1AAA BG5DRB +00');
+    expect(triggerReEncode).toHaveBeenCalledWith(operator.config.id, {
+      source: 'operator-edit',
+      reason: 'requestCall updated operator context',
+      decisionEpoch: expect.any(Number),
+    });
 
     await pluginManager.shutdown();
   });
@@ -574,7 +618,7 @@ describe('PluginManager standard-qso late re-decision', () => {
       autoResumeCQAfterSuccess: true,
     });
     const requestTransmitSpy = (payload: { operatorId: string; transmission: string }) => payload;
-    const transmissions: Array<{ operatorId: string; transmission: string }> = [];
+    const transmissions: Array<{ operatorId: string; transmission: string; decisionEpoch?: number }> = [];
     eventEmitter.on('requestTransmit', (payload) => {
       transmissions.push(payload);
     });
@@ -690,6 +734,7 @@ describe('PluginManager standard-qso late re-decision', () => {
     expect(transmissions).toEqual([{
       operatorId: operator.config.id,
       transmission: expectedTransmission,
+      decisionEpoch: expect.any(Number),
     }]);
 
     const pending = persistenceRequest;
@@ -1621,9 +1666,9 @@ describe('PluginManager standard-qso late re-decision', () => {
     await pluginManager.shutdown();
   });
 
-  it('immediately interrupts the active transmission when a late re-decision stops the operator', async () => {
+  it('stops future automation without interrupting committed RF when a late re-decision stops the operator', async () => {
     const interruptOperatorTransmission = vi.fn(async () => undefined);
-    const { operator, pluginManager } = await createRuntimeHarness({
+    const { operator, pluginManager, requestOperatorStrategyStop } = await createRuntimeHarness({
       myCallsign: 'BG7XTV',
       myGrid: 'OL32',
       targetCallsign: 'BG5DRB',
@@ -1655,8 +1700,8 @@ describe('PluginManager standard-qso late re-decision', () => {
     expect(stopped).toBe(false);
     expect(pluginManager.getOperatorRuntimeStatus(operator.config.id).currentSlot).toBe('TX6');
     expect(operator.isTransmitting).toBe(false);
-    expect(interruptOperatorTransmission).toHaveBeenCalledTimes(1);
-    expect(interruptOperatorTransmission).toHaveBeenCalledWith(operator.config.id);
+    expect(requestOperatorStrategyStop).toHaveBeenCalledWith(operator.config.id, 'strategy stop');
+    expect(interruptOperatorTransmission).not.toHaveBeenCalled();
 
     await pluginManager.shutdown();
   });

--- a/packages/server/src/plugin/marketplace-installer.ts
+++ b/packages/server/src/plugin/marketplace-installer.ts
@@ -10,7 +10,7 @@ import type {
   PluginMarketInstallRecord,
   PluginMarketInstallResult,
 } from '@tx5dr/contracts';
-import { validatePluginDefinition } from './PluginLoader.js';
+import { canonicalizePluginDefinition } from './PluginLoader.js';
 import { fetchPluginMarketCatalog } from './marketplace.js';
 import { writePluginSource } from './plugin-source.js';
 import {
@@ -125,16 +125,26 @@ async function resolvePluginEntryPath(pluginRoot: string): Promise<string> {
   throw new Error(`Plugin archive is missing an entry file (${ENTRY_FILE_CANDIDATES.join(', ')})`);
 }
 
-async function validateExtractedPlugin(pluginRoot: string, expectedPluginName: string): Promise<void> {
+async function validateExtractedPlugin(
+  pluginRoot: string,
+  expectedPluginName: string,
+  expectedPermissions: readonly string[],
+): Promise<void> {
   const entryPath = await resolvePluginEntryPath(pluginRoot);
   const entryUrl = pathToFileURL(path.resolve(entryPath));
   entryUrl.searchParams.set('tx5dr_market_validate', `${Date.now()}`);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mod: any = await import(entryUrl.href);
-  const definition = mod.default ?? mod;
-  validatePluginDefinition(definition);
+  const definition = canonicalizePluginDefinition(mod.default ?? mod);
   if (definition.name !== expectedPluginName) {
     throw new Error(`Plugin archive name mismatch: expected ${expectedPluginName}, received ${definition.name}`);
+  }
+  const actualPermissions = [...(definition.permissions ?? [])].sort();
+  const catalogPermissions = [...expectedPermissions].sort();
+  if (JSON.stringify(actualPermissions) !== JSON.stringify(catalogPermissions)) {
+    throw new Error(
+      `Plugin archive permission mismatch for ${expectedPluginName}: catalog and archive declarations differ`,
+    );
   }
 }
 
@@ -225,7 +235,7 @@ export async function installPluginFromMarketplace(
     const extractDir = path.join(tempRoot, 'extract');
     await extractZipArchive(archivePath, extractDir);
     const extractedRoot = await resolveExtractedPluginRoot(extractDir);
-    await validateExtractedPlugin(extractedRoot, pluginName);
+    await validateExtractedPlugin(extractedRoot, pluginName, artifact.permissions);
 
     const destinationDir = resolveSafeRelativePath(pluginDir, pluginName);
     if (!destinationDir) {

--- a/packages/server/src/plugin/types.ts
+++ b/packages/server/src/plugin/types.ts
@@ -1,6 +1,8 @@
 import type {
-  PluginDefinition,
-  PluginContext,
+  AnyPluginDefinition,
+  RuntimePluginContext,
+  PluginOperatorCommand,
+  PluginOperatorCommandResult,
   StrategyRuntime,
   KVStore,
   PluginUIInstanceTarget,
@@ -36,7 +38,7 @@ export interface FlushableKVStore extends KVStore {
  * 已加载的插件（内存中的运行时表示）
  */
 export interface LoadedPlugin {
-  definition: PluginDefinition;
+  definition: AnyPluginDefinition;
   /** 是否为内置插件（不可禁用、不来自文件系统） */
   isBuiltIn: boolean;
   /** 插件目录路径（内置插件若有 UI 文件也需提供） */
@@ -54,9 +56,21 @@ export interface PluginInstance {
   plugin: LoadedPlugin;
   scope: { kind: 'operator'; operatorId: string } | { kind: 'global' };
   /** 当前操作员的 PluginContext */
-  ctx: PluginContext;
+  ctx: RuntimePluginContext;
+  /** Unguarded context retained only for host-owned teardown. */
+  rawCtx: RuntimePluginContext;
   /** strategy 插件的显式运行时 */
   runtime?: StrategyRuntime;
+  /** Monotonic host generation used to revoke stale async continuations. */
+  generation: number;
+  /** Host-owned lifecycle gate. Only `active` instances may accept new ingress. */
+  lifecycle: 'inactive' | 'starting' | 'active' | 'stopping' | 'quarantined' | 'disposed';
+  /** Serializes enable, disable, reload and teardown for this instance. */
+  lifecycleTail: Promise<void>;
+  /** Latest requested lifecycle state; queued transitions reconcile to this value. */
+  desiredLifecycle: 'active' | 'inactive' | 'disposed';
+  /** Monotonic request generation used to tombstone obsolete transitions. */
+  lifecycleRevision: number;
   /** 是否已启用（enabled in config） */
   enabled: boolean;
   /** 连续错误计数（按 hook 名统计） */
@@ -77,11 +91,16 @@ export interface PluginSystemRuntimeState {
  * 操作员决策状态 — 由 DecisionOrchestrator 管理
  */
 export interface OperatorDecisionState {
-  decisionInProgress: boolean;
   lastDecisionTransmission: string | null;
   lastDecisionMessageSet: Set<string> | null;
   /** handleEncodeStart 已排队的发射文本（用于检测 slotStart/encodeStart 竞态） */
   preDecisionEncodedTransmission?: string;
+}
+
+export interface TransmissionRefreshOptions {
+  source?: 'late-decode' | 'operator-edit' | 'plugin';
+  reason?: string;
+  decisionEpoch?: number;
 }
 
 /**
@@ -97,30 +116,51 @@ export interface DecisionOrchestratorDeps {
   getCurrentMode: () => import('@tx5dr/contracts').ModeDescriptor;
   getOperatorAutomationSnapshot: (id: string) => import('@tx5dr/plugin-api').StrategyRuntimeSnapshot | null;
   interruptOperatorTransmission: (operatorId: string) => Promise<void>;
+  requestOperatorStrategyStop?: (operatorId: string, reason: string) => void;
+  transitionTargetReservation?: (operatorId: string, epoch: number, targetCallsign?: string) => boolean;
+  releaseTargetReservation?: (operatorId: string, epoch?: number) => void;
   analyzeCallsignForOperator?: (
     operatorId: string,
     callsign: string,
     grid?: string,
   ) => Promise<import('@tx5dr/contracts').LogbookAnalysis | null>;
   resolveGrid?: (callsign: string) => string | undefined;
-  setOperatorAudioFrequency?: (operatorId: string, frequency: number) => Promise<void>;
+  setOperatorAudioFrequency?: (
+    operatorId: string,
+    frequency: number,
+    commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken,
+  ) => Promise<void>;
   isSnrPriorityEnabled?: (operatorId: string) => boolean;
   isStoppedDirectCallAutoReplyEnabled?: (operatorId: string) => boolean;
   getStrategyRuntime: (operatorId: string) => import('@tx5dr/plugin-api').StrategyRuntime | undefined;
-  getCtxForInstance: (instance: PluginInstance) => PluginContext;
+  getStrategyRuntimeGeneration: (operatorId: string) => number | undefined;
+  invokeStrategyRuntime: <T>(
+    operatorId: string,
+    operation: string,
+    callback: (runtime: import('@tx5dr/plugin-api').StrategyRuntime) => T | Promise<T>,
+    options?: { signal?: AbortSignal },
+  ) => Promise<T | undefined>;
+  invokeStrategyRuntimeSync: <T>(
+    operatorId: string,
+    operation: string,
+    callback: (runtime: import('@tx5dr/plugin-api').StrategyRuntime) => T,
+  ) => T | undefined;
+  getCtxForInstance: (instance: PluginInstance) => RuntimePluginContext;
   dispatcher: import('./PluginHookDispatcher.js').PluginHookDispatcher;
   eventEmitter: import('eventemitter3').EventEmitter<import('@tx5dr/contracts').DigitalRadioEngineEvents>;
   requestCall: (
     operatorId: string,
     callsign: string,
     lastMessage?: { message: import('@tx5dr/contracts').FrameMessage; slotInfo: import('@tx5dr/contracts').SlotInfo },
+    options?: { commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken },
   ) => void;
   notifyQSOFail: (
     operatorId: string,
     info: import('@tx5dr/plugin-api').QSOFailureInfo,
   ) => Promise<void>;
   /** 触发操作员重新编码（用于 slotStart/encodeStart 竞态修正） */
-  triggerReEncode?: (operatorId: string) => void;
+  triggerReEncode?: (operatorId: string, options?: TransmissionRefreshOptions) => void;
+  intentCoordinator: import('../transmission/OperatorIntentCoordinator.js').OperatorIntentCoordinator;
 }
 
 /**
@@ -143,6 +183,10 @@ export interface PluginManagerDeps {
   getEngineMode?: () => EngineMode;
   getCurrentRadioMode?: () => string | null;
   setRadioFrequency: (freq: number) => void | boolean | Promise<boolean | void>;
+  submitRadioMaintenanceCommand?: (
+    command: import('@tx5dr/plugin-api').PluginRadioCommand
+      | import('@tx5dr/plugin-api').PluginRadioTunerCommand,
+  ) => Promise<void>;
   getRadioBand: () => string;
   getRadioConnected: () => boolean;
   getRadioCapabilitySnapshot?: () => CapabilityList;
@@ -162,8 +206,27 @@ export interface PluginManagerDeps {
     guardBandwidth?: number,
     additionalOccupiedFrequenciesHz?: readonly number[],
   ) => number | undefined;
-  setOperatorAudioFrequency?: (operatorId: string, frequency: number) => Promise<void>;
+  setOperatorAudioFrequency?: (
+    operatorId: string,
+    frequency: number,
+    commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken,
+  ) => Promise<void>;
   interruptOperatorTransmission: (operatorId: string) => Promise<void>;
+  requestOperatorStrategyStop?: (operatorId: string, reason: string) => void;
+  transitionTargetReservation?: (operatorId: string, epoch: number, targetCallsign?: string) => boolean;
+  releaseTargetReservation?: (operatorId: string, epoch?: number) => void;
+  removeOperatorContribution?: (
+    operatorId: string,
+    options: {
+      signal: AbortSignal;
+      commandToken: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken;
+    },
+  ) => Promise<void>;
+  submitOperatorCommand?: (
+    operatorId: string,
+    command: PluginOperatorCommand,
+    pluginName: string,
+  ) => Promise<PluginOperatorCommandResult>;
   hasWorkedCallsign: (operatorId: string, callsign: string, options?: { anyBand?: boolean }) => Promise<boolean>;
   hasWorkedDXCC?: (operatorId: string, dxccEntity: string) => Promise<boolean>;
   hasWorkedGrid?: (operatorId: string, grid: string) => Promise<boolean>;
@@ -174,8 +237,9 @@ export interface PluginManagerDeps {
   ) => Promise<import('@tx5dr/contracts').LogbookAnalysis | null>;
   resolveGrid?: (callsign: string) => string | undefined;
   resetOperatorRuntime: (operatorId: string, reason: string) => void;
-  /** 触发操作员替换编码（DecisionOrchestrator 竞态修正用） */
-  triggerReEncode?: (operatorId: string) => void;
+  /** 将已更新的操作员上下文提交给当前数字帧。 */
+  triggerReEncode?: (operatorId: string, options?: TransmissionRefreshOptions) => void;
+  intentCoordinator?: import('../transmission/OperatorIntentCoordinator.js').OperatorIntentCoordinator;
   dataDir: string;
   /** Optional callback for logbook sync provider registration. */
   registerLogbookSyncProvider?: (
@@ -195,6 +259,9 @@ export interface PluginManagerDeps {
  */
 export function toPluginStatus(plugin: LoadedPlugin, instance?: PluginInstance): PluginStatus {
   const capabilities: PluginStatus['capabilities'] = [];
+  if (plugin.definition.isAutoCallEnabled) {
+    capabilities.push('auto_call_control');
+  }
   if (plugin.definition.hooks?.onAutoCallCandidate) {
     capabilities.push('auto_call_candidate');
   }
@@ -220,7 +287,7 @@ export function toPluginStatus(plugin: LoadedPlugin, instance?: PluginInstance):
     quickActions: plugin.definition.quickActions,
     quickSettings: plugin.definition.quickSettings,
     panels: plugin.definition.panels,
-    permissions: plugin.definition.permissions,
+    permissions: plugin.definition.permissions ? [...plugin.definition.permissions] : undefined,
     capabilities: capabilities.length > 0 ? capabilities : undefined,
     ui: plugin.definition.ui ? {
       dir: plugin.definition.ui.dir ?? 'ui',

--- a/packages/server/src/radio/PhysicalRadioManager.ts
+++ b/packages/server/src/radio/PhysicalRadioManager.ts
@@ -55,6 +55,7 @@ import {
 } from '../state-machines/radioStateMachine.js';
 import { RadioState, type RadioInput } from '../state-machines/types.js';
 import { ConfigManager } from '../config/config-manager.js';
+import { buildFrequencyOperatingStateRequest } from './frequencyRadioMode.js';
 
 const logger = createLogger('PhysicalRadioManager');
 const NORMAL_FREQUENCY_POLL_MS = 2000;
@@ -138,7 +139,10 @@ function isRecoverableTciWriteTimeout(error: unknown): boolean {
     return false;
   }
   if (error.context?.writeTimeout === true || error.context?.recoverable === true) {
-    return true;
+    // A PTT state acknowledgement timeout is different from an optional
+    // frequency/mode confirmation timeout: the TRX command may still arrive
+    // after this promise rejects, so the session must be treated as poisoned.
+    return error.context?.stateUncertain !== true;
   }
   return collectErrorMessages(error).some((message) => {
     const lowerMessage = message.toLowerCase();
@@ -479,6 +483,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
    */
   private sessionMutationTail: Promise<unknown> = Promise.resolve();
   private sessionMutationActive = false;
+  private connectionGeneration = 0;
 
   /**
    * 连接事件清理器列表（用于断开时清理）
@@ -517,6 +522,11 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
    */
   getConfig(): HamlibConfig {
     return { ...this.currentConfig };
+  }
+
+  /** Monotonic identity for the currently adopted physical CAT session. */
+  getConnectionGeneration(): number {
+    return this.connectionGeneration;
   }
 
   /**
@@ -808,6 +818,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
           try { await this.connection.disconnect(reason); } catch {}
           this.cleanupConnectionListeners();
           this.connection = null;
+          this.connectionGeneration += 1;
         }
 
         // 然后通知状态机
@@ -1165,34 +1176,70 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
 
   /**
    * 虚拟频率：发射结束后把 dial 频率恢复到接收频点。
-   * 兜底保证——即使恢复写入失败也清除平移守卫并记录 error，避免接收 dial 永久跑偏。
+   * 恢复写入未确认前保留平移守卫，确保一次失败的恢复不会被误判为安全；
+   * 后续 retry 可以重新提交同一个恢复目标。
    */
   async clearTxDialOffset(): Promise<void> {
     if (!this.txDialOffsetActive) {
       return;
     }
     const restore = this.txDialRestoreFrequency;
-    // 释放守卫后走标准 setFrequency 恢复：重建 settle 窗口与频率写跟踪，
-    // 因恢复目标 == 原接收 dial == 当前 lastKnownFrequency，前端不会产生跳变。
-    this.txDialOffsetActive = false;
-    this.txDialRestoreFrequency = null;
-    this.txDialCurrentOffsetHz = 0;
     if (restore === null || restore <= 0) {
+      this.txDialOffsetActive = false;
+      this.txDialRestoreFrequency = null;
+      this.txDialCurrentOffsetHz = 0;
       return;
     }
     try {
+      // 保持守卫直到硬件确认恢复成功，避免频率监测或新发射进入不确定窗口。
       const ok = await this.setFrequency(restore);
       if (!ok) {
-        logger.error('Failed to restore RX dial after TX dial offset', { restoreHz: restore });
+        throw new Error(`Failed to restore RX dial after TX dial offset: ${restore} Hz`);
       } else {
+        this.txDialOffsetActive = false;
+        this.txDialRestoreFrequency = null;
+        this.txDialCurrentOffsetHz = 0;
         logger.debug('TX dial offset cleared, RX dial restored', { rxDialHz: restore });
       }
     } catch (error) {
       logger.error(`Failed to restore RX dial after TX dial offset: ${(error as Error).message}`);
+      throw error;
     }
   }
 
-  async applyOperatingState(request: ApplyOperatingStateRequest): Promise<ApplyOperatingStateResult> {
+  async applyOperatingState(
+    request: ApplyOperatingStateRequest,
+    options: { expectedConnectionGeneration?: number } = {},
+  ): Promise<ApplyOperatingStateResult> {
+    return this.runSessionMutation('applyOperatingState', async () => {
+      if (
+        options.expectedConnectionGeneration !== undefined
+        && options.expectedConnectionGeneration !== this.connectionGeneration
+      ) {
+        throw new Error('radio connection changed before operating state could be applied');
+      }
+
+      const resumeFrequencyMonitoring = this.pauseFrequencyMonitoringForMutation();
+      try {
+        const result = await this.applyOperatingStateInternal(request);
+        if (
+          options.expectedConnectionGeneration !== undefined
+          && options.expectedConnectionGeneration !== this.connectionGeneration
+        ) {
+          throw new Error('radio connection changed while operating state was being applied');
+        }
+        return result;
+      } finally {
+        if (resumeFrequencyMonitoring && this.connection) {
+          this.startFrequencyMonitoring();
+        }
+      }
+    });
+  }
+
+  private async applyOperatingStateInternal(
+    request: ApplyOperatingStateRequest,
+  ): Promise<ApplyOperatingStateResult> {
     if (!this.connection) {
       throw new Error('radio not connected');
     }
@@ -1322,8 +1369,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
    */
   async setPTT(state: boolean): Promise<void> {
     if (!this.connection) {
-      logger.error('Radio not connected, cannot set PTT');
-      return;
+      throw new Error('Radio not connected, cannot set PTT');
     }
 
     try {
@@ -1334,17 +1380,18 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       logger.debug(`PTT set: ${state ? 'TX' : 'RX'}`);
     } catch (error) {
       if (isRecoverableTciWriteTimeout(error)) {
-        logger.warn('TCI write timeout tolerated', {
+        logger.warn('TCI PTT write result is uncertain', {
           operation: 'setPTT',
           ptt: state,
           error: (error as Error).message,
         });
-        return;
+        throw new Error(`PTT ${state ? 'start' : 'stop'} result is uncertain: ${(error as Error).message}`);
       }
       logger.error(
         `PTT ${state ? 'TX' : 'RX'} failed: ${(error as Error).message}`
       );
       this.handleConnectionError(error as Error);
+      throw error;
     }
   }
 
@@ -2314,6 +2361,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
     this.cleanupConnectionListeners();
     try { await this.connection.disconnect('preparing new connection'); } catch {}
     this.connection = null;
+    this.connectionGeneration += 1;
 
     if (config.type === 'icom-wlan') {
       logger.debug('Waiting for ICOM radio to release old connection');
@@ -2346,6 +2394,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
   }
 
   private activateConnectedSession(connection: IRadioConnection): void {
+    this.connectionGeneration += 1;
     connection.startBackgroundTasks?.();
     this.startFrequencyMonitoring();
     void this.startTunerMonitoring();
@@ -2396,6 +2445,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
 
       this.cleanupConnectionListeners();
       this.connection = null;
+      this.connectionGeneration += 1;
     }
 
     logger.info('Disconnected');
@@ -2563,6 +2613,7 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
       this.cleanupConnectionListeners();
       // 不调用 connection.disconnect()，因为连接已断（被动断线）
       this.connection = null;
+      this.connectionGeneration += 1;
     }
   }
 
@@ -2591,107 +2642,113 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
 
   private async restoreSavedFrequencyIfAvailable(): Promise<number | null> {
     try {
-      const voiceState = this.getSavedStartupVoiceState();
-      if (voiceState) {
-        const result = await this.applyOperatingState({
-          frequency: voiceState.frequency,
-          mode: voiceState.radioMode,
-          bandwidth: voiceState.radioMode ? 'nochange' : undefined,
-          options: voiceState.radioMode ? { intent: 'voice' } : undefined,
-          tolerateModeFailure: true,
+      const saved = await this.getSavedStartupOperatingState();
+      if (!saved) {
+        logger.info('Bootstrap operating state skipped: no valid saved state');
+        return null;
+      }
+
+      const result = await this.applyOperatingStateInternal(saved.request);
+      if (!result.frequencyApplied) {
+        logger.warn('Bootstrap operating state failed', {
+          engineMode: saved.engineMode,
+          frequencyHz: saved.frequency,
+          radioMode: saved.request.mode,
         });
-
-        if (!result.frequencyApplied) {
-          logger.warn(`Bootstrap voice frequency restore failed: ${(voiceState.frequency / 1000000).toFixed(3)} MHz`);
-          return null;
-        }
-
-        if (result.modeError) {
-          logger.warn(`Bootstrap voice frequency restored but radio mode restore failed: ${result.modeError.message}`);
-        }
-
-        logger.info(`Bootstrap voice operating state restored: ${(voiceState.frequency / 1000000).toFixed(3)} MHz${voiceState.radioMode ? ` (${voiceState.radioMode})` : ''}`);
-        return voiceState.frequency;
-      }
-
-      const targetFrequency = this.getSavedStartupFrequency();
-      if (!targetFrequency) {
-        logger.info('No valid saved frequency config, skipping bootstrap restore');
         return null;
       }
 
-      const success = await this.setFrequency(targetFrequency);
-      if (!success) {
-        logger.warn(`Bootstrap frequency restore failed: ${(targetFrequency / 1000000).toFixed(3)} MHz`);
-        return null;
-      }
-
-      logger.info(`Bootstrap frequency restored: ${(targetFrequency / 1000000).toFixed(3)} MHz`);
-      return targetFrequency;
+      const status = saved.request.mode && !result.modeApplied
+        ? 'partially-applied'
+        : 'applied';
+      logger.info(`Bootstrap operating state ${status}`, {
+        engineMode: saved.engineMode,
+        frequencyHz: saved.frequency,
+        radioMode: saved.request.mode,
+        modeError: result.modeError?.message,
+      });
+      return saved.frequency;
     } catch (error) {
       logger.warn(
-        `Bootstrap frequency restore failed, will fall through to captureInitialFrequency: ` +
+        `Bootstrap operating state failed, will fall through to captureInitialFrequency: ` +
         `${(error as Error).message}`
       );
       return null;
     }
   }
 
-  private getSavedStartupFrequency(): number | null {
+  private async getSavedStartupOperatingState(): Promise<{
+    engineMode: 'digital' | 'voice' | 'cw';
+    frequency: number;
+    request: ApplyOperatingStateRequest;
+  } | null> {
     const engineMode = this.configManager.getLastEngineMode();
 
     if (engineMode === 'voice') {
-      return null;
+      const lastVoice = this.configManager.getLastVoiceFrequency();
+      if (!lastVoice || !this.validateSavedStartupFrequency(lastVoice.frequency, 'voice')) {
+        return null;
+      }
+      return {
+        engineMode,
+        frequency: lastVoice.frequency,
+        request: {
+          frequency: lastVoice.frequency,
+          mode: lastVoice.radioMode,
+          bandwidth: lastVoice.radioMode ? 'nochange' : undefined,
+          options: lastVoice.radioMode ? { intent: 'voice' } : undefined,
+          tolerateModeFailure: true,
+        },
+      };
+    }
+
+    if (engineMode === 'cw') {
+      const lastCW = this.configManager.getLastCWFrequency();
+      const frequency = lastCW?.frequency || await this.getFrequency().catch(() => 0);
+      if (!this.validateSavedStartupFrequency(frequency, 'cw')) {
+        return null;
+      }
+      const radioMode = lastCW?.radioMode || 'CW';
+      return {
+        engineMode,
+        frequency,
+        request: {
+          frequency,
+          mode: radioMode,
+          bandwidth: 'nochange',
+          options: { intent: 'cw' },
+          tolerateModeFailure: true,
+        },
+      };
     }
 
     const lastDigital = this.configManager.getLastSelectedFrequency();
-    if (!lastDigital) {
+    if (!lastDigital || !this.validateSavedStartupFrequency(lastDigital.frequency, 'digital')) {
       return null;
     }
-
-    if (!isFrequencyInHamlibRange(lastDigital.frequency)) {
-      logger.warn(
-        `Invalid saved digital frequency detected: ${lastDigital.frequency} Hz ` +
-        `(valid range: ${HAMLIB_MIN_FREQUENCY_HZ}-${HAMLIB_MAX_FREQUENCY_HZ} Hz). ` +
-        'Clearing saved digital config to prevent recurrence.'
-      );
-      void this.configManager.clearLastSelectedFrequency().catch(err =>
-        logger.warn('Failed to clear invalid digital frequency from config:', err)
-      );
-      return null;
-    }
-
-    logger.info(`Restoring digital frequency during bootstrap: ${(lastDigital.frequency / 1000000).toFixed(3)} MHz (${lastDigital.description || lastDigital.mode})`);
-    return lastDigital.frequency;
+    const effectiveMode = this.configManager.getLastDigitalModeName() || lastDigital.mode;
+    return {
+      engineMode,
+      frequency: lastDigital.frequency,
+      request: buildFrequencyOperatingStateRequest({
+        frequency: lastDigital.frequency,
+        radioMode: lastDigital.radioMode,
+        effectiveMode,
+        engineMode: 'digital',
+        digitalModeRadioMode: this.configManager.getRadioConfig().digitalModeRadioMode,
+      }),
+    };
   }
 
-  private getSavedStartupVoiceState(): { frequency: number; radioMode?: string } | null {
-    if (this.configManager.getLastEngineMode() !== 'voice') {
-      return null;
-    }
-
-    const lastVoice = this.configManager.getLastVoiceFrequency();
-    if (!lastVoice) {
-      return null;
-    }
-
-    if (!isFrequencyInHamlibRange(lastVoice.frequency)) {
+  private validateSavedStartupFrequency(frequency: number, engineMode: 'digital' | 'voice' | 'cw'): boolean {
+    if (!isFrequencyInHamlibRange(frequency)) {
       logger.warn(
-        `Invalid saved voice frequency detected: ${lastVoice.frequency} Hz ` +
-        `(valid range: ${HAMLIB_MIN_FREQUENCY_HZ}-${HAMLIB_MAX_FREQUENCY_HZ} Hz). ` +
-        'Clearing saved voice config to prevent recurrence.'
+        `Invalid saved ${engineMode} frequency detected: ${frequency} Hz `
+        + `(valid range: ${HAMLIB_MIN_FREQUENCY_HZ}-${HAMLIB_MAX_FREQUENCY_HZ} Hz)`,
       );
-      void this.configManager.clearLastVoiceFrequency().catch(err =>
-        logger.warn('Failed to clear invalid voice frequency from config:', err)
-      );
-      return null;
+      return false;
     }
-
-    logger.info(`Restoring voice operating state during bootstrap: ${(lastVoice.frequency / 1000000).toFixed(3)} MHz (${lastVoice.description || lastVoice.radioMode || 'voice'})`);
-    return {
-      frequency: lastVoice.frequency,
-      radioMode: lastVoice.radioMode,
-    };
+    return true;
   }
 
   private async captureInitialFrequency(): Promise<void> {
@@ -2959,6 +3016,18 @@ export class PhysicalRadioManager extends EventEmitter<PhysicalRadioManagerEvent
     this.frequencyMonitoringActive = true;
     this.frequencyMonitoringGeneration += 1;
     this.scheduleNextFrequencyPoll();
+  }
+
+  /** Pause polling without discarding the last confirmed projection. */
+  private pauseFrequencyMonitoringForMutation(): boolean {
+    const wasActive = this.frequencyMonitoringActive;
+    this.frequencyMonitoringActive = false;
+    this.frequencyMonitoringGeneration += 1;
+    if (this.frequencyPollingInterval) {
+      clearTimeout(this.frequencyPollingInterval);
+      this.frequencyPollingInterval = null;
+    }
+    return wasActive;
   }
 
   /**

--- a/packages/server/src/radio/TuneToneController.ts
+++ b/packages/server/src/radio/TuneToneController.ts
@@ -1,5 +1,5 @@
-import type { AudioStreamManager } from '../audio/AudioStreamManager.js';
 import type { PhysicalRadioManager } from './PhysicalRadioManager.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { createLogger } from '../utils/logger.js';
 import type { TuneToneStatus } from '@tx5dr/contracts';
 
@@ -15,10 +15,9 @@ const RAMP_MS = 20;
 
 export interface TuneToneControllerDeps {
   radioManager: PhysicalRadioManager;
-  audioStreamManager: AudioStreamManager;
+  physicalTxCoordinator: PhysicalTxCoordinator;
   isTransmitBusy: () => boolean;
   getOperatorToneHz: (operatorId?: string | null) => number | null;
-  setSoftwarePttActive: (active: boolean) => void;
   emitStatus: (status: TuneToneStatus) => void;
 }
 
@@ -35,6 +34,7 @@ export class TuneToneController {
   private maxDurationMs = DEFAULT_MAX_DURATION_MS;
   private timeout: NodeJS.Timeout | null = null;
   private generation = 0;
+  private physicalLeaseId: string | null = null;
 
   constructor(private readonly deps: TuneToneControllerDeps) {}
 
@@ -69,34 +69,46 @@ export class TuneToneController {
     this.deps.emitStatus(this.getStatus());
 
     try {
-      await this.deps.radioManager.setPTT(true);
+      const leaseId = await this.deps.physicalTxCoordinator.acquireLease({
+        source: 'tune-tone',
+        reason: 'tune tone',
+        playbackKind: 'tune-tone',
+        deferActiveUntilAudio: true,
+      });
+      this.physicalLeaseId = leaseId;
+      if (this.generation !== currentGeneration || !this.active) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          leaseId,
+          'tune tone cancelled while starting',
+        );
+        this.physicalLeaseId = null;
+        return;
+      }
       this.pttAsserted = true;
-      this.deps.setSoftwarePttActive(true);
       this.timeout = setTimeout(() => {
         void this.stop('timeout').catch((error) => {
           logger.error('Failed to auto-stop tune tone', error);
         });
-      }, this.maxDurationMs);
+      }, this.maxDurationMs + 1000);
 
       const audio = generateTone(toneHz, this.maxDurationMs, TONE_SAMPLE_RATE);
-      void this.deps.audioStreamManager.playAudio(audio, TONE_SAMPLE_RATE, {
-        injectIntoMonitor: true,
+      const completion = this.deps.physicalTxCoordinator.playAudioOnLease(this.physicalLeaseId, {
+        audioData: audio,
+        sampleRate: TONE_SAMPLE_RATE,
         playbackKind: 'tune-tone',
-      })
-        .then(() => {
+        playbackOptions: { injectIntoMonitor: true },
+      });
+      await Promise.resolve();
+      void completion
+        .then((result) => {
           if (this.generation === currentGeneration && this.active) {
-            void this.stop('complete');
+            this.finishAfterPhysicalCompletion(result.error);
           }
         })
         .catch((error) => {
-          const interrupted = error instanceof Error && error.message === 'playback interrupted';
           if (this.generation === currentGeneration && this.active) {
-            if (interrupted) {
-              void this.stop('playback-interrupted');
-            } else {
-              logger.error('Tune tone playback failed', error);
-              void this.stop('playback-error', error instanceof Error ? error.message : String(error));
-            }
+            logger.error('Tune tone playback failed', error);
+            this.finishAfterPhysicalCompletion(error instanceof Error ? error.message : String(error));
           }
         });
     } catch (error) {
@@ -106,7 +118,7 @@ export class TuneToneController {
   }
 
   async stop(_reason = 'manual', error?: string): Promise<void> {
-    if (!this.active && !this.pttAsserted) {
+    if (!this.active && !this.pttAsserted && !this.physicalLeaseId) {
       if (error) {
         this.deps.emitStatus(this.getStatus(error));
       }
@@ -116,30 +128,38 @@ export class TuneToneController {
     ++this.generation;
     this.clearTimeout();
 
-    const shouldStopPlayback = this.deps.audioStreamManager.isPlaying('tune-tone');
     const shouldReleasePtt = this.pttAsserted;
     this.active = false;
     this.toneHz = null;
     this.startedAt = null;
 
-    if (shouldStopPlayback) {
-      try {
-        await this.deps.audioStreamManager.stopCurrentPlayback({ kind: 'tune-tone' });
-      } catch (stopError) {
-        logger.warn('Stopping tune tone playback failed', stopError);
-      }
-    }
-
     if (shouldReleasePtt) {
       try {
-        await this.deps.radioManager.setPTT(false);
+        if (this.physicalLeaseId) {
+          const snapshot = this.deps.physicalTxCoordinator.getSnapshot();
+          if (snapshot.leaseId === this.physicalLeaseId && snapshot.phase === 'unknown') {
+            await this.deps.physicalTxCoordinator.retryUnknownStop(`tune tone stop retry: ${_reason}`);
+          } else {
+            await this.deps.physicalTxCoordinator.forceInterruptLease(
+              this.physicalLeaseId,
+              `tune tone stop: ${_reason}`,
+            );
+          }
+        }
       } catch (pttError) {
         logger.warn('Releasing tune tone PTT failed', pttError);
       }
-      this.pttAsserted = false;
+      const snapshot = this.deps.physicalTxCoordinator.getSnapshot();
+      const releaseUncertain = snapshot.leaseId === this.physicalLeaseId
+        && snapshot.phase === 'unknown';
+      if (!releaseUncertain) {
+        this.pttAsserted = false;
+        this.physicalLeaseId = null;
+      } else {
+        error = error ?? 'PTT release unconfirmed';
+      }
     }
 
-    this.deps.setSoftwarePttActive(false);
     this.deps.emitStatus(this.getStatus(error));
   }
 
@@ -156,6 +176,16 @@ export class TuneToneController {
       clearTimeout(this.timeout);
       this.timeout = null;
     }
+  }
+
+  private finishAfterPhysicalCompletion(error?: string): void {
+    this.clearTimeout();
+    this.active = false;
+    this.pttAsserted = false;
+    this.physicalLeaseId = null;
+    this.toneHz = null;
+    this.startedAt = null;
+    this.deps.emitStatus(this.getStatus(error));
   }
 }
 

--- a/packages/server/src/radio/__tests__/HamlibConnection.test.ts
+++ b/packages/server/src/radio/__tests__/HamlibConnection.test.ts
@@ -190,6 +190,27 @@ describe('HamlibConnection', () => {
     await writePromise;
   });
 
+  it('keeps later PTT writes fenced until the native command really settles', async () => {
+    const firstStop = createDeferred<number>();
+    const { connection, rig } = createConnectedConnection({
+      setPtt: vi.fn()
+        .mockReturnValueOnce(firstStop.promise)
+        .mockResolvedValueOnce(0),
+    });
+
+    const oldStop = connection.setPTT(false);
+    await Promise.resolve();
+    const newStart = connection.setPTT(true);
+    await Promise.resolve();
+
+    expect(rig.setPtt).toHaveBeenCalledTimes(1);
+    expect(rig.setPtt).toHaveBeenNthCalledWith(1, false);
+    firstStop.resolve(0);
+    await oldStop;
+    await newStart;
+    expect(rig.setPtt).toHaveBeenNthCalledWith(2, true);
+  });
+
   it('skips DCD polling while a critical CAT write is active', async () => {
     const firstWrite = createDeferred<number>();
     const { connection, rig } = createConnectedConnection({

--- a/packages/server/src/radio/__tests__/PhysicalRadioManager.test.ts
+++ b/packages/server/src/radio/__tests__/PhysicalRadioManager.test.ts
@@ -46,9 +46,12 @@ type PhysicalRadioManagerTestAccessor = {
   radioActor: TestRadioActor | null;
   connection: TestRadioConnection;
   preconnectedSessionToAdopt?: TestRadioConnection | null;
+  connectionGeneration: number;
   lastKnownFrequency: number | null;
   configManager: {
     getLastEngineMode: ReturnType<typeof vi.fn>;
+    getLastDigitalModeName: ReturnType<typeof vi.fn>;
+    getRadioConfig: ReturnType<typeof vi.fn>;
     getLastSelectedFrequency: ReturnType<typeof vi.fn>;
     getLastVoiceFrequency: ReturnType<typeof vi.fn>;
   };
@@ -758,6 +761,22 @@ describe('PhysicalRadioManager', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('rejects an operating-state write when the physical session generation changed', async () => {
+    const applyOperatingState = vi.fn().mockResolvedValue({
+      frequencyApplied: true,
+      modeApplied: true,
+    });
+    asTestManager(manager).connection = { applyOperatingState };
+    asTestManager(manager).connectionGeneration = 4;
+
+    await expect(manager.applyOperatingState(
+      { frequency: 14_074_000, tolerateModeFailure: true },
+      { expectedConnectionGeneration: 3 },
+    )).rejects.toThrow('radio connection changed before operating state could be applied');
+
+    expect(applyOperatingState).not.toHaveBeenCalled();
+  });
+
   it('does not treat tolerated mode failures as connection health failures', async () => {
     const applyOperatingState = vi.fn().mockResolvedValue({
       frequencyApplied: true,
@@ -1319,14 +1338,21 @@ describe('PhysicalRadioManager', () => {
         order.push('tuner');
         return { supported: true, hasSwitch: true, hasManualTune: true };
       }),
-      setFrequency: vi.fn().mockImplementation(async () => {
+      applyOperatingState: vi.fn().mockImplementation(async () => {
         order.push('restore');
+        return { frequencyApplied: true, modeApplied: true };
       }),
       getFrequency: vi.fn().mockResolvedValue(14074000),
     };
 
     vi.spyOn(RadioConnectionFactory, 'create').mockReturnValue(connection as never);
     vi.spyOn(testManager.configManager, 'getLastEngineMode').mockReturnValue('digital');
+    vi.spyOn(testManager.configManager, 'getLastDigitalModeName').mockReturnValue('FT8');
+    vi.spyOn(testManager.configManager, 'getRadioConfig').mockReturnValue({
+      type: 'network',
+      network: { host: '127.0.0.1', port: 4532 },
+      digitalModeRadioMode: 'usb-data',
+    } as HamlibConfig);
     vi.spyOn(testManager.configManager, 'getLastSelectedFrequency').mockReturnValue({
       frequency: 14074000,
       mode: 'FT8',
@@ -1367,7 +1393,12 @@ describe('PhysicalRadioManager', () => {
     ]);
     expect(connection.startBackgroundTasks).toHaveBeenCalledTimes(1);
     expect(connection.setPTT).toHaveBeenCalledWith(false);
-    expect(connection.setFrequency).toHaveBeenCalledWith(14074000);
+    expect(connection.applyOperatingState).toHaveBeenCalledWith(expect.objectContaining({
+      frequency: 14074000,
+      mode: 'USB',
+      bandwidth: 'nochange',
+      options: { intent: 'digital' },
+    }));
     expect(testManager.capabilityManager.onConnected).toHaveBeenCalledTimes(1);
 
     await manager.disconnect('test cleanup');
@@ -1397,8 +1428,9 @@ describe('PhysicalRadioManager', () => {
         order.push('tuner');
         return { supported: true, hasSwitch: true, hasManualTune: true };
       }),
-      setFrequency: vi.fn().mockImplementation(async () => {
+      applyOperatingState: vi.fn().mockImplementation(async () => {
         order.push('restore');
+        return { frequencyApplied: true, modeApplied: true };
       }),
       getFrequency: vi.fn().mockResolvedValue(21074000),
     };
@@ -1626,7 +1658,7 @@ describe('PhysicalRadioManager', () => {
 
     it('restores the RX dial on clear and allows a fresh offset afterward', async () => {
       const setFrequency = vi.fn().mockResolvedValue(undefined);
-      asTestManager(manager).connection = { setFrequency };
+      asTestManager(manager).connection = { setFrequency, setKnownFrequency: vi.fn() };
       asTestManager(manager).lastKnownFrequency = 7074000;
 
       await manager.setTxDialOffset(681);
@@ -1640,6 +1672,26 @@ describe('PhysicalRadioManager', () => {
       setFrequency.mockClear();
       await expect(manager.setTxDialOffset(900)).resolves.toBe(true);
       expect(setFrequency).toHaveBeenCalledWith(7074900);
+    });
+
+    it('keeps the dial guard after a failed restore so retry can repair the same offset', async () => {
+      const connectionSetFrequency = vi.fn().mockResolvedValue(undefined);
+      asTestManager(manager).connection = { setFrequency: connectionSetFrequency };
+      asTestManager(manager).lastKnownFrequency = 7074000;
+
+      await expect(manager.setTxDialOffset(681)).resolves.toBe(true);
+      const restore = vi.spyOn(manager, 'setFrequency')
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      await expect(manager.clearTxDialOffset()).rejects.toThrow('Failed to restore RX dial');
+      expect(manager.isTxDialOffsetActive()).toBe(true);
+
+      await expect(manager.clearTxDialOffset()).resolves.toBeUndefined();
+      expect(restore).toHaveBeenCalledTimes(2);
+      expect(restore).toHaveBeenNthCalledWith(1, 7074000);
+      expect(restore).toHaveBeenNthCalledWith(2, 7074000);
+      expect(manager.isTxDialOffsetActive()).toBe(false);
     });
   });
 });

--- a/packages/server/src/radio/__tests__/TciConnection.test.ts
+++ b/packages/server/src/radio/__tests__/TciConnection.test.ts
@@ -201,6 +201,39 @@ describe('TciConnection', () => {
     await connection.disconnect('test complete');
   });
 
+  it('poisons the session after an unconfirmed PTT write and rejects the opposite write', async () => {
+    server = new MockTciServer();
+    // Suppress the TRX state echo: the command has been sent, but its
+    // physical result is intentionally unknown to the client.
+    server.onCommand(({ command }) => command.name === 'trx');
+    await server.start();
+    const endpoint = new URL(server.url());
+    const connection = new TciConnection({ writeTimeoutMs: 25 });
+
+    await connection.connect({
+      type: 'tci',
+      tci: {
+        host: endpoint.hostname,
+        port: Number(endpoint.port),
+        receiver: 0,
+        trx: 0,
+        vfo: 0,
+        audioEnabled: true,
+        audioSampleRate: 12000,
+      },
+    });
+
+    await expect(connection.setPTT(true)).rejects.toThrow(/timed out|uncertain/i);
+    expect(connection.getState()).toBe(RadioConnectionState.ERROR);
+    expect(connection.isHealthy()).toBe(false);
+
+    const trxWritesAfterTimeout = server.receivedCommands.filter((command) => command.name === 'trx');
+    await expect(connection.setPTT(false)).rejects.toThrow(/uncertain|not connected/i);
+    expect(server.receivedCommands.filter((command) => command.name === 'trx')).toEqual(trxWritesAfterTimeout);
+
+    await connection.disconnect('test complete');
+  });
+
   it('downgrades operating-state TCI frequency confirmation timeouts without disconnecting', async () => {
     server = new MockTciServer();
     server.onCommand(({ command }) => command.name === 'vfo');

--- a/packages/server/src/radio/__tests__/TuneToneController.test.ts
+++ b/packages/server/src/radio/__tests__/TuneToneController.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { TuneToneController } from '../TuneToneController.js';
+import { PhysicalTxCoordinator } from '../../transmission/PhysicalTxCoordinator.js';
 import type { TuneToneStatus } from '@tx5dr/contracts';
 
 function deferred<T = void>() {
@@ -24,37 +25,44 @@ function createController(options: { busy?: boolean; connected?: boolean } = {})
     playAudio: vi.fn(() => playback.promise),
     stopCurrentPlayback: vi.fn().mockResolvedValue(0),
   };
-  const setSoftwarePttActive = vi.fn();
+  const physicalTxCoordinator = new PhysicalTxCoordinator({
+    isRadioConnected: radioManager.isConnected,
+    setPTT: radioManager.setPTT,
+    playAudio: audioStreamManager.playAudio,
+    stopCurrentPlayback: audioStreamManager.stopCurrentPlayback,
+    isAudioPlaying: audioStreamManager.isPlaying,
+    sleep: async () => undefined,
+  });
   const controller = new TuneToneController({
     radioManager: radioManager as never,
-    audioStreamManager: audioStreamManager as never,
+    physicalTxCoordinator,
     isTransmitBusy: () => options.busy ?? false,
     getOperatorToneHz: () => 1234,
-    setSoftwarePttActive,
     emitStatus: (status) => statuses.push(status),
   });
 
-  return { controller, radioManager, audioStreamManager, setSoftwarePttActive, statuses, playback };
+  return { controller, radioManager, audioStreamManager, statuses, playback };
 }
 
 describe('TuneToneController', () => {
   it('starts PTT, plays a generated tone, and emits active status', async () => {
-    const { controller, radioManager, audioStreamManager, setSoftwarePttActive, statuses } = createController();
+    const { controller, radioManager, audioStreamManager, statuses } = createController();
 
     await controller.start({ operatorId: 'op1' });
 
     expect(radioManager.setPTT).toHaveBeenCalledWith(true);
-    expect(setSoftwarePttActive).toHaveBeenCalledWith(true);
-    expect(audioStreamManager.playAudio).toHaveBeenCalledWith(
-      expect.any(Float32Array),
-      12000,
-      expect.objectContaining({ injectIntoMonitor: true, playbackKind: 'tune-tone' }),
-    );
+    await vi.waitFor(() => {
+      expect(audioStreamManager.playAudio).toHaveBeenCalledWith(
+        expect.any(Float32Array),
+        12000,
+        expect.objectContaining({ injectIntoMonitor: true, playbackKind: 'tune-tone' }),
+      );
+    });
     expect(statuses[0]).toMatchObject({ active: true, toneHz: 1234 });
   });
 
   it('stops playback and releases PTT idempotently', async () => {
-    const { controller, radioManager, audioStreamManager, setSoftwarePttActive, statuses } = createController();
+    const { controller, radioManager, audioStreamManager, statuses } = createController();
 
     await controller.start({ toneHz: 1600 });
     await controller.stop('manual');
@@ -62,12 +70,29 @@ describe('TuneToneController', () => {
 
     expect(audioStreamManager.stopCurrentPlayback).toHaveBeenCalledWith({ kind: 'tune-tone' });
     expect(radioManager.setPTT).toHaveBeenCalledWith(false);
-    expect(setSoftwarePttActive).toHaveBeenLastCalledWith(false);
     expect(statuses[statuses.length - 1]).toMatchObject({ active: false, toneHz: null });
   });
 
+  it('keeps an uncertain PTT release retryable and visible', async () => {
+    const { controller, radioManager, statuses } = createController();
+
+    await controller.start({ toneHz: 1600 });
+    radioManager.setPTT.mockRejectedValueOnce(new Error('USB write failed'));
+    await controller.stop('manual');
+
+    expect(statuses[statuses.length - 1]).toMatchObject({
+      active: false,
+      error: 'PTT release unconfirmed',
+    });
+
+    await controller.stop('manual retry');
+    expect(radioManager.setPTT).toHaveBeenLastCalledWith(false);
+    expect(statuses[statuses.length - 1]).toMatchObject({ active: false, toneHz: null });
+    expect(statuses[statuses.length - 1].error).toBeUndefined();
+  });
+
   it('releases PTT if tune tone playback is interrupted externally', async () => {
-    const { controller, radioManager, setSoftwarePttActive, statuses, playback } = createController();
+    const { controller, radioManager, statuses, playback } = createController();
 
     await controller.start({ toneHz: 1600 });
     playback.reject(new Error('playback interrupted'));
@@ -76,7 +101,6 @@ describe('TuneToneController', () => {
       expect(radioManager.setPTT).toHaveBeenCalledWith(false);
     });
 
-    expect(setSoftwarePttActive).toHaveBeenLastCalledWith(false);
     expect(statuses[statuses.length - 1]).toMatchObject({ active: false, toneHz: null });
   });
 

--- a/packages/server/src/radio/__tests__/hamlibConfigUtils.test.ts
+++ b/packages/server/src/radio/__tests__/hamlibConfigUtils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeHamlibConfig } from '../hamlibConfigUtils.js';
+
+describe('normalizeHamlibConfig digital mode preference', () => {
+  it('migrates a missing preference to USB', () => {
+    expect(normalizeHamlibConfig({ type: 'serial' }).digitalModeRadioMode).toBe('usb');
+  });
+
+  it.each(['none', 'usb', 'usb-data'] as const)('preserves an explicit %s preference', (preference) => {
+    expect(normalizeHamlibConfig({
+      type: 'serial',
+      digitalModeRadioMode: preference,
+    }).digitalModeRadioMode).toBe(preference);
+  });
+});

--- a/packages/server/src/radio/connections/HamlibConnection.ts
+++ b/packages/server/src/radio/connections/HamlibConnection.ts
@@ -3074,12 +3074,10 @@ export class HamlibConnection
     this.checkConnected();
 
     try {
-      await Promise.race([
-        this.rig!.setFrequency(frequency),
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Set frequency timeout')), 5000)
-        ),
-      ]);
+      // Critical writes must keep the RadioIoQueue occupied until the native
+      // operation really settles. A local Promise.race timeout would let a
+      // stale frequency write land during a newer transmission.
+      await this.rig!.setFrequency(frequency);
 
       this.lastSuccessfulOperation = Date.now();
       this.currentFrequencyHz = frequency;
@@ -3189,12 +3187,10 @@ export class HamlibConnection
     }
 
     try {
-      await Promise.race([
-        this.rig!.setPtt(enabled),
-        new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('PTT operation timeout')), 3000)
-        ),
-      ]);
+      // The coordinator owns the user-visible timeout. Keep this critical
+      // queue fenced until Hamlib's actual command settles so an old PTT-off
+      // cannot arrive after a newer PTT-on.
+      await this.rig!.setPtt(enabled);
 
       this.lastSuccessfulOperation = Date.now();
       logger.debug(`PTT set: ${enabled ? 'TX' : 'RX'}`);

--- a/packages/server/src/radio/connections/TciConnection.ts
+++ b/packages/server/src/radio/connections/TciConnection.ts
@@ -51,6 +51,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   private lastKnownFrequency: number | null = null;
   private lastKnownMode: string | null = null;
   private lastKnownPtt: boolean | null = null;
+  // A state-ack timeout means the TRX command may already be in flight. Do
+  // not allow a later lease to reuse this session and apply an old ON/OFF.
+  private pttWriteUncertain = false;
   private lastRxLevelDbm: number | null = null;
   private lastTxPowerW: number | null = null;
   private lastTxPeakPowerW: number | null = null;
@@ -62,6 +65,12 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   private txAudioChunkOffset = 0;
   private txAudioQueuedSamples = 0;
   private txDrainWaiters: TxDrainWaiter[] = [];
+  private readonly options: { writeTimeoutMs?: number };
+
+  constructor(options: { writeTimeoutMs?: number } = {}) {
+    super();
+    this.options = options;
+  }
 
   getType(): RadioConnectionType {
     return RadioConnectionType.TCI;
@@ -72,7 +81,9 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
   }
 
   isHealthy(): boolean {
-    return this.state === RadioConnectionState.CONNECTED && Boolean(this.client?.isConnected());
+    return this.state === RadioConnectionState.CONNECTED
+      && !this.pttWriteUncertain
+      && Boolean(this.client?.isConnected());
   }
 
   isConnected(): boolean {
@@ -116,6 +127,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     this.lastKnownFrequency = null;
     this.lastKnownMode = null;
     this.lastKnownPtt = null;
+    this.pttWriteUncertain = false;
     this.audioRunning = false;
     this.audioStreamOwners.clear();
     this.txTransmissionActive = false;
@@ -131,7 +143,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
       connectTimeoutMs: TCI_CONNECT_TIMEOUT_MS,
       commandTimeoutMs: TCI_COMMAND_TIMEOUT_MS,
       writeAckMode: 'state',
-      writeTimeoutMs: TCI_WRITE_TIMEOUT_MS,
+      writeTimeoutMs: this.options.writeTimeoutMs ?? TCI_WRITE_TIMEOUT_MS,
       frequencyWriteSettleMs: TCI_FREQUENCY_WRITE_SETTLE_MS,
     });
     this.client = client;
@@ -174,6 +186,7 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
     logger.info(`Disconnecting TCI radio: ${reason || 'no reason'}`);
     this.ioSessionId += 1;
     await this.cleanup();
+    this.pttWriteUncertain = false;
     this.setState(RadioConnectionState.DISCONNECTED);
     this.emit('disconnected', reason);
   }
@@ -210,6 +223,15 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
 
   async setPTT(enabled: boolean): Promise<void> {
     await this.runTask('setPTT', async () => {
+      if (this.pttWriteUncertain) {
+        throw new RadioError({
+          code: RadioErrorCode.OPERATION_TIMEOUT,
+          message: 'TCI PTT state is uncertain; reconnect before issuing another PTT command',
+          userMessage: 'TCI PTT state is uncertain. Reconnect the radio before transmitting again.',
+          severity: RadioErrorSeverity.CRITICAL,
+          context: { operation: 'setPTT', protocol: 'tci', stateUncertain: true },
+        });
+      }
       this.checkConnected();
       if (!enabled) {
         this.clearTxAudioQueue('ptt-off');
@@ -219,7 +241,20 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
         this.lastKnownPtt = enabled;
         return;
       }
-      await this.client!.setPtt(enabled, { source: enabled ? 'tci' : undefined });
+      try {
+        await this.client!.setPtt(enabled, { source: enabled ? 'tci' : undefined });
+      } catch (error) {
+        if (isTciCommandTimeout(error)) {
+          this.pttWriteUncertain = true;
+          this.lastKnownPtt = null;
+          this.setState(RadioConnectionState.ERROR);
+          logger.error('TCI PTT state acknowledgement timed out; poisoning session', {
+            enabled,
+            operation: 'setPTT',
+          });
+        }
+        throw error;
+      }
       this.lastKnownPtt = enabled;
       if (!enabled) {
         this.clearTxAudioQueue('ptt-off-applied');
@@ -792,7 +827,13 @@ export class TciConnection extends EventEmitter<IRadioConnectionEvents> implemen
         'Avoid connecting multiple TCI clients if the radio rejects them',
       ],
       cause: error,
-      context: { operation, protocol: 'tci', writeTimeout: isWriteTimeout, recoverable: isWriteTimeout },
+      context: {
+        operation,
+        protocol: 'tci',
+        writeTimeout: isWriteTimeout,
+        recoverable: isWriteTimeout,
+        stateUncertain: operation === 'setPTT' && this.pttWriteUncertain,
+      },
     });
   }
 }

--- a/packages/server/src/radio/frequencyRadioMode.ts
+++ b/packages/server/src/radio/frequencyRadioMode.ts
@@ -21,6 +21,9 @@ function isDigitalAppMode(mode: string | undefined): boolean {
 export function normalizeDigitalModeRadioModePreference(
   value: unknown,
 ): DigitalModeRadioModePreference {
+  if (value === undefined || value === null) {
+    return 'usb';
+  }
   return value === 'usb' || value === 'usb-data' ? value : 'none';
 }
 

--- a/packages/server/src/radio/hamlibConfigUtils.ts
+++ b/packages/server/src/radio/hamlibConfigUtils.ts
@@ -84,12 +84,17 @@ export function normalizeSerialConnectionConfig(serial?: Partial<SerialConnectio
 }
 
 export function normalizeHamlibConfig(config: HamlibConfig): HamlibConfig {
+  const normalizedConfig: HamlibConfig = {
+    ...config,
+    digitalModeRadioMode: config.digitalModeRadioMode ?? 'usb',
+  };
+
   if (config.type !== 'serial') {
-    return config;
+    return normalizedConfig;
   }
 
   return {
-    ...config,
+    ...normalizedConfig,
     serial: normalizeSerialConnectionConfig(config.serial),
   };
 }

--- a/packages/server/src/rigctld/RadioControllerAdapter.ts
+++ b/packages/server/src/rigctld/RadioControllerAdapter.ts
@@ -27,6 +27,7 @@ import {
   type RigctlVfo,
 } from '@tx5dr/rigctld-server';
 import type { PhysicalRadioManager } from '../radio/PhysicalRadioManager.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import type { IRadioConnection, RadioModeBandwidth } from '../radio/connections/IRadioConnection.js';
 import { ConfigManager } from '../config/config-manager.js';
 import { RadioPowerController } from '../radio/RadioPowerController.js';
@@ -84,7 +85,12 @@ function hzToBandwidth(hz: number): RadioModeBandwidth {
 }
 
 export class RadioControllerAdapter implements RadioController {
-  constructor(private readonly pm: PhysicalRadioManager) {}
+  private pttLeaseId: string | null = null;
+
+  constructor(
+    private readonly pm: PhysicalRadioManager,
+    private readonly physicalTxCoordinator: PhysicalTxCoordinator,
+  ) {}
 
   private requireConnected(): void {
     if (!this.pm.isConnected()) {
@@ -146,8 +152,55 @@ export class RadioControllerAdapter implements RadioController {
 
   async setPTT(on: boolean): Promise<void> {
     this.requireConnected();
-    this.pm.setPTTActive(on);
-    await this.pm.setPTT(on);
+    try {
+      if (on) {
+        const snapshot = this.physicalTxCoordinator.getSnapshot();
+        if (this.pttLeaseId
+          && snapshot.leaseId === this.pttLeaseId
+          && snapshot.source === 'manual'
+          && snapshot.phase !== 'idle') {
+          return;
+        }
+        // The lease may have been cleared by a disconnect/recovery path while
+        // this adapter still held its local handle.  Never treat that stale
+        // handle as proof that PTT is active.
+        this.pttLeaseId = null;
+        this.pttLeaseId = await this.physicalTxCoordinator.acquireLease({
+          source: 'manual',
+          reason: 'rigctld PTT',
+        });
+        return;
+      }
+      if (this.pttLeaseId) {
+        const leaseId = this.pttLeaseId;
+        let result = await this.physicalTxCoordinator.releaseLease(leaseId, 'rigctld PTT release');
+        let snapshot = this.physicalTxCoordinator.getSnapshot();
+        if (!result.success && snapshot.leaseId === leaseId && snapshot.phase === 'unknown') {
+          // releaseLease is intentionally idempotent once a release promise is
+          // cached; an unknown stop needs the coordinator's explicit retry
+          // path so a late CAT acknowledgement cannot be mistaken for RX.
+          result = await this.physicalTxCoordinator.retryUnknownStop('rigctld PTT release retry')
+            ?? result;
+          snapshot = this.physicalTxCoordinator.getSnapshot();
+        }
+        if (snapshot.leaseId !== leaseId || snapshot.phase === 'idle') {
+          this.pttLeaseId = null;
+        }
+        // A retry result intentionally reports `success: false` because no RF
+        // frame was transmitted; once the coordinator is idle, the safety
+        // recovery itself succeeded and rigctld should observe RX normally.
+        if (!result.success && snapshot.phase !== 'idle') {
+          throw new Error(result.error ?? result.reason);
+        }
+      } else if (this.physicalTxCoordinator.getSnapshot().source === 'manual') {
+        const result = await this.physicalTxCoordinator.retryUnknownStop('rigctld PTT release retry');
+        if (result && !result.success && this.physicalTxCoordinator.getSnapshot().phase !== 'idle') {
+          throw new Error(result.error ?? result.reason);
+        }
+      }
+    } catch (error) {
+      throw new RigctldProtocolError(RigErr.EIO, (error as Error).message);
+    }
   }
 
   async getLevel(name: RigctlLevel): Promise<number> {

--- a/packages/server/src/rigctld/RigctldBridge.ts
+++ b/packages/server/src/rigctld/RigctldBridge.ts
@@ -20,6 +20,7 @@ import {
 } from '@tx5dr/rigctld-server';
 import type { RigctldBridgeConfig, RigctldStatus } from '@tx5dr/contracts';
 import type { PhysicalRadioManager } from '../radio/PhysicalRadioManager.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { ConfigManager } from '../config/config-manager.js';
 import { createLogger } from '../utils/logger.js';
 import { RadioControllerAdapter } from './RadioControllerAdapter.js';
@@ -36,7 +37,10 @@ export class RigctldBridge extends EventEmitter<RigctldBridgeEvents> {
   private lastError: string | undefined;
   private clients = new Map<number, RigctldClientInfo>();
 
-  constructor(private readonly radioManager: PhysicalRadioManager) {
+  constructor(
+    private readonly radioManager: PhysicalRadioManager,
+    private readonly physicalTxCoordinator: PhysicalTxCoordinator,
+  ) {
     super();
   }
 
@@ -74,7 +78,7 @@ export class RigctldBridge extends EventEmitter<RigctldBridgeEvents> {
     }
 
     const server = new RigctldServer({
-      controller: new RadioControllerAdapter(this.radioManager),
+      controller: new RadioControllerAdapter(this.radioManager, this.physicalTxCoordinator),
       host: next.bindAddress,
       port: next.port,
       readOnly: next.readOnly,

--- a/packages/server/src/rigctld/__tests__/RadioControllerAdapter.test.ts
+++ b/packages/server/src/rigctld/__tests__/RadioControllerAdapter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RadioControllerAdapter } from '../RadioControllerAdapter.js';
+
+describe('RadioControllerAdapter', () => {
+  it('retries an unknown lease instead of reusing the cached release promise', async () => {
+    let snapshot: any = {
+      leaseId: null,
+      source: undefined,
+      phase: 'idle',
+    };
+    const acquireLease = vi.fn().mockImplementation(async () => {
+      snapshot = { leaseId: 'lease-1', source: 'manual', phase: 'active' };
+      return 'lease-1';
+    });
+    const releaseLease = vi.fn().mockImplementation(async () => {
+      snapshot = { leaseId: 'lease-1', source: 'manual', phase: 'unknown' };
+      return { success: false, reason: 'PTT release unconfirmed', physicalConfirmed: true };
+    });
+    const retryUnknownStop = vi.fn().mockImplementation(async () => {
+      snapshot = { leaseId: null, source: undefined, phase: 'idle' };
+      return { success: false, reason: 'retry succeeded without RF frame', physicalConfirmed: false };
+    });
+    const coordinator = {
+      acquireLease,
+      releaseLease,
+      retryUnknownStop,
+      getSnapshot: vi.fn(() => snapshot),
+    };
+    const radioManager = {
+      isConnected: vi.fn(() => true),
+      isPTTActive: vi.fn(() => false),
+    };
+    const adapter = new RadioControllerAdapter(radioManager as any, coordinator as any);
+
+    await adapter.setPTT(true);
+    await adapter.setPTT(false);
+
+    expect(releaseLease).toHaveBeenCalledWith('lease-1', 'rigctld PTT release');
+    expect(retryUnknownStop).toHaveBeenCalledWith('rigctld PTT release retry');
+  });
+});

--- a/packages/server/src/routes/__tests__/radio.auth.test.ts
+++ b/packages/server/src/routes/__tests__/radio.auth.test.ts
@@ -196,6 +196,35 @@ describe('radioRoutes authorization', () => {
     expect(response.statusCode).toBe(403);
   });
 
+  it('runs temporary PTT tests through a complete physical lease', async () => {
+    const { runTemporaryPhysicalPttTest } = await import('../radio.js');
+    const setPTT = vi.fn().mockResolvedValue(undefined);
+
+    await runTemporaryPhysicalPttTest(
+      { isConnected: () => true, setPTT } as any,
+      500,
+      vi.fn().mockResolvedValue(undefined),
+    );
+
+    expect(setPTT.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it('retries an unconfirmed temporary PTT stop without reporting success', async () => {
+    const { runTemporaryPhysicalPttTest } = await import('../radio.js');
+    const setPTT = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('USB write failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(runTemporaryPhysicalPttTest(
+      { isConnected: () => true, setPTT } as any,
+      500,
+      vi.fn().mockResolvedValue(undefined),
+    )).rejects.toThrow('USB write failed');
+
+    expect(setPTT.mock.calls).toEqual([[true], [false], [false]]);
+  });
+
   it('reuses an already-open CW keyer backend for CW hardware tests', async () => {
     existingCWKeyerManager = {
       getStatus: vi.fn(() => ({ active: false })),

--- a/packages/server/src/routes/radio.ts
+++ b/packages/server/src/routes/radio.ts
@@ -21,6 +21,7 @@ const { SerialPort } = serialport;
 
 import { PhysicalRadioManager } from '../radio/PhysicalRadioManager.js';
 import type { RepeaterDuplexApplyResult, RepeaterDuplexConfig, ToneSquelchApplyResult, ToneSquelchConfig } from '../radio/PhysicalRadioManager.js';
+import { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { FrequencyManager } from '../radio/FrequencyManager.js';
 import { CWKeyerHardware } from '../cw/CWKeyerHardware.js';
 import { CWKeyerTestFailure, type CWSerialKeyerTestTarget } from '../cw/CWKeyerManager.js';
@@ -115,6 +116,40 @@ async function listAndroidBridgeSerialPorts(): Promise<unknown[] | null> {
 }
 
 type CWKeyerTestPhase = 'open' | 'keyDown' | 'keyUp';
+
+export async function runTemporaryPhysicalPttTest(
+  manager: Pick<PhysicalRadioManager, 'isConnected' | 'setPTT'>,
+  durationMs = 500,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<void> {
+  const coordinator = new PhysicalTxCoordinator({
+    isRadioConnected: () => manager.isConnected(),
+    setPTT: (active) => manager.setPTT(active),
+    playAudio: async () => { throw new Error('PTT test does not support audio playback'); },
+    stopCurrentPlayback: async () => 0,
+    sleep,
+  });
+
+  try {
+    const leaseId = await coordinator.acquireLease({
+      source: 'test',
+      reason: 'authenticated temporary PTT test',
+    });
+    await sleep(durationMs);
+    const result = await coordinator.releaseLease(leaseId, 'PTT test complete');
+    if (!result.success) {
+      throw new Error(result.error ?? result.reason);
+    }
+  } catch (error) {
+    const snapshot = coordinator.getSnapshot();
+    if (snapshot.phase === 'unknown') {
+      await coordinator.retryUnknownStop('PTT test cleanup retry');
+    } else if (snapshot.phase !== 'idle') {
+      await coordinator.forceInterrupt('PTT test failed');
+    }
+    throw error;
+  }
+}
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -919,21 +954,6 @@ export async function radioRoutes(fastify: FastifyInstance) {
       });
     }
 
-    // PTT 测试辅助：开启 → 等 500ms → 关闭，确保异常时 PTT 关闭
-    const doPttTest = async (manager: PhysicalRadioManager) => {
-      try {
-        await manager.setPTT(true);
-        logger.debug('PTT enabled, radio in transmit state');
-        await new Promise(resolve => setTimeout(resolve, 500));
-        await manager.setPTT(false);
-        logger.info('PTT test complete, returned to receive state');
-      } catch (error) {
-        // 确保 PTT 关闭
-        try { await manager.setPTT(false); } catch { /* ignore */ }
-        throw error;
-      }
-    };
-
     // 智能复用：检查引擎是否已连接同一硬件
     if (radioManager.isConnected()) {
       const activeConfig = radioManager.getConfig();
@@ -941,7 +961,7 @@ export async function radioRoutes(fastify: FastifyInstance) {
       if (isHardwareSameTarget(activeConfig, config)) {
         logger.debug('Reusing existing connection for PTT test');
         try {
-          await doPttTest(radioManager);
+          await engine.testPhysicalPTT(500);
           return reply.send({ success: true, message: 'PTT test successful! Transmit state toggled for 0.5 seconds.' });
         } catch (error) {
           throw RadioError.from(error, RadioErrorCode.INVALID_OPERATION);
@@ -961,7 +981,8 @@ export async function radioRoutes(fastify: FastifyInstance) {
     const tester = new PhysicalRadioManager();
     try {
       await tester.applyConfig(config);
-      await doPttTest(tester);
+      await runTemporaryPhysicalPttTest(tester);
+      logger.info('PTT test complete, returned to receive state');
       return reply.send({ success: true, message: 'PTT test successful! Transmit state toggled for 0.5 seconds.' });
     } catch (e) {
       logger.error('PTT test failed:', e);
@@ -1141,6 +1162,16 @@ export async function radioRoutes(fastify: FastifyInstance) {
 
   // 断开电台连接
   fastify.post('/disconnect', { preHandler: [requireAbility('execute', 'RadioReconnect')] }, async (_req, reply) => {
+    // Release the shared physical lease before closing CAT. Closing the
+    // connection first makes a pending PTT-off impossible to confirm and can
+    // leave the radio keyed while the coordinator is still on-air.
+    try {
+      await engine.forceStopTransmission();
+    } catch (error) {
+      logger.warn('Failed to force-stop transmission before radio disconnect', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     await radioManager.disconnect();
 
     return reply.send({

--- a/packages/server/src/subsystems/ClockCoordinator.ts
+++ b/packages/server/src/subsystems/ClockCoordinator.ts
@@ -70,15 +70,11 @@ export class ClockCoordinator {
       // 处理器在 await 间隙通过 addTransmissionFrame 覆盖 lastSlotPack
       const latestSlotPack = slotPackManager.getLatestSlotPack();
 
-      // 确保PTT在新时隙开始时被停止
-      await getTransmissionPipeline().forceStopPTT();
-
-      // 停止残留音频 + 清空时隙缓存
-      await getTransmissionPipeline().onSlotStart();
+      // A physical lease may still be starting or draining at the boundary.
+      // The pipeline only clears a terminal/idle slot; it never truncates RF.
+      await getTransmissionPipeline().onSlotStart(slotInfo);
 
       // 时隙边界清理：取消重决策 debounce + 清空编码请求ID映射
-      operatorManager.onSlotBoundary();
-
       engineEmitter.emit('slotStart', slotInfo, latestSlotPack);
 
       // 广播所有操作员的状态更新

--- a/packages/server/src/subsystems/EngineLifecycle.ts
+++ b/packages/server/src/subsystems/EngineLifecycle.ts
@@ -29,6 +29,7 @@ import type { AudioVolumeController } from './AudioVolumeController.js';
 import { RadioError } from '../utils/errors/RadioError.js';
 import { createLogger } from '../utils/logger.js';
 import type { WSJTXDecodeWorkQueue } from '../decode/WSJTXDecodeWorkQueue.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 
 const logger = createLogger('EngineLifecycle');
 
@@ -42,6 +43,7 @@ export interface EngineLifecycleDeps {
   spectrumScheduler: SpectrumScheduler;
   decodeQueue: WSJTXDecodeWorkQueue;
   operatorManager: RadioOperatorManager;
+  physicalTxCoordinator: PhysicalTxCoordinator;
   audioMixer: AudioMixer;
   clockSource: ClockSourceSystem;
   subsystems: {
@@ -74,8 +76,7 @@ export interface EngineLifecycleDeps {
 export class EngineLifecycle {
   private isRunning = false;
   private audioStarted = false;
-  /** When true, radio stop handler skips disconnect (used for CW transitions). */
-  preserveRadioConnection = false;
+  private requestedStopScope: 'full' | 'mode-runtime' = 'full';
 
   // ICOM WLAN 音频适配器
   private icomWlanAudioAdapter: IcomWlanAudioAdapter | null = null;
@@ -158,7 +159,7 @@ export class EngineLifecycle {
     const configManager = ConfigManager.getInstance();
     const mode = this.deps.getCurrentMode();
     const resources = [
-      ...this.buildCoreResourcePlan(configManager),
+      ...this.buildConnectionAdapterResourcePlan(configManager),
       ...(mode.name === 'VOICE'
         ? this.buildVoiceModeResourcePlan()
         : mode.name === 'CW'
@@ -170,40 +171,10 @@ export class EngineLifecycle {
     return resources;
   }
 
-  private buildCoreResourcePlan(configManager: ConfigManager): SimplifiedResourceConfig[] {
+  private buildConnectionAdapterResourcePlan(configManager: ConfigManager): SimplifiedResourceConfig[] {
     const { radioManager, audioStreamManager } = this.deps;
-    const isCWMode = this.deps.getCurrentMode().name === 'CW';
 
     return [
-      {
-        name: 'radio',
-        start: async () => {
-          const radioConfig = configManager.getRadioConfig();
-          if (radioConfig.type === 'icom-wlan') {
-            if (!radioConfig.icomWlan?.ip || !radioConfig.icomWlan?.port) {
-              logger.error('ICOM WLAN config incomplete:', radioConfig.icomWlan);
-              throw new Error('ICOM WLAN IP or port missing');
-            }
-            logger.debug(`ICOM WLAN config validated: IP=${radioConfig.icomWlan.ip}, Port=${radioConfig.icomWlan.port}`);
-          } else if (radioConfig.type === 'tci') {
-            if (!radioConfig.tci?.host || !radioConfig.tci?.port) {
-              logger.error('TCI config incomplete:', radioConfig.tci);
-              throw new Error('TCI host or port missing');
-            }
-            logger.debug(`TCI config validated: ${radioConfig.tci.host}:${radioConfig.tci.port}`);
-          }
-          logger.debug('Applying radio config:', radioConfig);
-          await radioManager.applyConfig(radioConfig);
-        },
-        stop: async () => {
-          if (this.preserveRadioConnection) return;
-          if (radioManager.isConnected()) {
-            await radioManager.disconnect('Engine stopped');
-          }
-        },
-        priority: 1,
-        optional: isCWMode,
-      },
       {
         name: 'icomWlanAudioAdapter',
         start: async () => {
@@ -659,18 +630,34 @@ export class EngineLifecycle {
    * 停止引擎（外部 API，委托给状态机）
    */
   async stop(): Promise<void> {
+    return this.stopWithScope('full');
+  }
+
+  /** Stops mode-specific resources while preserving the active CAT session. */
+  async stopModeRuntime(): Promise<void> {
+    return this.stopWithScope('mode-runtime');
+  }
+
+  private async stopWithScope(scope: 'full' | 'mode-runtime'): Promise<void> {
     if (!this.engineStateMachineActor) {
       throw new Error('Engine state machine not initialized');
     }
 
     if (isEngineState(this.engineStateMachineActor, EngineState.IDLE)) {
       logger.info('Engine already stopped, sending status sync');
+      if (scope === 'full' && this.deps.radioManager.isConnected()) {
+        await this.deps.radioManager.disconnect('Engine stopped');
+      }
       const status = this.deps.getStatus();
       this.deps.engineEmitter.emit('systemStatus', status);
       return;
     }
 
     if (isEngineState(this.engineStateMachineActor, EngineState.STOPPING)) {
+      // A full stop may upgrade a mode-only stop that is already draining.
+      if (scope === 'full') {
+        this.requestedStopScope = 'full';
+      }
       logger.info('Engine already stopping, waiting for completion...');
       try {
         await waitForEngineState(this.engineStateMachineActor, EngineState.IDLE, 10000);
@@ -682,8 +669,15 @@ export class EngineLifecycle {
       return;
     }
 
-    logger.info('Delegating to state machine: STOP');
-    this.engineStateMachineActor.send({ type: 'STOP' });
+    this.requestedStopScope = scope;
+
+    const stoppingDuringStart = isEngineState(this.engineStateMachineActor, EngineState.STARTING);
+    logger.info(`Delegating to state machine: ${stoppingDuringStart ? 'FORCE_STOP' : 'STOP'}`);
+    this.engineStateMachineActor.send(
+      stoppingDuringStart
+        ? { type: 'FORCE_STOP', reason: `${scope} stop while starting` }
+        : { type: 'STOP' },
+    );
 
     // Wait for engine to reach IDLE state after sending STOP
     try {
@@ -701,6 +695,9 @@ export class EngineLifecycle {
   sendRadioDisconnected(reason: string): void {
     if (this.engineStateMachineActor && isEngineState(this.engineStateMachineActor, EngineState.RUNNING)) {
       logger.info('Sending RADIO_DISCONNECTED event');
+      // A real connection loss is always a full lifecycle boundary. Do not
+      // inherit a stale mode-only scope from a previous switch.
+      this.requestedStopScope = 'full';
       this.engineStateMachineActor.send({
         type: 'RADIO_DISCONNECTED',
         reason
@@ -729,8 +726,21 @@ export class EngineLifecycle {
 
     const mode = this.deps.getCurrentMode();
     logger.info(`Starting engine, mode: ${mode.name}`);
+    const radioWasConnected = this.deps.radioManager.isConnected();
 
     try {
+      const radioConfig = ConfigManager.getInstance().getRadioConfig();
+      try {
+        await this.deps.radioManager.applyConfig(radioConfig);
+      } catch (error) {
+        if (mode.name !== 'CW') {
+          throw error;
+        }
+        logger.warn('CW mode starting without a confirmed CAT session', {
+          error: (error as Error).message,
+        });
+      }
+
       // 1. 注册时钟/解码/频谱事件
       this.deps.subsystems.clockCoordinator.setup();
 
@@ -752,6 +762,9 @@ export class EngineLifecycle {
       logger.info('Engine started successfully');
     } catch (error) {
       logger.error('Engine start failed:', error);
+      if (!radioWasConnected && this.deps.radioManager.isConnected()) {
+        await this.deps.radioManager.disconnect('Engine start rollback').catch(() => undefined);
+      }
       // Clean up event listeners registered by setup() that won't be cleaned by rollback
       this.deps.subsystems.transmissionPipeline.teardown();
       this.deps.subsystems.clockCoordinator.teardown();
@@ -776,10 +789,18 @@ export class EngineLifecycle {
       // 3. 清除时钟/解码/频谱监听器
       this.deps.subsystems.clockCoordinator.teardown();
 
-      // 4. 按逆序停止资源
+      // 4. Shutdown is a hard-interrupt boundary. Release the single physical
+      // lease before audio/radio resources disappear underneath it.
+      await this.deps.physicalTxCoordinator.forceInterrupt('engine stopping');
+
+      // 5. 按逆序停止资源
       await this.deps.resourceManager.stopAll();
 
-      // 5. 清除状态标志
+      if (this.requestedStopScope === 'full' && this.deps.radioManager.isConnected()) {
+        await this.deps.radioManager.disconnect('Engine stopped');
+      }
+
+      // 6. 清除状态标志
       this.isRunning = false;
       this.audioStarted = false;
 
@@ -789,6 +810,8 @@ export class EngineLifecycle {
       this.isRunning = false;
       this.audioStarted = false;
       throw error;
+    } finally {
+      this.requestedStopScope = 'full';
     }
   }
 }

--- a/packages/server/src/subsystems/RadioBridge.ts
+++ b/packages/server/src/subsystems/RadioBridge.ts
@@ -11,6 +11,7 @@ import { ConfigManager } from '../config/config-manager.js';
 import { ListenerManager } from './ListenerManager.js';
 import type { TransmissionPipeline } from './TransmissionPipeline.js';
 import type { EngineLifecycle } from './EngineLifecycle.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { createLogger } from '../utils/logger.js';
 import { buildRadioStatusPayload } from '../radio/buildRadioStatusPayload.js';
 
@@ -23,6 +24,7 @@ export interface RadioBridgeDeps {
   slotPackManager: SlotPackManager;
   operatorManager: RadioOperatorManager;
   getTransmissionPipeline: () => TransmissionPipeline;
+  physicalTxCoordinator?: PhysicalTxCoordinator;
   getEngineLifecycle: () => EngineLifecycle;
   getEngineMode: () => EngineMode;
   getCurrentModeName?: () => string;
@@ -195,6 +197,20 @@ export class RadioBridge {
     logger.info('Radio connected');
 
     const { engineEmitter, radioManager } = this.deps;
+    // A disconnect can happen after the old CAT session has already gone
+    // away, so the previous lease may be left in `unknown` rather than being
+    // released by the normal force-stop path.  The PhysicalRadioManager
+    // performs its post-connect PTT-off safety write before emitting
+    // `connected`; retry the coordinator's release against this new session
+    // now.  Failure deliberately leaves the lease unknown and blocks TX.
+    const recovered = await this.deps.physicalTxCoordinator?.retryUnknownStop('radio reconnected');
+    const recoverySnapshot = this.deps.physicalTxCoordinator?.getSnapshot?.();
+    if (recovered && !recovered.success && recoverySnapshot?.phase !== 'idle') {
+      logger.warn('Physical TX lease remains unknown after radio reconnect', {
+        reason: recovered.reason,
+        error: recovered.error,
+      });
+    }
     const radioInfo = await radioManager.getRadioInfo();
     const radioConfig = radioManager.getConfig();
     const tunerCapabilities = await radioManager.getTunerCapabilities();
@@ -207,6 +223,16 @@ export class RadioBridge {
       tunerCapabilities,
       radioManager,
     }));
+
+    // A failed physical PTT release is a hardware-safety condition, not a
+    // transient automation error. Keep the previous running intent pending,
+    // but do not restart the engine while the coordinator is still unknown;
+    // otherwise it can keep producing deferred TX requests against a radio
+    // whose physical lease is not safe to use.
+    if (recoverySnapshot?.phase === 'unknown') {
+      logger.warn('Radio connected but physical TX recovery is still unknown; keeping automation stopped');
+      return;
+    }
 
     await this.restoreRunningStateIfNeeded();
   }

--- a/packages/server/src/subsystems/TransmissionPipeline.ts
+++ b/packages/server/src/subsystems/TransmissionPipeline.ts
@@ -3,25 +3,42 @@ import type { DigitalRadioEngineEvents, ModeDescriptor } from '@tx5dr/contracts'
 import type { ClockSourceSystem } from '@tx5dr/core';
 import type { AudioStreamManager } from '../audio/AudioStreamManager.js';
 import type { AudioMixer, MixedAudio } from '../audio/AudioMixer.js';
-import type { PhysicalRadioManager } from '../radio/PhysicalRadioManager.js';
 import type { SpectrumScheduler } from '../audio/SpectrumScheduler.js';
 import { TransmissionTracker, TransmissionPhase } from '../transmission/TransmissionTracker.js';
-import type { WSJTXEncodeWorkQueue } from '../decode/WSJTXEncodeWorkQueue.js';
+import type { WSJTXEncodeWorkQueue, EncodeRequest } from '../decode/WSJTXEncodeWorkQueue.js';
 import type { RadioOperatorManager } from '../operator/RadioOperatorManager.js';
+import type { DigitalFrameCoordinator } from '../transmission/DigitalFrameCoordinator.js';
+import {
+  PhysicalTxBusyError,
+  PhysicalTxPreparationError,
+  type PhysicalTxCoordinator,
+} from '../transmission/PhysicalTxCoordinator.js';
+import type { PhysicalTxSnapshot } from '../transmission/TransmissionIntent.js';
+import type { OperatorIntentCoordinator } from '../transmission/OperatorIntentCoordinator.js';
 import { ListenerManager } from './ListenerManager.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('TransmissionPipeline');
+const DIGITAL_TAIL_HOLD_MS = 500;
+
+class CompleteFrameBudgetExceededError extends Error {
+  constructor(message = 'complete frame no longer fits before PTT start') {
+    super(message);
+    this.name = 'CompleteFrameBudgetExceededError';
+  }
+}
 
 export interface TransmissionPipelineDeps {
   engineEmitter: EventEmitter<DigitalRadioEngineEvents>;
   audioMixer: AudioMixer;
   audioStreamManager: AudioStreamManager;
-  radioManager: PhysicalRadioManager;
   spectrumScheduler: SpectrumScheduler;
   transmissionTracker: TransmissionTracker;
   encodeQueue: WSJTXEncodeWorkQueue;
   operatorManager: RadioOperatorManager;
+  digitalFrameCoordinator: DigitalFrameCoordinator;
+  physicalTxCoordinator: PhysicalTxCoordinator;
+  intentCoordinator: OperatorIntentCoordinator;
   clockSource: ClockSourceSystem;
   getCurrentMode: () => ModeDescriptor;
   getCompensationMs: () => number;
@@ -29,351 +46,298 @@ export interface TransmissionPipelineDeps {
 }
 
 /**
- * 发射管线子系统
- *
- * 职责：encode→mix→PTT→play 全流程、编码跟踪
+ * Adapts existing encode and mixer events to the digital-frame and physical-TX
+ * lifecycle owners. It does not own PTT state or decide whether to truncate RF.
  */
 export class TransmissionPipeline {
-  private lm = new ListenerManager();
+  private readonly lm = new ListenerManager();
+  private currentSlotExpectedEncodes = 0;
+  private currentSlotCompletedEncodes = 0;
+  private currentSlotId = '';
+  private readonly terminalOperatorsByFrame = new Map<string, Set<string>>();
+  private readonly onAirTransmissionKeys = new Set<string>();
+  private operatorRemovalTransition: Promise<void> = Promise.resolve();
 
-  // PTT状态管理
-  private _isPTTActive = false;
-  private _isRemixing = false;
-
-  // PTT 轮询（替代 setTimeout，在高负载 CPU 上更精确）
-  private pttPollInterval: NodeJS.Timeout | null = null;
-  private pttAudioStoppedAt: number | null = null;
-  private static readonly PTT_POLL_INTERVAL_MS = 50;
-  private static readonly PTT_HOLD_AFTER_AUDIO_MS = 500;
-
-  // 编码状态跟踪
-  private currentSlotExpectedEncodes: number = 0;
-  private currentSlotCompletedEncodes: number = 0;
-  private currentSlotId: string = '';
-  private txSequence = 0;
-
-  constructor(private deps: TransmissionPipelineDeps) {}
+  constructor(private readonly deps: TransmissionPipelineDeps) {}
 
   getIsPTTActive(): boolean {
-    return this._isPTTActive;
+    return this.deps.physicalTxCoordinator.getSnapshot().phase !== 'idle';
   }
 
-  /**
-   * 注册编码/混音事件监听器（doStart 时调用）
-   */
   setup(): void {
-    const { encodeQueue, audioMixer } = this.deps;
+    const { encodeQueue, audioMixer, physicalTxCoordinator } = this.deps;
 
-    // 编码完成事件
     this.lm.listen(encodeQueue, 'encodeComplete', async (result: {
       operatorId: string;
       audioData: Float32Array;
       sampleRate: number;
       duration: number;
-      request?: { timeSinceSlotStartMs?: number; requestId?: string };
+      request?: EncodeRequest;
     }) => {
       await this.handleEncodeComplete(result);
     });
-
-    // 编码错误事件
-    this.lm.listen(encodeQueue, 'encodeError', (error: Error, request: { operatorId: string }) => {
-      logger.error(`encode failed: operatorId=${request.operatorId}: ${error.message}`);
-      this.deps.engineEmitter.emit('transmissionComplete', {
-        operatorId: request.operatorId,
-        success: false,
-        error: error.message
-      });
+    this.lm.listen(encodeQueue, 'encodeError', (error: Error, request: EncodeRequest) => {
+      this.handleEncodeError(error, request);
     });
-
-    // 混音完成事件
     this.lm.listen(audioMixer, 'mixedAudioReady', async (mixedAudio: MixedAudio) => {
       await this.handleMixedAudioReady(mixedAudio);
+    });
+    this.lm.listen(physicalTxCoordinator, 'phaseChanged', (snapshot: PhysicalTxSnapshot) => {
+      this.handlePhysicalPhaseChanged(snapshot);
+    });
+    this.lm.listen(this.deps.digitalFrameCoordinator, 'frameChanged', (frame) => {
+      if (frame.phase === 'committed' || frame.phase === 'on_air' || frame.phase === 'draining') {
+        this.deps.audioMixer.retainFrame(frame.frameId, frame.revision);
+      }
+      if (frame.phase === 'cancelled') {
+        this.deps.audioMixer.clearFrame(frame.frameId, frame.revision);
+      } else if (frame.phase === 'terminal') {
+        this.deps.audioMixer.releaseFrame(frame.frameId, frame.revision);
+        this.deps.audioMixer.clearFrame(frame.frameId, frame.revision);
+      }
     });
 
     logger.info(`event listeners registered (${this.lm.count})`);
   }
 
-  /**
-   * 清理监听器和 PTT 轮询（doStop 时调用）
-   */
   teardown(): void {
-    this.stopPTTPoll();
-
     this.lm.disposeAll();
     logger.info('event listeners cleaned up');
   }
 
-  /**
-   * 时隙开始时调用：停止残留音频播放 + 清空混音缓存
-   */
-  async onSlotStart(): Promise<void> {
-    // 停止上一时隙的残留音频播放，防止 isPlaying 状态泄漏到新时隙
-    if (this.isDigitalPlaybackInProgress()) {
-      await this.deps.audioStreamManager.stopCurrentPlayback();
-      logger.debug('stopped residual audio playback from previous slot');
-    } else if (this.deps.audioStreamManager.isPlaying()) {
-      logger.debug('preserved non-digital playback across slot start', {
-        kind: this.deps.audioStreamManager.getCurrentPlaybackKind(),
+  async onSlotStart(slotInfo?: { id: string }): Promise<void> {
+    if (slotInfo) {
+      this.deps.digitalFrameCoordinator.cancelPreCommitFramesOutsideSlot(
+        slotInfo.id,
+        'pre-commit frame expired at slot boundary',
+      );
+    }
+    const physical = this.deps.physicalTxCoordinator.getSnapshot();
+    if (physical.phase === 'idle') {
+      this.deps.audioMixer.clearSlotCache();
+      return;
+    }
+    logger.debug('preserving in-flight physical frame across slot boundary', {
+      leaseId: physical.leaseId,
+      frameId: physical.frameId,
+      phase: physical.phase,
+    });
+  }
+
+  onEncodeStart(slotInfo: { id: string; startMs?: number }): void {
+    this.currentSlotId = slotInfo.id;
+    this.currentSlotExpectedEncodes = this.deps.operatorManager.getPendingTransmissionsCount();
+    this.currentSlotCompletedEncodes = 0;
+    this.deps.operatorManager.processPendingTransmissions(slotInfo);
+  }
+
+  onTransmitStart(_slotInfo: { id: string }): void {
+    if (this.currentSlotExpectedEncodes > this.currentSlotCompletedEncodes) {
+      logger.warn('encode deadline reached before all frame members completed', {
+        slotId: this.currentSlotId,
+        expected: this.currentSlotExpectedEncodes,
+        completed: this.currentSlotCompletedEncodes,
       });
     }
+  }
+
+  async forceStopPTT(): Promise<void> {
+    await this.deps.physicalTxCoordinator.forceInterrupt('force stop PTT');
+  }
+
+  async forceStopTransmission(): Promise<void> {
+    await this.deps.physicalTxCoordinator.forceInterrupt('manual force stop transmission');
     this.deps.audioMixer.clearSlotCache();
   }
 
-  /**
-   * encodeStart 事件中调用
-   */
-  onEncodeStart(slotInfo: { id: string }): void {
-    this.currentSlotId = slotInfo.id;
-    this.currentSlotExpectedEncodes = 0;
-    this.currentSlotCompletedEncodes = 0;
-
-    const pendingCount = this.deps.operatorManager.getPendingTransmissionsCount();
-    this.deps.operatorManager.processPendingTransmissions(slotInfo);
-    this.currentSlotExpectedEncodes = pendingCount;
-
-    if (this.currentSlotExpectedEncodes > 0) {
-      logger.debug(`slot ${slotInfo.id}: expected ${this.currentSlotExpectedEncodes} encode tasks`);
+  async removeOperatorFromTransmission(
+    operatorId: string,
+    options: {
+      commandAlreadyAllocated?: boolean;
+      signal?: AbortSignal;
+      commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken;
+    } = {},
+  ): Promise<void> {
+    if (!options.commandAlreadyAllocated) {
+      const outcome = await this.deps.intentCoordinator.submit(
+        operatorId,
+        'manual',
+        async (token, signal) => {
+          if (signal.aborted || !this.deps.intentCoordinator.isCurrent(token)) return;
+          this.deps.operatorManager.getOperatorById(operatorId)?.stop();
+          this.deps.operatorManager.releaseTargetReservation(operatorId);
+          await this.removeOperatorFromTransmission(operatorId, {
+            commandAlreadyAllocated: true,
+            signal,
+            commandToken: token,
+          });
+        },
+      );
+      if (outcome.status === 'superseded') {
+        logger.info('operator removal superseded by a newer command', { operatorId });
+      }
+      return;
     }
-  }
 
-  /**
-   * transmitStart 事件中调用
-   */
-  onTransmitStart(_slotInfo: { id: string }): void {
-    if (this.currentSlotExpectedEncodes > 0 &&
-        this.currentSlotCompletedEncodes < this.currentSlotExpectedEncodes) {
-      const missingCount = this.currentSlotExpectedEncodes - this.currentSlotCompletedEncodes;
-      logger.warn(`encode timeout: expected ${this.currentSlotExpectedEncodes}, completed ${this.currentSlotCompletedEncodes}, missing ${missingCount}`);
-    } else if (this.currentSlotExpectedEncodes > 0) {
-      logger.debug(`all encode tasks completed on time (${this.currentSlotCompletedEncodes}/${this.currentSlotExpectedEncodes})`);
+    const previous = this.operatorRemovalTransition;
+    let releaseTransition!: () => void;
+    const current = new Promise<void>((resolve) => { releaseTransition = resolve; });
+    this.operatorRemovalTransition = previous.then(() => current, () => current);
+    await previous.catch(() => undefined);
+    if (!this.isRemovalCommandCurrent(options)) {
+      releaseTransition();
+      return;
     }
-  }
-
-  /**
-   * 强制停止PTT
-   */
-  async forceStopPTT(): Promise<void> {
-    this.stopPTTPoll();
-    if (this._isPTTActive) {
-      await this.stopPTT();
-    }
-  }
-
-  /**
-   * 强制停止当前发射（公开方法）
-   */
-  async forceStopTransmission(): Promise<void> {
+    let released = false;
+    const releaseOnce = () => {
+      if (released) return;
+      released = true;
+      releaseTransition();
+    };
     try {
-      const stoppedBytes = await this.deps.audioStreamManager.stopCurrentPlayback();
-      await this.forceStopPTT();
-      this.deps.audioMixer.clear();
-      logger.info('force stop transmission', { stoppedBytes });
-    } catch (error) {
-      logger.error(`force stop transmission failed: ${error}`);
-      throw error;
-    }
-  }
-
-  /**
-   * 从当前发射中移除单个操作员的音频并重混音
-   * 如果移除后还有其他操作员，继续播放重混音后的音频
-   * 如果移除后没有操作员了，停止播放和PTT
-   */
-  async removeOperatorFromTransmission(operatorId: string): Promise<void> {
-    const { audioMixer, audioStreamManager } = this.deps;
-
-    const removed = audioMixer.clearOperatorAudio(operatorId);
-    if (!removed) {
-      logger.debug(`operator ${operatorId} not in mixer cache, skipping`);
-      return;
-    }
-
-    const remainingCount = audioMixer.getStatus().cacheCount;
-
-    if (remainingCount === 0) {
-      logger.info(`last operator ${operatorId} removed, stopping transmission`);
-      const stoppedBytes = await audioStreamManager.stopCurrentPlayback();
-      await this.forceStopPTT();
-      audioMixer.clear();
-      logger.info('transmission fully stopped after last operator removed', { stoppedBytes });
-      return;
-    }
-
-    if (audioStreamManager.isPlaying()) {
-      if (this._isRemixing) {
-        logger.debug(`operator ${operatorId} removed from cache, remix already in progress`);
-        return;
-      }
-
-      logger.info(`operator ${operatorId} removed, remixing with ${remainingCount} remaining`);
-      this._isRemixing = true;
-      try {
-        const elapsedTimeMs = await audioStreamManager.stopCurrentPlayback();
-        audioMixer.markPlaybackStop();
-
-        const remixedAudio = await audioMixer.remixAfterUpdate(elapsedTimeMs);
-        if (remixedAudio) {
-          const txId = this.nextTxId('digital-remix-remove');
-          this.deps.engineEmitter.emit('pttStatusChanged', {
-            isTransmitting: true,
-            operatorIds: remixedAudio.operatorIds,
-          });
-          this.deps.operatorManager.updateActiveTransmissionOperators(remixedAudio.operatorIds);
-          audioMixer.markPlaybackStart();
-          await audioStreamManager.playAudio(remixedAudio.audioData, remixedAudio.sampleRate, {
-            playbackKind: 'digital',
-            diagnosticContext: { txId, operatorIds: remixedAudio.operatorIds, reason: 'operator-removed-remix' },
-          });
-          this.startPTTPoll();
-        } else {
-          logger.info('remix returned null after operator removal, stopping PTT');
-          await this.forceStopPTT();
-        }
-      } catch (error) {
-        logger.error(`remix after operator removal failed: ${error}`);
-      } finally {
-        this._isRemixing = false;
-      }
-    } else {
-      logger.debug(`operator ${operatorId} removed from cache, not currently playing`);
-    }
-  }
-
-  // ─── 内部方法 ────────────────────────────────────
-
-  private nextTxId(reason: string): string {
-    this.txSequence += 1;
-    return `${reason}-${Date.now()}-${this.txSequence}`;
-  }
-
-  private async startPTT(operatorIds: string[], txId?: string): Promise<void> {
-    if (this._isPTTActive) {
-      logger.info('PTT already active, skipping start request', { txId, operatorIds });
-      return;
-    }
-
-    if (this.deps.radioManager.isConnected()) {
-      try {
-        const pttStartTime = Date.now();
-        logger.info('PTT start requested', {
-          txId,
-          operatorIds,
-          requestedAt: new Date(pttStartTime).toISOString(),
-        });
-        await this.deps.radioManager.setPTT(true);
-        const durationMs = Date.now() - pttStartTime;
-
-        this._isPTTActive = true;
-
-        this.deps.spectrumScheduler.setPTTActive(true);
-        this.deps.radioManager.setPTTActive(true);
-
-        this.deps.engineEmitter.emit('pttStatusChanged', {
-          isTransmitting: true,
-          operatorIds
-        });
-
-        this.deps.operatorManager.updateActiveTransmissionOperators(operatorIds);
-
-        logger.info('PTT started', { txId, operatorIds, durationMs });
-      } catch (error) {
-        logger.error(`PTT start failed: ${error}`, { txId, operatorIds });
-        throw error;
-      }
-    } else {
-      logger.warn('radio not connected, skipping PTT start', { txId, operatorIds });
-    }
-  }
-
-  private async stopPTT(): Promise<void> {
-    if (!this._isPTTActive) {
-      logger.debug('PTT already stopped, skipping');
-      // 兜底清除可能残留的虚拟频率平移（如 startPTT 失败导致 PTT 未真正激活的场景）
-      await this.deps.radioManager.clearTxDialOffset();
-      return;
-    }
-
-    try {
-      if (this.deps.radioManager.isConnected()) {
-        try {
-          await this.deps.radioManager.setPTT(false);
-          this._isPTTActive = false;
-
-          this.deps.spectrumScheduler.setPTTActive(false);
-          this.deps.radioManager.setPTTActive(false);
-
-          this.deps.engineEmitter.emit('pttStatusChanged', {
-            isTransmitting: false,
-            operatorIds: []
-          });
-
-          this.deps.operatorManager.updateActiveTransmissionOperators([]);
-
-          logger.debug('PTT stopped');
-        } catch (error) {
-          logger.error(`PTT stop failed: ${error}`);
-          this._isPTTActive = false;
-          this.deps.spectrumScheduler.setPTTActive(false);
-          this.deps.radioManager.setPTTActive(false);
-          this.deps.operatorManager.updateActiveTransmissionOperators([]);
-        }
-      } else {
-        this._isPTTActive = false;
-        this.deps.spectrumScheduler.setPTTActive(false);
-        this.deps.radioManager.setPTTActive(false);
-        this.deps.operatorManager.updateActiveTransmissionOperators([]);
-        logger.debug('radio not connected, PTT state set to stopped');
-      }
+      await this.performOperatorRemoval(operatorId, releaseOnce, options);
     } finally {
-      // 虚拟频率：PTT 关闭后恢复接收 dial（在 PTT 真正关闭之后执行，避免发射期间提前回频）
-      await this.deps.radioManager.clearTxDialOffset();
+      releaseOnce();
     }
   }
 
-  /**
-   * 启动 PTT 状态轮询（替代 setTimeout 预测计时）。
-   * 轮询检测音频是否仍在播放/remix，停止后等待 hold 时间再关闭 PTT。
-   */
-  private startPTTPoll(): void {
-    if (this.pttPollInterval) return;
-    this.pttAudioStoppedAt = null;
-    this.pttPollInterval = setInterval(() => this.pollPTTState(), TransmissionPipeline.PTT_POLL_INTERVAL_MS);
-  }
-
-  private stopPTTPoll(): void {
-    if (this.pttPollInterval) {
-      clearInterval(this.pttPollInterval);
-      this.pttPollInterval = null;
-    }
-    this.pttAudioStoppedAt = null;
-  }
-
-  private pollPTTState(): void {
-    if (!this._isPTTActive) {
-      this.stopPTTPoll();
+  private async performOperatorRemoval(
+    operatorId: string,
+    onTransitionCommitted: () => void,
+    command: {
+      signal?: AbortSignal;
+      commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken;
+    },
+  ): Promise<void> {
+    if (!this.isRemovalCommandCurrent(command)) return;
+    const physical = this.deps.physicalTxCoordinator.getSnapshot();
+    if (physical.source !== 'digital'
+      || !physical.frameId
+      || !physical.leaseId
+      || !physical.operatorIds.includes(operatorId)) {
+      const outcome = this.deps.operatorManager.requestStrategyStop(
+        operatorId,
+        'operator removed from transmission',
+      );
+      logger.info('operator transmission stop requested', { operatorId, outcome });
       return;
     }
 
-    const isPlaying = this.deps.audioStreamManager.isPlaying();
-    const isRemixing = this._isRemixing;
-
-    if (isPlaying || isRemixing) {
-      this.pttAudioStoppedAt = null;
-    } else if (!this.pttAudioStoppedAt) {
-      this.pttAudioStoppedAt = Date.now();
-      logger.debug('PTT poll: audio stopped, starting hold countdown');
-    } else {
-      const holdElapsed = Date.now() - this.pttAudioStoppedAt;
-      if (holdElapsed >= TransmissionPipeline.PTT_HOLD_AFTER_AUDIO_MS) {
-        logger.debug(`PTT poll: hold expired (${holdElapsed}ms), stopping PTT`);
-        this.stopPTT();
-        this.stopPTTPoll();
+    const removal = this.deps.digitalFrameCoordinator.prepareParticipantRemoval(
+      physical.frameId,
+      operatorId,
+      'operator explicitly removed from active transmission',
+    );
+    if (!this.isRemovalCommandCurrent(command)) {
+      if (removal.frame) {
+        this.deps.digitalFrameCoordinator.cancelFrame(
+          removal.frame.frameId,
+          'participant removal superseded before physical handover',
+        );
       }
+      return;
     }
+    if (removal.action === 'stop-physical') {
+      await this.deps.physicalTxCoordinator.forceInterruptLease(
+        physical.leaseId,
+        'last operator explicitly removed from transmission',
+      );
+      logger.info('last digital frame participant removed; physical PTT stopped', {
+        operatorId,
+        frameId: physical.frameId,
+      });
+      return;
+    }
+    if (removal.action !== 'replace-current' || !removal.frame || !removal.replacedFrame) {
+      logger.info('operator removal did not replace active audio', {
+        operatorId,
+        frameId: physical.frameId,
+        outcome: removal.action,
+        reason: removal.reason,
+      });
+      return;
+    }
+
+    const replacementSnapshot = this.deps.audioMixer.cloneFrameTracks(
+      {
+        frameId: removal.replacedFrame.frameId,
+        frameRevision: removal.replacedFrame.revision,
+      },
+      {
+        frameId: removal.frame.frameId,
+        frameRevision: removal.frame.revision,
+        slotId: removal.frame.slotId,
+      },
+      removal.remainingOperatorIds,
+    );
+    const expected = [...removal.remainingOperatorIds].sort();
+    const actual = replacementSnapshot
+      ? Array.from(replacementSnapshot.tracks.keys()).sort()
+      : [];
+    if (actual.length !== expected.length
+      || actual.some((id, index) => id !== expected[index])) {
+      const reason = 'retained operator audio is unavailable for active-frame removal';
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(removal.frame.frameId, reason);
+      logger.warn(reason, {
+        operatorId,
+        frameId: physical.frameId,
+        expected,
+        actual,
+      });
+      return;
+    }
+
+    const offsetMs = this.deps.digitalFrameCoordinator.getPlaybackOffsetMs(
+      removal.frame.frameId,
+      this.deps.clockSource.now(),
+    );
+    const remixed = replacementSnapshot
+      ? await this.deps.audioMixer.mixFrame(replacementSnapshot, offsetMs)
+      : null;
+    if (!this.isRemovalCommandCurrent(command)) {
+      this.deps.digitalFrameCoordinator.cancelFrame(
+        removal.frame.frameId,
+        'participant removal superseded after remix',
+      );
+      return;
+    }
+    if (!remixed) {
+      const reason = 'no retained operator waveform remains after participant removal';
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(removal.frame.frameId, reason);
+      logger.info(reason, { operatorId, frameId: physical.frameId });
+      return;
+    }
+    await this.handleMixedAudioReady(remixed, onTransitionCommitted);
   }
 
-  private shouldReleasePTTImmediatelyAfterAudio(): boolean {
-    return this.deps.radioManager.getConfig().type === 'icom-wlan' || this.deps.radioManager.getConfig().type === 'tci';
+  private isRemovalCommandCurrent(command: {
+    signal?: AbortSignal;
+    commandToken?: import('../transmission/OperatorIntentCoordinator.js').OperatorCommandToken;
+  }): boolean {
+    return !command.signal?.aborted
+      && (!command.commandToken || this.deps.intentCoordinator.isCurrent(command.commandToken));
+  }
+
+  private handleEncodeError(error: Error, request: EncodeRequest): void {
+    logger.error('frame encode failed', {
+      frameId: request.frameId,
+      operatorId: request.operatorId,
+      error: error.message,
+    });
+    if (!request.frameId || request.frameRevision === undefined || request.decisionEpoch === undefined) return;
+    const failedFrame = this.deps.digitalFrameCoordinator.failEncodeResult({
+      frameId: request.frameId,
+      operatorId: request.operatorId,
+      decisionEpoch: request.decisionEpoch,
+      revision: request.frameRevision,
+    }, 'encode failed');
+    if (!failedFrame) return;
+    this.emitFrameTerminal(failedFrame.frameId, failedFrame.participantOperatorIds, {
+      physicalConfirmed: false,
+      terminalReason: 'encode failed',
+      success: false,
+      error: error.message,
+    });
   }
 
   private async handleEncodeComplete(result: {
@@ -381,236 +345,592 @@ export class TransmissionPipeline {
     audioData: Float32Array;
     sampleRate: number;
     duration: number;
-    request?: { timeSinceSlotStartMs?: number; requestId?: string; txDialShiftHz?: number };
+    request?: EncodeRequest;
   }): Promise<void> {
-    try {
-      const request = result.request;
-      const requestId = request?.requestId;
-      const timeSinceSlotStartMs = request?.timeSinceSlotStartMs || 0;
-      const mode = this.deps.getCurrentMode();
+    const request = result.request;
+    if (!request?.frameId || request.frameRevision === undefined || request.decisionEpoch === undefined) {
+      logger.warn('discarding encode callback without frame identity', { operatorId: result.operatorId });
+      return;
+    }
 
-      logger.debug('encode complete', {
-        operatorId: result.operatorId,
-        duration: result.duration,
-        requestId: requestId || 'N/A'
+    const accepted = this.deps.digitalFrameCoordinator.acceptEncodeResult({
+      frameId: request.frameId,
+      operatorId: result.operatorId,
+      decisionEpoch: request.decisionEpoch,
+      revision: request.frameRevision,
+    });
+    if (!accepted) return;
+
+    this.currentSlotCompletedEncodes += 1;
+    this.deps.transmissionTracker.updatePhase(result.operatorId, TransmissionPhase.MIXING, {});
+    this.deps.transmissionTracker.updatePhase(result.operatorId, TransmissionPhase.READY, {
+      audioData: result.audioData,
+      sampleRate: result.sampleRate,
+      duration: result.duration,
+    });
+
+    const mode = this.deps.getCurrentMode();
+    const now = this.deps.clockSource.now();
+    const currentSlotStartMs = Math.floor(now / mode.slotMs) * mode.slotMs;
+    const slotStartMs = request.slotStartMs ?? currentSlotStartMs;
+    this.deps.audioMixer.addOperatorAudio(
+      result.operatorId,
+      result.audioData,
+      result.sampleRate,
+      slotStartMs,
+      request.requestId,
+      request.txDialShiftHz ?? 0,
+      {
+        frameId: request.frameId,
+        frameRevision: request.frameRevision,
+        slotId: `slot-${slotStartMs}`,
+      },
+    );
+    this.deps.transmissionTracker.recordAudioAddedToMixer(result.operatorId);
+
+    const frame = this.deps.digitalFrameCoordinator.getFrame(request.frameId);
+    if (frame?.phase !== 'ready') return;
+
+    const playbackOffsetMs = this.deps.digitalFrameCoordinator.getPlaybackOffsetMs(
+      request.frameId,
+      now,
+    );
+
+    if (this.deps.digitalFrameCoordinator.getPreparationAction(request.frameId) === 'restart-current') {
+      const replacement = await this.deps.audioMixer.mixFrameById(
+        request.frameId,
+        request.frameRevision,
+        playbackOffsetMs,
+      );
+      if (replacement) await this.handleMixedAudioReady(replacement);
+      return;
+    }
+
+    const transmitStartMs = Math.max(0, (mode.transmitTiming || 0) - this.deps.getCompensationMs());
+    const targetPlaybackTime = currentSlotStartMs + transmitStartMs;
+    if (now >= targetPlaybackTime) {
+      const mixedAudio = await this.deps.audioMixer.mixFrameById(
+        request.frameId,
+        request.frameRevision,
+        playbackOffsetMs,
+      );
+      if (mixedAudio) await this.handleMixedAudioReady(mixedAudio);
+    } else {
+      this.deps.audioMixer.scheduleFrameMixing(
+        { frameId: request.frameId, revision: request.frameRevision },
+        targetPlaybackTime,
+        targetPlaybackTime,
+      );
+    }
+  }
+
+  private async handleMixedAudioReady(
+    mixedAudio: MixedAudio,
+    onReplacementStarted?: () => void,
+  ): Promise<void> {
+    if (!mixedAudio.frameId) {
+      logger.warn('discarding mixed audio without frame identity');
+      return;
+    }
+
+    const readyFrame = this.deps.digitalFrameCoordinator.getFrame(mixedAudio.frameId);
+    if (readyFrame?.phase !== 'ready') return;
+    const expectedOperators = [...readyFrame.participantOperatorIds].sort();
+    const mixedOperators = [...mixedAudio.operatorIds].sort();
+    if (expectedOperators.length !== mixedOperators.length
+      || expectedOperators.some((operatorId, index) => operatorId !== mixedOperators[index])) {
+      this.failCommittedFrame(readyFrame.frameId, mixedAudio, 'mixed frame participants are incomplete');
+      return;
+    }
+    if (!this.deps.digitalFrameCoordinator.hasCompleteFrameBudget(
+      readyFrame.frameId,
+      this.deps.clockSource.now(),
+      mixedAudio.duration * 1_000,
+    )) {
+      const reason = 'complete frame no longer fits current slot after encode/mix';
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(readyFrame.frameId, reason);
+      logger.info('Deferring ready digital frame before physical commit', {
+        frameId: readyFrame.frameId,
+        operatorIds: mixedAudio.operatorIds,
+        reason,
       });
+      return;
+    }
+    const action = this.deps.digitalFrameCoordinator.getPreparationAction(readyFrame.frameId);
+    const physicalBefore = this.deps.physicalTxCoordinator.getSnapshot();
+    const replacedFrameId = this.deps.digitalFrameCoordinator.getReplacedFrameId(readyFrame.frameId);
+    if (physicalBefore.phase !== 'idle'
+      && (action !== 'restart-current'
+        || physicalBefore.source !== 'digital'
+        || physicalBefore.frameId !== replacedFrameId)) {
+      const reason = `physical transmitter busy (${physicalBefore.phase})`;
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(readyFrame.frameId, reason);
+      logger.info('Deferring digital frame until the physical transmitter is idle', {
+        frameId: readyFrame.frameId,
+        physicalLeaseId: physicalBefore.leaseId,
+        physicalPhase: physicalBefore.phase,
+      });
+      return;
+    }
 
-      // 检查是否为该操作员的最新编码请求（丢弃过期编码，防止双重编码竞态）
-      const latestRequestId = this.deps.operatorManager.getLatestEncodeRequestId(result.operatorId);
-      if (requestId && latestRequestId && requestId !== latestRequestId) {
-        logger.debug(`Skipping stale encode result: operatorId=${result.operatorId}, requestId=${requestId}, latest=${latestRequestId}`);
+    const prepared = this.deps.digitalFrameCoordinator.prepareFrameForHandover(
+      mixedAudio.frameId,
+      mixedAudio.operatorIds,
+    );
+    if (!prepared || prepared.phase !== 'prepared') return;
+
+    let audioForTransmission = mixedAudio;
+    let activeLeaseId: string | null = null;
+
+    try {
+      if (physicalBefore.phase !== 'idle') {
+        await this.replaceCommittedFrameAudio(
+          prepared.frameId,
+          prepared.participantOperatorIds,
+          physicalBefore,
+          audioForTransmission,
+          onReplacementStarted,
+        );
         return;
       }
 
-      this.currentSlotCompletedEncodes++;
-      logger.debug(`slot ${this.currentSlotId}: completed ${this.currentSlotCompletedEncodes}/${this.currentSlotExpectedEncodes}`);
+      const committed = this.deps.digitalFrameCoordinator.commitFrame(prepared.frameId);
+      if (!committed || committed.phase !== 'committed') return;
 
-      this.deps.transmissionTracker.updatePhase(result.operatorId, TransmissionPhase.MIXING, {});
-      this.deps.transmissionTracker.updatePhase(result.operatorId, TransmissionPhase.READY, {
-        audioData: result.audioData,
-        sampleRate: result.sampleRate,
-        duration: result.duration
-      });
-
-      const now = this.deps.clockSource.now();
-      const currentSlotStartMs = Math.floor(now / mode.slotMs) * mode.slotMs;
-      const currentTimeSinceSlotStartMs = now - currentSlotStartMs;
-      const transmitStartFromSlotMs = mode.transmitTiming || 0;
-      const compensationMs = this.deps.getCompensationMs();
-      const compensatedTransmitStart = Math.max(0, transmitStartFromSlotMs - compensationMs);
-
-      if (compensationMs !== 0) {
-        logger.debug(`transmit compensation applied: ${compensationMs}ms, target=${compensatedTransmitStart}ms (original=${transmitStartFromSlotMs}ms)`);
-      }
-
-      this.deps.audioMixer.addOperatorAudio(
-        result.operatorId,
-        result.audioData,
-        result.sampleRate,
-        currentSlotStartMs,
-        requestId,
-        result.request?.txDialShiftHz ?? 0
-      );
-
-      this.deps.transmissionTracker.recordAudioAddedToMixer(result.operatorId);
-
-      const isMidSlotSwitch = timeSinceSlotStartMs > 0 &&
-                              Math.abs(timeSinceSlotStartMs - compensatedTransmitStart) > 100;
-
-      const isCurrentlyPlaying = this.isDigitalPlaybackInProgress();
-
-      if (isCurrentlyPlaying) {
-        logger.debug('playback in progress, triggering remix');
-        this._isRemixing = true;
-        try {
-          const elapsedTimeMs = await this.deps.audioStreamManager.stopCurrentPlayback();
-          this.deps.audioMixer.markPlaybackStop();
-
-          const remixedAudio = await this.deps.audioMixer.remixAfterUpdate(elapsedTimeMs);
-          if (remixedAudio) {
-            const txId = this.nextTxId('digital-remix-update');
-            logger.debug('remix complete', {
-              operators: remixedAudio.operatorIds,
-              duration: remixedAudio.duration
-            });
-            // 重混音后操作者列表可能变化，更新前端
-            this.deps.engineEmitter.emit('pttStatusChanged', {
-              isTransmitting: true,
-              operatorIds: remixedAudio.operatorIds
-            });
-            this.deps.operatorManager.updateActiveTransmissionOperators(remixedAudio.operatorIds);
-            this.deps.audioMixer.markPlaybackStart();
-            await this.deps.audioStreamManager.playAudio(remixedAudio.audioData, remixedAudio.sampleRate, {
-              playbackKind: 'digital',
-              diagnosticContext: { txId, operatorIds: remixedAudio.operatorIds, reason: 'encode-update-remix' },
-            });
-            this.startPTTPoll();
-          }
-        } catch (remixError) {
-          logger.error(`remix failed: ${remixError}`);
-        } finally {
-          this._isRemixing = false;
-        }
-      } else if (isMidSlotSwitch && currentTimeSinceSlotStartMs >= compensatedTransmitStart) {
-        logger.debug('mid-slot switch, mixing immediately');
-        const elapsedFromTransmitStart = currentTimeSinceSlotStartMs - compensatedTransmitStart;
-        const mixedAudio = await this.deps.audioMixer.mixAllOperatorAudios(elapsedFromTransmitStart);
-        if (mixedAudio) {
-          this.deps.audioMixer.emit('mixedAudioReady', mixedAudio);
-        }
-      } else {
-        const targetPlaybackTime = currentSlotStartMs + compensatedTransmitStart;
-        this.deps.audioMixer.scheduleMixing(targetPlaybackTime);
-      }
-    } catch (error) {
-      logger.error(`encode result handling failed: ${error}`);
-      this.deps.engineEmitter.emit('transmissionComplete', {
-        operatorId: result.operatorId,
-        success: false,
-        error: error instanceof Error ? error.message : String(error)
-      });
-    }
-  }
-
-  private async handleMixedAudioReady(mixedAudio: MixedAudio): Promise<void> {
-    try {
-      const txId = this.nextTxId('digital-tx');
-      logger.debug('mixed audio ready', {
-        txId,
-        operators: mixedAudio.operatorIds,
-        duration: mixedAudio.duration,
-        sampleRate: mixedAudio.sampleRate
-      });
-
-      for (const operatorId of mixedAudio.operatorIds) {
-        this.deps.transmissionTracker.recordMixedAudioReady(operatorId);
-      }
-
-      await this.deps.onBeforeStartPTT?.();
-
-      // 虚拟频率：在 PTT 之前临时把电台 dial 反向平移到本次发射的 shift。
-      // shift 与音频同源（随 mixedAudio 负载流转），保证施加到 dial 的平移量恒等于编码所用 shift。
-      // 音频已按 (origFreq - shift) 编码，dial +shift 后打到空中的绝对 RF 不变。
-      // clearTxDialOffset() 在 stopPTT 的 finally 中兜底恢复。
-      const txDialShiftHz = mixedAudio.txDialShiftHz ?? 0;
-      if (txDialShiftHz !== 0) {
-        await this.deps.radioManager.setTxDialOffset(txDialShiftHz);
-      }
-
-      const startSequenceAt = Date.now();
-      logger.info('starting PTT and audio playback in parallel', {
-        txId,
-        operatorIds: mixedAudio.operatorIds,
-        mixedSamples: mixedAudio.audioData.length,
-        sampleRate: mixedAudio.sampleRate,
-        durationMs: Math.round(mixedAudio.duration * 1000),
-        startSequenceAt: new Date(startSequenceAt).toISOString(),
-      });
-
-      for (const operatorId of mixedAudio.operatorIds) {
-        this.deps.transmissionTracker.recordAudioPlaybackStart(operatorId);
-      }
-
-      const pttPromise = this.startPTT(mixedAudio.operatorIds, txId).then(() => {
-        for (const operatorId of mixedAudio.operatorIds) {
-          this.deps.transmissionTracker.recordPTTStart(operatorId);
-        }
-      });
-
-      this.deps.audioMixer.markPlaybackStart();
-      logger.info('audio playback request issued', {
-        txId,
-        operatorIds: mixedAudio.operatorIds,
-        msAfterStartSequence: Date.now() - startSequenceAt,
-      });
-      const audioPromise = this.deps.audioStreamManager.playAudio(mixedAudio.audioData, mixedAudio.sampleRate, {
+      activeLeaseId = await this.deps.physicalTxCoordinator.acquireLease({
+        source: 'digital',
+        frameId: committed.frameId,
+        frameRevision: committed.revision,
+        operatorIds: audioForTransmission.operatorIds,
+        reason: action === 'restart-current' ? 'late correction restart' : 'digital slot frame',
+        beforeStart: this.deps.onBeforeStartPTT,
         playbackKind: 'digital',
-        diagnosticContext: { txId, operatorIds: mixedAudio.operatorIds },
-      });
-
-      logger.debug('PTT timing', {
-        txId,
-        audioMs: Math.round(mixedAudio.duration * 1000),
-        pollIntervalMs: TransmissionPipeline.PTT_POLL_INTERVAL_MS,
-        holdMs: TransmissionPipeline.PTT_HOLD_AFTER_AUDIO_MS
-      });
-
-      this.startPTTPoll();
-      await Promise.all([pttPromise, audioPromise]);
-
-      this.deps.audioMixer.markPlaybackStop();
-      logger.info('audio playback and PTT start promises completed', {
-        txId,
-        operatorIds: mixedAudio.operatorIds,
-        elapsedMs: Date.now() - startSequenceAt,
-        pttActive: this._isPTTActive,
-      });
-
-      if (this.shouldReleasePTTImmediatelyAfterAudio()) {
-        logger.debug('Radio audio output complete, stopping PTT without post-audio hold');
-        this.stopPTTPoll();
-        await this.stopPTT();
-      }
-
-      for (const operatorId of mixedAudio.operatorIds) {
-        this.deps.engineEmitter.emit('transmissionComplete', {
-          operatorId,
-          success: true,
-          duration: mixedAudio.duration,
-          mixedWith: mixedAudio.operatorIds.filter(id => id !== operatorId)
-        });
-      }
-    } catch (error) {
-      const isInterrupted = error instanceof Error && error.message === 'playback interrupted';
-      if (isInterrupted) {
-        // 播放被 stopCurrentPlayback 正常中断（中途内容切换），不关闭 PTT
-        // 停止旧轮询，后续 remix 路径会启动新轮询
-        logger.debug('audio playback interrupted by content switch (expected)');
-        this.stopPTTPoll();
-        this.deps.audioMixer.markPlaybackStop();
-      } else {
-        // 真正的播放错误，需要清理 PTT
-        logger.error(`mixed audio playback failed: ${error}`);
-        this.stopPTTPoll();
-        this.deps.audioMixer.markPlaybackStop();
-        await this.stopPTT();
-        for (const operatorId of mixedAudio.operatorIds) {
-          this.deps.engineEmitter.emit('transmissionComplete', {
-            operatorId,
-            success: false,
-            error: error instanceof Error ? error.message : String(error)
+        afterAudioDrain: async () => {
+          const refreshedOffsetMs = this.deps.digitalFrameCoordinator.getPlaybackOffsetMs(
+            committed.frameId,
+            this.deps.clockSource.now(),
+          );
+          const refreshedMix = await this.deps.audioMixer.mixFrameById(
+            committed.frameId,
+            committed.revision,
+            refreshedOffsetMs,
+          );
+          const refreshedAudio = refreshedMix
+            ? this.alignMixedAudioToCurrentCursor(committed.frameId, refreshedMix, refreshedOffsetMs)
+            : null;
+          if (!refreshedAudio) {
+            throw new CompleteFrameBudgetExceededError(
+              'digital waveform fully consumed while previous audio drained',
+            );
+          }
+          const refreshedOperators = [...refreshedAudio.operatorIds].sort();
+          const committedOperators = [...committed.participantOperatorIds].sort();
+          if (refreshedOperators.length !== committedOperators.length
+            || refreshedOperators.some((operatorId, index) => operatorId !== committedOperators[index])) {
+            throw new Error('digital frame participants changed while previous audio drained');
+          }
+          audioForTransmission = refreshedAudio;
+          logger.info('Refreshed digital frame after previous audio drained', {
+            frameId: prepared.frameId,
+            playbackOffsetMs: refreshedOffsetMs,
+            durationMs: Math.round(refreshedAudio.duration * 1_000),
           });
-        }
+        },
+        deferActiveUntilAudio: true,
+        validateStart: () => {
+          if (!this.deps.digitalFrameCoordinator.hasCompleteFrameBudget(
+            committed.frameId,
+            this.deps.clockSource.now(),
+            audioForTransmission.duration * 1_000,
+          )) {
+            throw new CompleteFrameBudgetExceededError();
+          }
+        },
+        txDialShiftHz: audioForTransmission.txDialShiftHz,
+      });
+
+      const physicalAfterAcquire = this.deps.physicalTxCoordinator.getSnapshot();
+      if (physicalAfterAcquire.leaseId === activeLeaseId
+        && physicalAfterAcquire.frameId
+        && physicalAfterAcquire.frameId !== committed.frameId) {
+        const supersededResult = await this.deps.physicalTxCoordinator.playAudioOnLease(activeLeaseId, {
+          audioData: audioForTransmission.audioData,
+          sampleRate: audioForTransmission.sampleRate,
+          playbackKind: 'digital',
+          frameId: committed.frameId,
+          operatorIds: audioForTransmission.operatorIds,
+          reason: 'superseded before initial audio start',
+        });
+        activeLeaseId = null;
+        this.finishDigitalFramePlayback(committed.frameId, audioForTransmission, supersededResult);
+        return;
       }
+
+      // PTT acknowledgement can itself be delayed. Freeze the actual playback
+      // bytes only after it succeeds, so a mid-slot start or correction begins
+      // at the waveform position visible to the operator at that moment.
+      const finalPlaybackOffsetMs = this.deps.digitalFrameCoordinator.getPlaybackOffsetMs(
+        committed.frameId,
+        this.deps.clockSource.now(),
+      );
+      const mixedAtPtt = await this.deps.audioMixer.mixFrameById(
+        committed.frameId,
+        committed.revision,
+        finalPlaybackOffsetMs,
+      );
+      const finalAudio = mixedAtPtt
+        ? this.alignMixedAudioToCurrentCursor(committed.frameId, mixedAtPtt, finalPlaybackOffsetMs)
+        : null;
+      if (!finalAudio) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          activeLeaseId,
+          'digital waveform fully consumed before audio start',
+        );
+        activeLeaseId = null;
+        const reason = 'digital waveform fully consumed before audio start';
+        this.deps.operatorManager.deferPreparedFrameToNextSlot(committed.frameId, reason);
+        return;
+      }
+      const finalOperators = [...finalAudio.operatorIds].sort();
+      const committedOperators = [...committed.participantOperatorIds].sort();
+      if (finalOperators.length !== committedOperators.length
+        || finalOperators.some((operatorId, index) => operatorId !== committedOperators[index])) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          activeLeaseId,
+          'digital frame participants changed before audio start',
+        );
+        activeLeaseId = null;
+        this.failCommittedFrame(committed.frameId, finalAudio, 'digital frame participants changed before audio start');
+        return;
+      }
+      audioForTransmission = finalAudio;
+      if (!this.deps.digitalFrameCoordinator.hasCompleteFrameBudget(
+        committed.frameId,
+        this.deps.clockSource.now(),
+        audioForTransmission.duration * 1_000,
+      )) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          activeLeaseId,
+          'complete frame no longer fits after PTT acknowledgement',
+        );
+        activeLeaseId = null;
+        const reason = 'complete frame no longer fits after PTT acknowledgement';
+        this.deps.operatorManager.deferPreparedFrameToNextSlot(committed.frameId, reason);
+        return;
+      }
+
+      const result = await this.deps.physicalTxCoordinator.playAudioOnLease(activeLeaseId, {
+        audioData: audioForTransmission.audioData,
+        sampleRate: audioForTransmission.sampleRate,
+        playbackKind: 'digital',
+        frameId: committed.frameId,
+        operatorIds: audioForTransmission.operatorIds,
+        reason: 'digital slot frame audio',
+        playbackOptions: {
+          diagnosticContext: {
+            frameId: prepared.frameId,
+            operatorIds: audioForTransmission.operatorIds,
+          },
+        },
+        tailHoldMs: DIGITAL_TAIL_HOLD_MS,
+      });
+      activeLeaseId = null;
+      this.finishDigitalFramePlayback(committed.frameId, audioForTransmission, result);
+    } catch (error) {
+      if (activeLeaseId) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          activeLeaseId,
+          'digital frame start failed',
+        ).catch((cleanupError) => {
+          logger.warn('Failed to clean up digital physical lease after start failure', {
+            frameId: prepared.frameId,
+            cleanupError: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        });
+        activeLeaseId = null;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      if (error instanceof CompleteFrameBudgetExceededError) {
+        this.deps.operatorManager.deferPreparedFrameToNextSlot(prepared.frameId, message);
+        logger.info('Deferring committed frame after pre-PTT work exceeded slot budget', {
+          frameId: prepared.frameId,
+        });
+        return;
+      }
+      if (error instanceof PhysicalTxPreparationError) {
+        this.deps.operatorManager.deferPreparedFrameToNextSlot(prepared.frameId, message);
+        logger.warn('Deferring committed frame because physical audio output is not ready', {
+          frameId: prepared.frameId,
+          error: message,
+        });
+        return;
+      }
+      if (error instanceof PhysicalTxBusyError) {
+        this.deps.operatorManager.deferPreparedFrameToNextSlot(prepared.frameId, message);
+        logger.info('Deferring committed frame while physical cleanup is fenced', {
+          frameId: prepared.frameId,
+        });
+        return;
+      }
+      logger.error('physical digital transmission failed', {
+        frameId: prepared.frameId,
+        error: message,
+      });
+      this.failCommittedFrame(prepared.frameId, audioForTransmission, message);
     }
   }
 
-  private isDigitalPlaybackInProgress(): boolean {
-    if (!this.deps.audioStreamManager.isPlaying()) {
-      return false;
+  private async replaceCommittedFrameAudio(
+    frameId: string,
+    participantOperatorIds: string[],
+    physical: PhysicalTxSnapshot,
+    initialAudio: MixedAudio,
+    onReplacementStarted?: () => void,
+  ): Promise<void> {
+    if (!physical.leaseId) {
+      this.failCommittedFrame(frameId, initialAudio, 'physical lease disappeared before audio replacement');
+      return;
     }
 
-    const kind = this.deps.audioStreamManager.getCurrentPlaybackKind();
-    return kind === null || kind === 'digital';
+    const mixStartedAtMs = this.deps.clockSource.now();
+    const replacementOffsetMs = this.deps.digitalFrameCoordinator.getPlaybackOffsetMs(
+      frameId,
+      mixStartedAtMs,
+    );
+    const frame = this.deps.digitalFrameCoordinator.getFrame(frameId);
+    const remixed = frame
+      ? await this.deps.audioMixer.mixFrameById(frame.frameId, frame.revision, replacementOffsetMs)
+      : null;
+    const waveformStartMs = this.deps.clockSource.now();
+    const aligned = remixed
+      ? this.alignMixedAudioToCurrentCursor(frameId, remixed, replacementOffsetMs, waveformStartMs)
+      : null;
+    if (!aligned) {
+      const reason = 'replacement audio was fully consumed before handover preparation';
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(frameId, reason);
+      return;
+    }
+    const actualOperators = [...aligned.operatorIds].sort();
+    const expectedOperators = [...participantOperatorIds].sort();
+    if (actualOperators.length !== expectedOperators.length
+      || actualOperators.some((operatorId, index) => operatorId !== expectedOperators[index])) {
+      this.failCommittedFrame(frameId, aligned, 'replacement mix lost one or more frame participants');
+      return;
+    }
+    if (!this.deps.digitalFrameCoordinator.hasCompleteFrameBudget(
+      frameId,
+      waveformStartMs,
+      aligned.duration * 1_000,
+    )) {
+      const reason = 'complete replacement no longer fits before handover preparation';
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(frameId, reason);
+      return;
+    }
+
+    const currentPhysical = this.deps.physicalTxCoordinator.getSnapshot();
+    if (currentPhysical.leaseId !== physical.leaseId
+      || currentPhysical.epoch !== physical.epoch
+      || currentPhysical.playbackGeneration !== physical.playbackGeneration) {
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(
+        frameId,
+        'physical replacement precondition changed before handover',
+      );
+      return;
+    }
+
+    const audioForTransmission = aligned;
+    const result = await this.deps.physicalTxCoordinator.replaceAudioOnLease(physical.leaseId, {
+      frameId,
+      frameRevision: this.deps.digitalFrameCoordinator.getFrame(frameId)?.revision,
+      operatorIds: participantOperatorIds,
+      reason: 'digital frame audio replacement',
+      playbackKind: 'digital',
+      audioData: aligned.audioData,
+      sampleRate: aligned.sampleRate,
+      playbackOptions: {
+        diagnosticContext: { frameId, operatorIds: aligned.operatorIds },
+      },
+      tailHoldMs: DIGITAL_TAIL_HOLD_MS,
+      waveformStartMs,
+      slotEndMs: this.deps.digitalFrameCoordinator.getSlotEndMs(frameId),
+      expectedLeaseEpoch: physical.epoch,
+      expectedPlaybackGeneration: physical.playbackGeneration,
+      expectedFrameId: physical.frameId,
+      onHandoverCommitted: () => {
+        const committed = this.deps.digitalFrameCoordinator.commitFrame(frameId);
+        if (committed?.phase !== 'committed') {
+          return {
+            status: 'superseded' as const,
+            reason: 'digital replacement candidate is no longer prepared',
+          };
+        }
+        return { status: 'committed' as const };
+      },
+      onPlaybackStarted: onReplacementStarted,
+    });
+
+    if (!result.success && result.leaseContinues) {
+      this.deps.operatorManager.deferPreparedFrameToNextSlot(frameId, result.reason);
+    }
+    this.finishDigitalFramePlayback(frameId, audioForTransmission, result);
+  }
+
+  private finishDigitalFramePlayback(
+    frameId: string,
+    audio: MixedAudio,
+    result: {
+      success: boolean;
+      reason: string;
+      error?: string;
+      physicalConfirmed: boolean;
+      leaseContinues?: boolean;
+    },
+  ): void {
+    if (result.leaseContinues) {
+      logger.info('Digital frame audio was superseded within the active PTT lease', {
+        frameId,
+        reason: result.reason,
+        physicalConfirmed: result.physicalConfirmed,
+      });
+    } else if (!result.success) {
+      logger.warn('Physical digital playback completed unsuccessfully', {
+        frameId,
+        reason: result.reason,
+        error: result.error,
+        physicalConfirmed: result.physicalConfirmed,
+        leaseContinues: result.leaseContinues,
+      });
+    }
+    this.deps.digitalFrameCoordinator.completeFrame(frameId, result.reason);
+    if (result.success) {
+      for (const operatorId of audio.operatorIds) {
+        const text = this.deps.digitalFrameCoordinator.getIntentText(frameId, operatorId);
+        if (text) this.deps.operatorManager.notifyPhysicalTransmissionComplete(operatorId, text);
+      }
+    }
+    this.emitFrameTerminal(frameId, audio.operatorIds, {
+      physicalConfirmed: result.physicalConfirmed,
+      terminalReason: result.reason,
+      success: result.success,
+      duration: audio.duration,
+      error: result.error,
+    });
+  }
+
+  private alignMixedAudioToCurrentCursor(
+    frameId: string,
+    mixedAudio: MixedAudio,
+    mixedAtOffsetMs: number,
+    currentTimeMs = this.deps.clockSource.now(),
+  ): MixedAudio | null {
+    const currentOffsetMs = this.deps.digitalFrameCoordinator.getPlaybackOffsetMs(
+      frameId,
+      currentTimeMs,
+    );
+    const additionalOffsetMs = Math.max(0, currentOffsetMs - mixedAtOffsetMs);
+    if (additionalOffsetMs === 0) return mixedAudio;
+
+    const skipSamples = Math.floor((additionalOffsetMs / 1_000) * mixedAudio.sampleRate);
+    if (skipSamples >= mixedAudio.audioData.length) return null;
+    const audioData = mixedAudio.audioData.subarray(skipSamples);
+    return {
+      ...mixedAudio,
+      audioData,
+      duration: audioData.length / mixedAudio.sampleRate,
+    };
+  }
+
+  private failCommittedFrame(frameId: string, mixedAudio: MixedAudio, reason: string): void {
+    const frame = this.deps.digitalFrameCoordinator.completeFrame(frameId, reason);
+    this.emitFrameTerminal(frameId, frame?.participantOperatorIds ?? mixedAudio.operatorIds, {
+      physicalConfirmed: false,
+      terminalReason: reason,
+      success: false,
+      error: reason,
+    });
+  }
+
+  private emitFrameTerminal(
+    frameId: string,
+    operatorIds: string[],
+    result: {
+      physicalConfirmed: boolean;
+      terminalReason: string;
+      success: boolean;
+      duration?: number;
+      error?: string;
+    },
+  ): void {
+    let emitted = this.terminalOperatorsByFrame.get(frameId);
+    if (!emitted) {
+      emitted = new Set();
+      this.terminalOperatorsByFrame.set(frameId, emitted);
+    }
+    for (const operatorId of operatorIds) {
+      if (emitted.has(operatorId)) continue;
+      emitted.add(operatorId);
+      this.deps.engineEmitter.emit('transmissionComplete', {
+        operatorId,
+        frameId,
+        ...result,
+        mixedWith: operatorIds.filter((id) => id !== operatorId),
+      });
+    }
+    if (this.terminalOperatorsByFrame.size > 256) {
+      const oldestFrameId = this.terminalOperatorsByFrame.keys().next().value as string | undefined;
+      if (oldestFrameId) this.terminalOperatorsByFrame.delete(oldestFrameId);
+    }
+  }
+
+  private handlePhysicalPhaseChanged(snapshot: PhysicalTxSnapshot): void {
+    if (snapshot.source && snapshot.source !== 'digital') return;
+    if (snapshot.frameId) {
+      if (snapshot.phase === 'active') {
+        const frame = this.deps.digitalFrameCoordinator.markOnAir(snapshot.frameId);
+        if (frame) this.emitPhysicalTransmissionFacts(frame, snapshot);
+      } else if (snapshot.phase === 'draining') {
+        this.deps.digitalFrameCoordinator.markDraining(snapshot.frameId);
+      }
+    }
+
+  }
+
+  private emitPhysicalTransmissionFacts(
+    frame: import('../transmission/TransmissionIntent.js').FrameLease,
+    snapshot: PhysicalTxSnapshot,
+  ): void {
+    const slotStartMs = Number(frame.slotId.replace(/^slot-/, ''));
+    if (!Number.isFinite(slotStartMs)) {
+      logger.warn('Cannot publish physical transmission fact for an unparseable slot id', {
+        frameId: frame.frameId,
+        slotId: frame.slotId,
+      });
+      return;
+    }
+    for (const operatorId of frame.participantOperatorIds) {
+      const key = `${frame.frameId}:${snapshot.playbackGeneration}:${operatorId}`;
+      if (this.onAirTransmissionKeys.has(key)) continue;
+      const message = this.deps.digitalFrameCoordinator.getIntentText(frame.frameId, operatorId);
+      const context = this.deps.operatorManager.getTransmissionFactContext(operatorId);
+      if (!message || !context) continue;
+      this.onAirTransmissionKeys.add(key);
+      this.deps.engineEmitter.emit('transmissionLog', {
+        operatorId,
+        frameId: frame.frameId,
+        revision: frame.revision,
+        playbackGeneration: snapshot.playbackGeneration,
+        phase: 'on_air',
+        physicalConfirmed: true,
+        time: new Date(slotStartMs).toISOString().slice(11, 19).replace(/:/g, ''),
+        message,
+        frequency: context.frequency,
+        slotStartMs,
+        replaceExisting: this.deps.digitalFrameCoordinator.getReplacedFrameId(frame.frameId) !== undefined,
+        frequencyContext: context.frequencyContext,
+      });
+    }
+    if (this.onAirTransmissionKeys.size > 1_024) {
+      this.onAirTransmissionKeys.clear();
+    }
   }
 }

--- a/packages/server/src/subsystems/__tests__/EngineLifecycle.test.ts
+++ b/packages/server/src/subsystems/__tests__/EngineLifecycle.test.ts
@@ -7,8 +7,14 @@ function createLifecycle(initialModeName: 'FT8' | 'VOICE' | 'CW' = 'FT8') {
   let currentModeName = initialModeName;
   const resourceManager = {
     stopAll: vi.fn(async () => undefined),
+    startAll: vi.fn(async () => undefined),
     clear: vi.fn(),
     register: vi.fn(),
+  };
+  const radioManager = {
+    isConnected: vi.fn(() => true),
+    applyConfig: vi.fn(async () => undefined),
+    disconnect: vi.fn(async () => undefined),
   };
   const voiceSessionManager = {
     start: vi.fn(),
@@ -17,6 +23,9 @@ function createLifecycle(initialModeName: 'FT8' | 'VOICE' | 'CW' = 'FT8') {
   const decodeQueue = {
     start: vi.fn(async () => undefined),
     stop: vi.fn(async () => undefined),
+  };
+  const physicalTxCoordinator = {
+    forceInterrupt: vi.fn(async () => null),
   };
 
   const audioSidecar = {
@@ -45,15 +54,20 @@ function createLifecycle(initialModeName: 'FT8' | 'VOICE' | 'CW' = 'FT8') {
     slotClock: {} as any,
     slotScheduler: {} as any,
     audioStreamManager: {} as any,
-    radioManager: {} as any,
+    radioManager: radioManager as any,
     spectrumScheduler: {} as any,
     decodeQueue: decodeQueue as any,
     operatorManager: {} as any,
+    physicalTxCoordinator: physicalTxCoordinator as any,
     audioMixer: {} as any,
     clockSource: {} as any,
     subsystems: {
-      transmissionPipeline: { forceStopPTT: vi.fn() } as any,
-      clockCoordinator: {} as any,
+      transmissionPipeline: {
+        forceStopPTT: vi.fn(),
+        setup: vi.fn(),
+        teardown: vi.fn(),
+      } as any,
+      clockCoordinator: { setup: vi.fn(), teardown: vi.fn() } as any,
     },
     getCurrentMode: () => ({ name: currentModeName } as any),
     getVoiceSessionManager: () => voiceSessionManager as any,
@@ -68,6 +82,8 @@ function createLifecycle(initialModeName: 'FT8' | 'VOICE' | 'CW' = 'FT8') {
     lifecycle,
     resourceManager,
     decodeQueue,
+    radioManager,
+    physicalTxCoordinator,
     setModeName: (modeName: 'FT8' | 'VOICE' | 'CW') => {
       currentModeName = modeName;
     },
@@ -87,7 +103,6 @@ describe('EngineLifecycle', () => {
     expect(resourceManager.stopAll).toHaveBeenCalledTimes(1);
     expect(resourceManager.clear).toHaveBeenCalledTimes(1);
     expect(resourceManager.register.mock.calls.map(([config]) => config.name)).toEqual([
-      'radio',
       'icomWlanAudioAdapter',
       'tciAudioAdapter',
       'openwebrxAudioAdapter',
@@ -108,13 +123,12 @@ describe('EngineLifecycle', () => {
 
     expect(resourceManager.stopAll).toHaveBeenCalledTimes(2);
     expect(resourceManager.clear).toHaveBeenCalledTimes(2);
-    const firstPlanCount = 9; // radio + icom + tci + openwebrx + decodeWorkerPool + clock + slotScheduler + spectrumScheduler + operatorManager
+    const firstPlanCount = 8;
     const secondPlanNames = resourceManager.register.mock.calls
       .slice(firstPlanCount)
       .map(([config]) => config.name);
 
     expect(secondPlanNames).toEqual([
-      'radio',
       'icomWlanAudioAdapter',
       'tciAudioAdapter',
       'openwebrxAudioAdapter',
@@ -157,7 +171,6 @@ describe('EngineLifecycle', () => {
     const names = resourceManager.register.mock.calls.map(([config]) => config.name);
     expect(names).not.toContain('decodeWorkerPool');
     expect(names).toEqual([
-      'radio',
       'icomWlanAudioAdapter',
       'tciAudioAdapter',
       'openwebrxAudioAdapter',
@@ -173,7 +186,6 @@ describe('EngineLifecycle', () => {
 
     const names = resourceManager.register.mock.calls.map(([config]) => config.name);
     expect(names).toEqual([
-      'radio',
       'icomWlanAudioAdapter',
       'tciAudioAdapter',
       'openwebrxAudioAdapter',
@@ -184,5 +196,24 @@ describe('EngineLifecycle', () => {
     expect(names).not.toContain('clock');
     expect(names).not.toContain('slotScheduler');
     expect(names).not.toContain('operatorManager');
+  });
+
+  it('stops only mode runtime resources without disconnecting the CAT session', async () => {
+    const { lifecycle, radioManager, resourceManager } = createLifecycle('FT8');
+    (lifecycle as any).requestedStopScope = 'mode-runtime';
+
+    await (lifecycle as any).doStop();
+
+    expect(resourceManager.stopAll).toHaveBeenCalledOnce();
+    expect(radioManager.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the CAT session during a full engine stop', async () => {
+    const { lifecycle, radioManager } = createLifecycle('FT8');
+    (lifecycle as any).requestedStopScope = 'full';
+
+    await (lifecycle as any).doStop();
+
+    expect(radioManager.disconnect).toHaveBeenCalledWith('Engine stopped');
   });
 });

--- a/packages/server/src/subsystems/__tests__/RadioBridge.test.ts
+++ b/packages/server/src/subsystems/__tests__/RadioBridge.test.ts
@@ -72,6 +72,77 @@ describe('RadioBridge', () => {
     }));
   });
 
+  it('retries an unknown physical TX release after the radio session reconnects', async () => {
+    const radioManager = createRadioManagerStub();
+    const retryUnknownStop = vi.fn().mockResolvedValue({
+      success: true,
+      reason: 'radio reconnected',
+      physicalConfirmed: false,
+    });
+
+    const bridge = new RadioBridge({
+      engineEmitter: new EventEmitter() as any,
+      radioManager: radioManager as any,
+      frequencyManager: { findMatchingPreset: vi.fn() } as any,
+      slotPackManager: { clearInMemory: vi.fn() } as any,
+      operatorManager: { stopAllOperators: vi.fn() } as any,
+      getTransmissionPipeline: () => ({ getIsPTTActive: vi.fn().mockReturnValue(true) } as any),
+      physicalTxCoordinator: { retryUnknownStop } as any,
+      getEngineLifecycle: () => ({
+        getIsRunning: vi.fn().mockReturnValue(false),
+        getEngineState: vi.fn().mockReturnValue('idle'),
+        start: vi.fn(),
+        sendRadioDisconnected: vi.fn(),
+      } as any),
+      getEngineMode: () => 'digital',
+    });
+
+    bridge.setupListeners();
+    radioManager.emit('connected');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(retryUnknownStop).toHaveBeenCalledWith('radio reconnected');
+  });
+
+  it('does not restore automation while the physical TX lease remains unknown', async () => {
+    const radioManager = createRadioManagerStub();
+    const start = vi.fn();
+    const retryUnknownStop = vi.fn().mockResolvedValue({
+      success: false,
+      reason: 'radio reconnected: PTT release unconfirmed',
+      physicalConfirmed: true,
+    });
+
+    const bridge = new RadioBridge({
+      engineEmitter: new EventEmitter() as any,
+      radioManager: radioManager as any,
+      frequencyManager: { findMatchingPreset: vi.fn() } as any,
+      slotPackManager: { clearInMemory: vi.fn() } as any,
+      operatorManager: { stopAllOperators: vi.fn() } as any,
+      getTransmissionPipeline: () => ({ getIsPTTActive: vi.fn().mockReturnValue(true) } as any),
+      physicalTxCoordinator: {
+        retryUnknownStop,
+        getSnapshot: vi.fn().mockReturnValue({ phase: 'unknown' }),
+      } as any,
+      getEngineLifecycle: () => ({
+        getIsRunning: vi.fn().mockReturnValue(false),
+        getEngineState: vi.fn().mockReturnValue('idle'),
+        start,
+        sendRadioDisconnected: vi.fn(),
+      } as any),
+      getEngineMode: () => 'digital',
+    });
+
+    bridge.wasRunningBeforeDisconnect = true;
+    bridge.setupListeners();
+    radioManager.emit('connected');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(retryUnknownStop).toHaveBeenCalledWith('radio reconnected');
+    expect(start).not.toHaveBeenCalled();
+    expect(bridge.wasRunningBeforeDisconnect).toBe(true);
+  });
+
   it('does not retry engine restore on audio failure (handled by AudioSidecarController)', async () => {
     vi.useFakeTimers();
 

--- a/packages/server/src/subsystems/__tests__/TransmissionPipeline.test.ts
+++ b/packages/server/src/subsystems/__tests__/TransmissionPipeline.test.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'eventemitter3';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { DigitalFrameCoordinator } from '../../transmission/DigitalFrameCoordinator.js';
+import { OperatorIntentCoordinator } from '../../transmission/OperatorIntentCoordinator.js';
+import { PhysicalTxCoordinator } from '../../transmission/PhysicalTxCoordinator.js';
 import { TransmissionPipeline } from '../TransmissionPipeline.js';
 
-function createDeferred<T = void>() {
+function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
+  let reject!: (error?: unknown) => void;
   const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
@@ -12,196 +15,707 @@ function createDeferred<T = void>() {
   return { promise, resolve, reject };
 }
 
-function createPipeline(configType: 'icom-wlan' | 'hamlib') {
+function createHarness(options: {
+  pttStart?: Promise<void>;
+  nowMs?: number;
+  slotEndMs?: number;
+  expectedDurationMs?: number;
+  beforeStart?: Promise<void>;
+  dialOffset?: Promise<void>;
+  stopPlayback?: Promise<void>;
+  playbackStartMs?: number;
+  operatorIds?: string[];
+} = {}) {
   const engineEmitter = new EventEmitter();
-  const audioDone = createDeferred<void>();
-  const setPTT = vi.fn<[boolean], Promise<void>>(async () => undefined);
-
+  const encodeQueue = new EventEmitter();
+  const mixerEmitter = new EventEmitter();
+  const audioDones = [deferred<void>()];
+  let playbackIndex = 0;
+  let playing = false;
+  let nowMs = options.nowMs ?? 1_000;
+  const setPTT = vi.fn(async (active: boolean) => {
+    if (active && options.pttStart) await options.pttStart;
+  });
+  const playAudio = vi.fn((_audioData: Float32Array, _sampleRate: number, options?: { onPlaybackStarted?: () => void }) => {
+    const audioDone = audioDones[playbackIndex] ?? (audioDones[playbackIndex] = deferred<void>());
+    playbackIndex += 1;
+    playing = true;
+    options?.onPlaybackStarted?.();
+    return audioDone.promise.finally(() => {
+      playing = false;
+    });
+  });
+  const stopCurrentPlayback = vi.fn(async () => {
+    playing = false;
+    audioDones[Math.max(0, playbackIndex - 1)].reject(new Error('playback interrupted'));
+    if (options.stopPlayback) await options.stopPlayback;
+    return 0;
+  });
+  const prepareAudioPlayback = vi.fn(async () => false);
+  let frameSequence = 0;
+  const digitalFrameCoordinator = new DigitalFrameCoordinator({ idFactory: () => `frame-${++frameSequence}` });
+  const frameMixes = new Map<string, Record<string, any>>();
+  const physicalTxCoordinator = new PhysicalTxCoordinator({
+    isRadioConnected: () => true,
+    setPTT,
+    playAudio,
+    stopCurrentPlayback,
+    prepareAudioPlayback,
+    isAudioPlaying: () => playing,
+    setTxDialOffset: vi.fn(async () => {
+      if (options.dialOffset) await options.dialOffset;
+    }),
+    clearTxDialOffset: vi.fn(async () => undefined),
+    now: () => nowMs,
+    sleep: vi.fn(async () => undefined),
+  }, { idFactory: () => 'lease-1' });
+  const audioMixer = Object.assign(mixerEmitter, {
+    addOperatorAudio: vi.fn(),
+    mixFrameById: vi.fn(async (frameId: string, revision: number) => frameMixes.get(`${frameId}:${revision}`) ?? null),
+    mixFrame: vi.fn(async (snapshot: { frameId: string; revision: number }) => frameMixes.get(`${snapshot.frameId}:${snapshot.revision}`) ?? null),
+    scheduleFrameMixing: vi.fn(),
+    retainFrame: vi.fn(),
+    releaseFrame: vi.fn(),
+    clearSlotCache: vi.fn(),
+    cloneFrameTracks: vi.fn((
+      _source: unknown,
+      target: { frameId: string; frameRevision: number; slotId: string },
+      retainedOperatorIds: string[],
+    ) => ({
+      frameId: target.frameId,
+      revision: target.frameRevision,
+      slotId: target.slotId,
+      txDialShiftHz: 0,
+      tracks: new Map(retainedOperatorIds.map((operatorId) => [operatorId, { operatorId }])),
+    })),
+    clearFrame: vi.fn(),
+    clear: vi.fn(),
+  });
+  const operatorManager = {
+    getPendingTransmissionsCount: vi.fn(() => 0),
+    processPendingTransmissions: vi.fn(),
+    updateActiveTransmissionOperators: vi.fn(),
+    notifyPhysicalTransmissionComplete: vi.fn(),
+    requestStrategyStop: vi.fn(() => 'not-found'),
+    getOperatorById: vi.fn(() => ({ stop: vi.fn() })),
+    getTransmissionFactContext: vi.fn(() => ({
+      frequency: 7_074_000,
+      frequencyContext: { mode: 'FT8', radioMode: 'USB', frequency: 7_074_000 },
+    })),
+    releaseTargetReservation: vi.fn(),
+    deferPreparedFrameToNextSlot: vi.fn((frameId: string, reason: string) => {
+      return digitalFrameCoordinator.deferFrame(frameId, reason)?.phase === 'cancelled';
+    }),
+  };
+  const intentCoordinator = new OperatorIntentCoordinator();
+  const transmissionTracker = {
+    updatePhase: vi.fn(),
+    recordAudioAddedToMixer: vi.fn(),
+  };
   const deps = {
     engineEmitter,
-    audioMixer: {
-      markPlaybackStart: vi.fn(),
-      markPlaybackStop: vi.fn(),
-      clearSlotCache: vi.fn(),
-    },
-    audioStreamManager: {
-      playAudio: vi.fn(() => audioDone.promise),
-      isPlaying: vi.fn(() => false),
-      getCurrentPlaybackKind: vi.fn<[], 'digital' | 'voice-keyer' | 'tune-tone' | null>(() => null),
-      stopCurrentPlayback: vi.fn(),
-    },
-    radioManager: {
-      isConnected: vi.fn(() => true),
-      setPTT,
-      setPTTActive: vi.fn(),
-      getConfig: vi.fn(() => ({ type: configType })),
-      setTxDialOffset: vi.fn(async () => true),
-      clearTxDialOffset: vi.fn(async () => undefined),
-    },
-    spectrumScheduler: {
-      setPTTActive: vi.fn(),
-    },
-    transmissionTracker: {
-      recordMixedAudioReady: vi.fn(),
-      recordPTTStart: vi.fn(),
-      recordAudioPlaybackStart: vi.fn(),
-    },
-    encodeQueue: new EventEmitter(),
-    operatorManager: {
-      updateActiveTransmissionOperators: vi.fn(),
-    },
-    clockSource: {
-      now: vi.fn(() => Date.now()),
-    },
-    getCurrentMode: vi.fn(() => ({ name: 'FT8', slotMs: 15000, transmitTiming: 500 })),
-    getCompensationMs: vi.fn(() => 0),
-    onBeforeStartPTT: vi.fn().mockResolvedValue(undefined),
+    audioMixer,
+    audioStreamManager: { playAudio, stopCurrentPlayback },
+    spectrumScheduler: { setPTTActive: vi.fn() },
+    transmissionTracker,
+    encodeQueue,
+    operatorManager,
+    digitalFrameCoordinator,
+    physicalTxCoordinator,
+    intentCoordinator,
+    clockSource: { now: () => nowMs },
+    getCurrentMode: () => ({ name: 'FT8', slotMs: 15_000, transmitTiming: 500 }),
+    getCompensationMs: () => 0,
+    onBeforeStartPTT: vi.fn(async () => {
+      if (options.beforeStart) await options.beforeStart;
+    }),
   };
-
   const pipeline = new TransmissionPipeline(deps as never);
-  const mixedAudio = {
-    operatorIds: ['operator-a'],
-    audioData: new Float32Array(12000),
-    sampleRate: 12000,
-    duration: 1,
-    txDialShiftHz: 0,
-  };
+  pipeline.setup();
 
-  return { pipeline, deps, audioDone, mixedAudio };
+  const operatorIds = options.operatorIds ?? ['operator-a'];
+  const prepared = digitalFrameCoordinator.prepareFrame({
+    slotId: 'slot-0',
+    intents: operatorIds.map((operatorId) => ({
+      operatorId,
+      source: 'standard-qso' as const,
+      reason: 'test',
+      text: operatorId === 'operator-a' ? 'A B 73' : `${operatorId} TEST 73`,
+      decisionEpoch: 1,
+    })),
+    slotEndMs: options.slotEndMs,
+    expectedDurationMs: options.expectedDurationMs,
+    playbackStartMs: options.playbackStartMs,
+  });
+  digitalFrameCoordinator.beginEncoding(prepared.frame!.frameId);
+  prepared.intents.forEach((intent) => {
+    digitalFrameCoordinator.acceptEncodeResult({
+      frameId: prepared.frame!.frameId,
+      operatorId: intent.operatorId!,
+      decisionEpoch: intent.decisionEpoch,
+      revision: prepared.frame!.revision,
+    });
+  });
+  const mixedAudio = {
+    operatorIds,
+    audioData: new Float32Array(12_000),
+    sampleRate: 12_000,
+    duration: 1,
+    txDialShiftHz: 681,
+    frameId: prepared.frame!.frameId,
+    frameRevision: prepared.frame!.revision,
+    slotId: 'slot-0',
+  };
+  frameMixes.set(`${prepared.frame!.frameId}:${prepared.frame!.revision}`, mixedAudio);
+
+  return {
+    pipeline,
+    deps,
+    setPTT,
+    playAudio,
+    prepareAudioPlayback,
+    audioDone: audioDones[0],
+    getAudioDone: (index: number) => audioDones[index] ?? (audioDones[index] = deferred<void>()),
+    mixedAudio,
+    prepared,
+    setFrameMix: (frameId: string, revision: number, audio: Record<string, any>) => {
+      frameMixes.set(`${frameId}:${revision}`, audio);
+    },
+    setNow: (value: number) => { nowMs = value; },
+  };
 }
 
-describe('TransmissionPipeline PTT release timing', () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+describe('TransmissionPipeline lifecycle integration', () => {
+  it('reports on-air only after PTT confirmation and audio start, then completes once', async () => {
+    const harness = createHarness();
+    const physicalPhases: Array<{ phase: string; pttConfirmed: boolean }> = [];
+    const completions: Array<Record<string, unknown>> = [];
+    const transmissionLogs: Array<Record<string, unknown>> = [];
+    harness.deps.physicalTxCoordinator.on('phaseChanged', (event) => physicalPhases.push(event));
+    harness.deps.engineEmitter.on('transmissionComplete', (event) => completions.push(event));
+    harness.deps.engineEmitter.on('transmissionLog', (event) => transmissionLogs.push(event));
 
-  it('stops ICOM WLAN PTT as soon as the paced audio write resolves', async () => {
-    vi.useFakeTimers();
-    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('icom-wlan');
+    const handling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    expect(physicalPhases.some((event) => event.phase === 'active' && event.pttConfirmed === true)).toBe(true);
+    expect(transmissionLogs).toEqual([expect.objectContaining({
+      frameId: 'frame-1',
+      revision: 1,
+      playbackGeneration: 1,
+      phase: 'on_air',
+      physicalConfirmed: true,
+      operatorId: 'operator-a',
+      message: 'A B 73',
+    })]);
 
-    const handling = (pipeline as unknown as {
-      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
-    }).handleMixedAudioReady(mixedAudio);
-
-    await vi.waitFor(() => {
-      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
-    });
-
-    audioDone.resolve();
+    harness.audioDone.resolve();
     await handling;
 
-    expect(deps.radioManager.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(completions).toHaveLength(1);
+    expect(completions[0]).toMatchObject({
+      frameId: 'frame-1',
+      success: true,
+      physicalConfirmed: true,
+    });
+    expect(harness.deps.operatorManager.notifyPhysicalTransmissionComplete)
+      .toHaveBeenCalledWith('operator-a', 'A B 73');
   });
 
-  it('keeps Hamlib on the existing post-audio hold path', async () => {
-    vi.useFakeTimers();
-    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('hamlib');
+  it('does not display on-air or start audio while PTT is still starting', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({ pttStart: pttStart.promise });
+    const physicalPhases: Array<{ phase: string; pttConfirmed: boolean }> = [];
+    harness.deps.physicalTxCoordinator.on('phaseChanged', (event) => physicalPhases.push(event));
 
-    const handling = (pipeline as unknown as {
-      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
-    }).handleMixedAudioReady(mixedAudio);
+    const handling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    expect(harness.playAudio).not.toHaveBeenCalled();
+    expect(physicalPhases.some((event) => event.phase === 'active' && event.pttConfirmed === true)).toBe(false);
 
+    pttStart.resolve();
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    harness.audioDone.resolve();
+    await handling;
+  });
+
+  it('keeps the predecessor lease when a starting replacement is superseded before handover', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({
+      pttStart: pttStart.promise,
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 1_000,
+      playbackStartMs: 500,
+    });
+    const initialHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+
+    const frame2 = harness.deps.digitalFrameCoordinator.prepareFrame({
+      slotId: 'slot-0',
+      intents: [{
+        operatorId: 'operator-a',
+        source: 'operator-edit',
+        reason: 'first edit while PTT starts',
+        text: 'A B RR73',
+        decisionEpoch: 2,
+      }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 1_000,
+      playbackStartMs: 500,
+    });
+    expect(frame2.action).toBe('restart-current');
+    harness.deps.digitalFrameCoordinator.beginEncoding(frame2.frame!.frameId);
+    harness.deps.digitalFrameCoordinator.acceptEncodeResult({
+      frameId: frame2.frame!.frameId,
+      operatorId: 'operator-a',
+      decisionEpoch: frame2.intents[0].decisionEpoch,
+      revision: frame2.frame!.revision,
+    });
+    const frame2Audio = {
+      ...harness.mixedAudio,
+      frameId: frame2.frame!.frameId,
+      frameRevision: frame2.frame!.revision,
+    };
+    harness.setFrameMix(frame2.frame!.frameId, frame2.frame!.revision, frame2Audio);
+    const frame2Handling = (harness.pipeline as any).handleMixedAudioReady(frame2Audio);
     await vi.waitFor(() => {
-      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
+      expect(harness.deps.digitalFrameCoordinator.getFrame(frame2.frame!.frameId)?.phase).toBe('prepared');
     });
 
-    audioDone.resolve();
+    const frame3 = harness.deps.digitalFrameCoordinator.prepareFrame({
+      slotId: 'slot-0',
+      intents: [{
+        operatorId: 'operator-a',
+        source: 'operator-edit',
+        reason: 'newer edit supersedes pending handover',
+        text: 'A B 73',
+        decisionEpoch: 3,
+      }],
+      nowMs: 1_100,
+      slotEndMs: 15_000,
+      expectedDurationMs: 1_000,
+      playbackStartMs: 500,
+    });
+    expect(frame3.frame).not.toBeNull();
+    expect(harness.deps.digitalFrameCoordinator.getFrame(frame2.frame!.frameId)).toMatchObject({
+      phase: 'cancelled',
+      superseded: true,
+    });
+
+    pttStart.resolve();
+    await frame2Handling;
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.deps.audioStreamManager.stopCurrentPlayback).not.toHaveBeenCalled();
+    expect(harness.deps.physicalTxCoordinator.getSnapshot()).toMatchObject({
+      frameId: harness.prepared.frame!.frameId,
+      phase: 'active',
+      pttConfirmed: true,
+    });
+
+    harness.audioDone.resolve();
+    await initialHandling;
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('preserves an active lease at the next slot boundary', async () => {
+    const harness = createHarness();
+    const handling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    await harness.pipeline.onSlotStart();
+    expect(harness.deps.audioMixer.clearSlotCache).not.toHaveBeenCalled();
+    expect(harness.deps.audioStreamManager.stopCurrentPlayback).not.toHaveBeenCalled();
+
+    harness.audioDone.resolve();
+    await handling;
+  });
+
+  it('defers a fully encoded frame when delay consumes the physical slot budget', async () => {
+    const harness = createHarness({
+      nowMs: 14_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 1_000,
+    });
+
+    await (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+
+    expect(harness.deps.operatorManager.deferPreparedFrameToNextSlot)
+      .toHaveBeenCalledWith('frame-1', expect.stringContaining('no longer fits'));
+    expect(harness.deps.audioMixer.clearFrame).toHaveBeenCalledWith('frame-1', 1);
+    expect(harness.setPTT).not.toHaveBeenCalled();
+    expect(harness.playAudio).not.toHaveBeenCalled();
+  });
+
+  it('defers a ready frame instead of dropping it while another physical lease is active', async () => {
+    const harness = createHarness();
+    const leaseId = await harness.deps.physicalTxCoordinator.acquireLease({
+      source: 'voice',
+      reason: 'voice drain overlaps next digital slot',
+    });
+
+    await (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+
+    expect(harness.deps.operatorManager.deferPreparedFrameToNextSlot)
+      .toHaveBeenCalledWith('frame-1', expect.stringContaining('physical transmitter busy'));
+    expect(harness.deps.digitalFrameCoordinator.getFrame('frame-1')).toMatchObject({ phase: 'cancelled' });
+    expect(harness.playAudio).not.toHaveBeenCalled();
+    await harness.deps.physicalTxCoordinator.releaseLease(leaseId, 'voice complete');
+  });
+
+  it('rechecks the complete-frame budget after delayed PTT acknowledgement', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({
+      pttStart: pttStart.promise,
+      nowMs: 1_000,
+      slotEndMs: 3_000,
+      expectedDurationMs: 1_000,
+    });
+
+    const handling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    harness.setNow(2_000);
+    pttStart.resolve();
     await handling;
 
-    expect(deps.radioManager.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
-
-    await pipeline.forceStopPTT();
+    expect(harness.deps.operatorManager.deferPreparedFrameToNextSlot)
+      .toHaveBeenCalledWith('frame-1', expect.stringContaining('before PTT start'));
+    expect(harness.setPTT).toHaveBeenCalledWith(false);
+    expect(harness.playAudio).not.toHaveBeenCalled();
   });
 
-  it('does not stop tune tone playback at slot boundaries', async () => {
-    const { pipeline, deps } = createPipeline('hamlib');
-    deps.audioStreamManager.isPlaying.mockReturnValue(true);
-    deps.audioStreamManager.getCurrentPlaybackKind.mockReturnValue('tune-tone');
-
-    await pipeline.onSlotStart();
-
-    expect(deps.audioStreamManager.stopCurrentPlayback).not.toHaveBeenCalled();
-    expect(deps.audioMixer.clearSlotCache).toHaveBeenCalled();
-  });
-
-  it('stops tune tone before starting digital PTT and playback', async () => {
-    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('hamlib');
-    const cleanup = createDeferred<void>();
-    deps.onBeforeStartPTT.mockReturnValueOnce(cleanup.promise);
-
-    const handling = (pipeline as unknown as {
-      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
-    }).handleMixedAudioReady(mixedAudio);
-
-    await vi.waitFor(() => {
-      expect(deps.onBeforeStartPTT).toHaveBeenCalled();
+  it('recomputes the waveform offset after a delayed PTT acknowledgement', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({
+      pttStart: pttStart.promise,
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+      playbackStartMs: 500,
     });
-    expect(deps.radioManager.setPTT).not.toHaveBeenCalled();
-    expect(deps.audioStreamManager.playAudio).not.toHaveBeenCalled();
+    const finalAudio = {
+      ...harness.mixedAudio,
+      audioData: new Float32Array([2, 3, 4]),
+      sampleRate: 1_000,
+      duration: 10.64,
+    };
+    harness.setFrameMix('frame-1', 1, finalAudio);
 
-    cleanup.resolve();
-    await vi.waitFor(() => {
-      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
-      expect(deps.audioStreamManager.playAudio).toHaveBeenCalled();
-    });
+    const handling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    harness.setNow(2_500);
+    pttStart.resolve();
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
 
-    audioDone.resolve();
+    expect(harness.deps.audioMixer.mixFrameById).toHaveBeenCalledWith('frame-1', 1, 2_000);
+    expect(harness.playAudio).toHaveBeenCalledWith(
+      finalAudio.audioData,
+      finalAudio.sampleRate,
+      expect.any(Object),
+    );
+    harness.audioDone.resolve();
     await handling;
-    await pipeline.forceStopPTT();
-  });
-});
-
-describe('TransmissionPipeline fake frequency dial offset', () => {
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
-  it('applies the slot dial offset before PTT and restores it after stop', async () => {
-    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('hamlib');
-    // shift 随音频负载流转：在 mixedAudio 上携带，PTT 时点据此平移 dial
-    mixedAudio.txDialShiftHz = 681;
+  it('replaces an on-air correction without toggling the physical PTT lease', async () => {
+    const stopPlayback = deferred<void>();
+    const harness = createHarness({ stopPlayback: stopPlayback.promise });
+    const completions: Array<Record<string, unknown>> = [];
+    harness.deps.engineEmitter.on('transmissionComplete', (event) => completions.push(event));
+    const oldHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    const replacement = harness.deps.digitalFrameCoordinator.prepareFrame({
+      slotId: 'slot-0',
+      intents: [{
+        operatorId: 'operator-a',
+        source: 'late-decode',
+        reason: 'late RR73 correction',
+        text: 'A B RR73',
+        decisionEpoch: 2,
+      }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 1_000,
+      playbackStartMs: 500,
+    });
+    expect(replacement.action).toBe('restart-current');
+    harness.deps.digitalFrameCoordinator.beginEncoding(replacement.frame!.frameId);
+    harness.deps.digitalFrameCoordinator.acceptEncodeResult({
+      frameId: replacement.frame!.frameId,
+      operatorId: 'operator-a',
+      decisionEpoch: replacement.intents[0].decisionEpoch,
+      revision: replacement.frame!.revision,
+    });
+    const replacementAudio = {
+      ...harness.mixedAudio,
+      frameId: replacement.frame!.frameId,
+      frameRevision: replacement.frame!.revision,
+    };
+    harness.setFrameMix(replacement.frame!.frameId, replacement.frame!.revision, replacementAudio);
 
-    const handling = (pipeline as unknown as {
-      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
-    }).handleMixedAudioReady(mixedAudio);
+    const replacementHandling = (harness.pipeline as any).handleMixedAudioReady(replacementAudio);
+    await vi.waitFor(() => expect(harness.deps.audioStreamManager.stopCurrentPlayback).toHaveBeenCalled());
+    harness.setNow(1_100);
+    stopPlayback.resolve();
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+    expect(harness.prepareAudioPlayback).toHaveBeenCalledTimes(2);
+    expect(harness.deps.audioMixer.mixFrameById).toHaveBeenCalledWith('frame-2', 2, 500);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    harness.getAudioDone(1).resolve();
+    await Promise.all([oldHandling, replacementHandling]);
 
-    await vi.waitFor(() => {
-      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
+    expect(completions.filter((event) => event.frameId === 'frame-1')).toEqual([
+      expect.objectContaining({ success: false, physicalConfirmed: true }),
+    ]);
+    expect(completions.filter((event) => event.frameId === 'frame-2')).toEqual([
+      expect.objectContaining({ success: true, physicalConfirmed: true }),
+    ]);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('does not double-trim replacement audio across delayed mix and output drain stages', async () => {
+    const harness = createHarness({ nowMs: 1_000 });
+    const oldHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    const replacement = harness.deps.digitalFrameCoordinator.prepareFrame({
+      slotId: 'slot-0',
+      intents: [{
+        operatorId: 'operator-a',
+        source: 'operator-edit',
+        reason: 'frequency changed on air',
+        text: 'A B 73',
+        decisionEpoch: 2,
+      }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 3_000,
+      playbackStartMs: 500,
+    });
+    harness.deps.digitalFrameCoordinator.beginEncoding(replacement.frame!.frameId);
+    harness.deps.digitalFrameCoordinator.acceptEncodeResult({
+      frameId: replacement.frame!.frameId,
+      operatorId: 'operator-a',
+      decisionEpoch: replacement.intents[0].decisionEpoch,
+      revision: replacement.frame!.revision,
     });
 
-    // dial offset applied before PTT start, with the frozen slot shift
-    expect(deps.radioManager.setTxDialOffset).toHaveBeenCalledWith(681);
-    const offsetOrder = deps.radioManager.setTxDialOffset.mock.invocationCallOrder[0];
-    const pttOnOrder = deps.radioManager.setPTT.mock.invocationCallOrder[0];
-    expect(offsetOrder).toBeLessThan(pttOnOrder);
-
-    audioDone.resolve();
-    await handling;
-    await pipeline.forceStopPTT();
-
-    // dial restored after PTT stop
-    expect(deps.radioManager.clearTxDialOffset).toHaveBeenCalled();
-  });
-
-  it('does not touch the dial when the slot shift is zero', async () => {
-    const { pipeline, deps, audioDone, mixedAudio } = createPipeline('hamlib');
-    mixedAudio.txDialShiftHz = 0;
-
-    const handling = (pipeline as unknown as {
-      handleMixedAudioReady: (mixedAudio: unknown) => Promise<void>;
-    }).handleMixedAudioReady(mixedAudio);
-
-    await vi.waitFor(() => {
-      expect(deps.radioManager.setPTT).toHaveBeenCalledWith(true);
+    const delayedMix = deferred<Record<string, any>>();
+    const outputDrain = deferred<boolean>();
+    harness.deps.audioMixer.mixFrameById.mockReturnValueOnce(delayedMix.promise);
+    harness.prepareAudioPlayback.mockReturnValueOnce(outputDrain.promise);
+    const replacementHandling = (harness.pipeline as any).handleMixedAudioReady({
+      ...harness.mixedAudio,
+      frameId: replacement.frame!.frameId,
+      frameRevision: replacement.frame!.revision,
     });
 
-    expect(deps.radioManager.setTxDialOffset).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(harness.deps.audioMixer.mixFrameById).toHaveBeenCalledTimes(2));
+    harness.setNow(1_500);
+    delayedMix.resolve({
+      ...harness.mixedAudio,
+      frameId: replacement.frame!.frameId,
+      frameRevision: replacement.frame!.revision,
+      audioData: new Float32Array(3_000),
+      sampleRate: 1_000,
+      duration: 3,
+    });
+    await vi.waitFor(() => expect(harness.prepareAudioPlayback).toHaveBeenCalledTimes(2));
 
-    audioDone.resolve();
+    harness.setNow(1_750);
+    outputDrain.resolve(true);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+    expect(harness.playAudio.mock.calls[1]?.[0]).toHaveLength(2_250);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+
+    harness.getAudioDone(1).resolve();
+    await Promise.all([oldHandling, replacementHandling]);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('removes one mixed-frame operator by replacing audio while keeping PTT asserted', async () => {
+    const harness = createHarness({ operatorIds: ['operator-a', 'operator-b'] });
+    const initialHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    const replacementAudio = {
+      ...harness.mixedAudio,
+      frameId: 'frame-2',
+      frameRevision: 2,
+      operatorIds: ['operator-b'],
+      audioData: new Float32Array(10_000),
+      duration: 10_000 / 12_000,
+    };
+    harness.setFrameMix('frame-2', 2, replacementAudio);
+
+    const removal = harness.pipeline.removeOperatorFromTransmission('operator-a');
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.deps.physicalTxCoordinator.getSnapshot()).toMatchObject({
+      frameId: 'frame-2',
+      operatorIds: ['operator-b'],
+      phase: 'active',
+      pttConfirmed: true,
+    });
+    expect(harness.deps.audioMixer.cloneFrameTracks).toHaveBeenCalledWith(
+      { frameId: 'frame-1', frameRevision: 1 },
+      { frameId: 'frame-2', frameRevision: 2, slotId: 'slot-0' },
+      ['operator-b'],
+    );
+
+    harness.getAudioDone(1).resolve();
+    await Promise.all([initialHandling, removal]);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('releases PTT when the last active frame operator is explicitly removed', async () => {
+    const harness = createHarness();
+    const initialHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    await harness.pipeline.removeOperatorFromTransmission('operator-a');
+    await initialHandling;
+
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(harness.deps.physicalTxCoordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('stops shared PTT only after every mixed-frame operator is removed', async () => {
+    const harness = createHarness({ operatorIds: ['operator-a', 'operator-b'] });
+    const initialHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    const replacementAudio = {
+      ...harness.mixedAudio,
+      frameId: 'frame-2',
+      frameRevision: 2,
+      operatorIds: ['operator-b'],
+      audioData: new Float32Array(10_000),
+      duration: 10_000 / 12_000,
+    };
+    harness.setFrameMix('frame-2', 2, replacementAudio);
+
+    const removeA = harness.pipeline.removeOperatorFromTransmission('operator-a');
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.deps.physicalTxCoordinator.getSnapshot().operatorIds).toEqual(['operator-b']);
+
+    const removeB = harness.pipeline.removeOperatorFromTransmission('operator-b');
+    await Promise.all([initialHandling, removeA, removeB]);
+
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(harness.deps.physicalTxCoordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('hands a starting PTT lease directly to the retained operator mix', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({
+      operatorIds: ['operator-a', 'operator-b'],
+      pttStart: pttStart.promise,
+    });
+    const initialHandling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+
+    const replacementAudio = {
+      ...harness.mixedAudio,
+      frameId: 'frame-2',
+      frameRevision: 2,
+      operatorIds: ['operator-b'],
+      audioData: new Float32Array(10_000),
+      duration: 10_000 / 12_000,
+    };
+    harness.setFrameMix('frame-2', 2, replacementAudio);
+    const removal = harness.pipeline.removeOperatorFromTransmission('operator-a');
+    expect(harness.playAudio).not.toHaveBeenCalled();
+
+    pttStart.resolve();
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.deps.physicalTxCoordinator.getSnapshot()).toMatchObject({
+      frameId: 'frame-2',
+      operatorIds: ['operator-b'],
+      phase: 'active',
+    });
+
+    harness.audioDone.resolve();
+    await Promise.all([initialHandling, removal]);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('defers without asserting PTT when previous audio cannot be drained', async () => {
+    const harness = createHarness();
+    harness.prepareAudioPlayback.mockRejectedValueOnce(
+      new Error('RtAudio output drain timed out after 20ms'),
+    );
+
+    await (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+
+    expect(harness.deps.operatorManager.deferPreparedFrameToNextSlot)
+      .toHaveBeenCalledWith('frame-1', expect.stringContaining('audio output preparation failed'));
+    expect(harness.setPTT).not.toHaveBeenCalled();
+    expect(harness.playAudio).not.toHaveBeenCalled();
+  });
+
+  it('rechecks waveform position and slot budget after a delayed output drain', async () => {
+    const outputDrain = deferred<boolean>();
+    const harness = createHarness({
+      nowMs: 1_000,
+      slotEndMs: 3_000,
+      expectedDurationMs: 1_000,
+      playbackStartMs: 500,
+    });
+    harness.prepareAudioPlayback.mockReturnValueOnce(outputDrain.promise);
+
+    const handling = (harness.pipeline as any).handleMixedAudioReady(harness.mixedAudio);
+    await vi.waitFor(() => expect(harness.prepareAudioPlayback).toHaveBeenCalledOnce());
+    harness.setNow(2_500);
+    outputDrain.resolve(true);
     await handling;
-    await pipeline.forceStopPTT();
 
-    // clear is still called as an idempotent safety net
-    expect(deps.radioManager.clearTxDialOffset).toHaveBeenCalled();
+    expect(harness.deps.audioMixer.mixFrameById).toHaveBeenCalledWith('frame-1', 1, 2_000);
+    expect(harness.deps.operatorManager.deferPreparedFrameToNextSlot)
+      .toHaveBeenCalledWith('frame-1', expect.stringContaining('before PTT start'));
+    expect(harness.setPTT).not.toHaveBeenCalled();
+    expect(harness.playAudio).not.toHaveBeenCalled();
+  });
+
+  it('tombstones an old-slot encode without interrupting an active physical lease', async () => {
+    const harness = createHarness();
+    const leaseId = await harness.deps.physicalTxCoordinator.acquireLease({
+      source: 'voice',
+      reason: 'voice remains active across slot boundary',
+    });
+    const completions: Array<Record<string, unknown>> = [];
+    harness.deps.engineEmitter.on('transmissionComplete', (event) => completions.push(event));
+
+    await harness.pipeline.onSlotStart({ id: 'slot-2' });
+    expect(harness.deps.digitalFrameCoordinator.getFrame('frame-1')).toMatchObject({ phase: 'cancelled' });
+    expect(harness.deps.audioMixer.clearFrame).toHaveBeenCalledWith('frame-1', 1);
+    expect(harness.deps.audioMixer.clearSlotCache).not.toHaveBeenCalled();
+    expect(harness.setPTT).not.toHaveBeenCalledWith(false);
+
+    await (harness.pipeline as any).handleEncodeComplete({
+      operatorId: 'operator-a',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      duration: 1,
+      request: {
+        frameId: 'frame-1',
+        frameRevision: 1,
+        decisionEpoch: harness.prepared.intents[0].decisionEpoch,
+        requestId: 'late-frame-1',
+      },
+    });
+    expect(harness.deps.audioMixer.addOperatorAudio).not.toHaveBeenCalled();
+    expect(completions).toEqual([]);
+    expect(harness.deps.physicalTxCoordinator.getSnapshot()).toMatchObject({
+      leaseId,
+      phase: 'active',
+    });
+    await harness.deps.physicalTxCoordinator.releaseLease(leaseId, 'voice complete');
   });
 });

--- a/packages/server/src/transmission/DigitalFrameCoordinator.ts
+++ b/packages/server/src/transmission/DigitalFrameCoordinator.ts
@@ -1,0 +1,587 @@
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'eventemitter3';
+import type {
+  FrameLease,
+  FramePhase,
+  TransmissionIntent,
+  TransmissionIntentSource,
+} from './TransmissionIntent.js';
+
+export interface TransmissionIntentRequest {
+  operatorId: string;
+  source: TransmissionIntentSource;
+  reason: string;
+  text?: string;
+  decisionEpoch: number;
+}
+
+export interface PrepareDigitalFrameRequest {
+  slotId: string;
+  intents: TransmissionIntentRequest[];
+  participantOperatorIds?: string[];
+  nowMs?: number;
+  slotEndMs?: number;
+  expectedDurationMs?: number;
+  playbackStartMs?: number;
+}
+
+export type FramePreparationAction = 'encode' | 'restart-current' | 'defer-next-slot';
+
+export interface PreparedDigitalFrame {
+  action: FramePreparationAction;
+  frame: FrameLease | null;
+  intents: TransmissionIntent[];
+  reason?: string;
+}
+
+export interface PreparedParticipantRemoval {
+  action: 'replace-current' | 'stop-physical' | 'deferred' | 'not-found';
+  replacedFrame: FrameLease | null;
+  frame: FrameLease | null;
+  remainingOperatorIds: string[];
+  reason: string;
+}
+
+export interface EncodeResultIdentity {
+  frameId: string;
+  operatorId: string;
+  decisionEpoch: number;
+  revision: number;
+}
+
+export interface DigitalFrameCoordinatorEvents {
+  frameChanged: (frame: FrameLease, reason: string) => void;
+  staleCallbackDiscarded: (data: EncodeResultIdentity & { reason: string }) => void;
+  terminal: (frame: FrameLease, reason: string) => void;
+}
+
+interface MutableFrame extends FrameLease {
+  intents: Map<string, TransmissionIntent>;
+  expectedEncodeOperators: Set<string>;
+  completedEncodeOperators: Set<string>;
+  preparationAction: FramePreparationAction;
+  slotEndMs?: number;
+  expectedDurationMs?: number;
+  playbackStartMs?: number;
+  replacesFrameId?: string;
+}
+
+const CANDIDATE_PHASES = new Set<FramePhase>(['requested', 'encoding', 'ready', 'prepared']);
+const LIVE_PHASES = new Set<FramePhase>(['committed', 'on_air', 'draining']);
+
+export class DigitalFrameCoordinator extends EventEmitter<DigitalFrameCoordinatorEvents> {
+  private readonly frames = new Map<string, MutableFrame>();
+  private readonly physicalFrameBySlot = new Map<string, string>();
+  private readonly candidateFrameBySlot = new Map<string, string>();
+  private readonly slotRevisions = new Map<string, number>();
+  private readonly now: () => number;
+  private readonly idFactory: () => string;
+  private readonly physicalStartBudgetMs: number;
+  private readonly tailHoldMs: number;
+  private readonly maxRetainedFrames: number;
+  private readonly terminalFrameIds: string[] = [];
+  private staleCallbackDiscardCount = 0;
+
+  constructor(options: {
+    now?: () => number;
+    idFactory?: () => string;
+    physicalStartBudgetMs?: number;
+    tailHoldMs?: number;
+    maxRetainedFrames?: number;
+  } = {}) {
+    super();
+    this.now = options.now ?? Date.now;
+    this.idFactory = options.idFactory ?? randomUUID;
+    this.physicalStartBudgetMs = options.physicalStartBudgetMs ?? 300;
+    this.tailHoldMs = options.tailHoldMs ?? 500;
+    this.maxRetainedFrames = options.maxRetainedFrames ?? 256;
+  }
+
+  prepareFrame(request: PrepareDigitalFrameRequest): PreparedDigitalFrame {
+    if (request.intents.length === 0) {
+      return { action: 'defer-next-slot', frame: null, intents: [], reason: 'no intents' };
+    }
+    const physical = this.getMutablePhysicalFrame(request.slotId);
+    const candidate = this.getMutableCandidateFrame(request.slotId);
+    const predecessor = physical ?? (candidate && LIVE_PHASES.has(candidate.phase) ? candidate : null);
+    const nowMs = request.nowMs ?? this.now();
+    const action = this.resolvePreparationAction(predecessor, candidate, request, nowMs);
+    const intents = request.intents.map((intent) =>
+      this.materializeIntent(intent, request.slotId, predecessor?.frameId),
+    );
+    if (action === 'defer-next-slot') {
+      return {
+        action,
+        frame: predecessor ? this.snapshot(predecessor) : candidate ? this.snapshot(candidate) : null,
+        intents,
+        reason: predecessor?.phase === 'draining'
+          ? 'current frame is draining'
+          : 'insufficient slot budget for a complete replacement frame',
+      };
+    }
+
+    if (candidate && candidate.frameId !== predecessor?.frameId && CANDIDATE_PHASES.has(candidate.phase)) {
+      candidate.superseded = true;
+      this.cancelFrameInternal(candidate, 'superseded before handover');
+    }
+
+    const participants = Array.from(new Set([
+      ...(request.participantOperatorIds ?? []),
+      ...request.intents.map((intent) => intent.operatorId),
+    ]));
+    const revision = this.nextSlotRevision(request.slotId);
+    const frame: MutableFrame = {
+      frameId: this.idFactory(),
+      slotId: request.slotId,
+      participantOperatorIds: participants,
+      decisionEpoch: Math.max(...intents.map((intent) => intent.decisionEpoch)),
+      revision,
+      phase: 'requested',
+      terminalEmitted: false,
+      superseded: false,
+      intents: new Map(intents.map((intent) => [intent.operatorId!, intent])),
+      expectedEncodeOperators: new Set(request.intents.map((intent) => intent.operatorId)),
+      completedEncodeOperators: new Set(),
+      preparationAction: action,
+      slotEndMs: request.slotEndMs,
+      expectedDurationMs: request.expectedDurationMs,
+      playbackStartMs: request.playbackStartMs,
+      replacesFrameId: predecessor?.frameId,
+    };
+    this.frames.set(frame.frameId, frame);
+    this.candidateFrameBySlot.set(frame.slotId, frame.frameId);
+    this.emitChanged(frame, action === 'restart-current' ? 'replacement candidate requested' : 'frame requested');
+    return { action, frame: this.snapshot(frame), intents };
+  }
+
+  beginEncoding(frameId: string): FrameLease | null {
+    return this.transition(frameId, new Set(['requested']), 'encoding', 'encoding started');
+  }
+
+  acceptEncodeResult(identity: EncodeResultIdentity): boolean {
+    const frame = this.frames.get(identity.frameId);
+    const intent = frame?.intents.get(identity.operatorId);
+    const staleReason = this.getEncodeStaleReason(frame, intent, identity);
+    if (staleReason) {
+      this.staleCallbackDiscardCount += 1;
+      this.emit('staleCallbackDiscarded', { ...identity, reason: staleReason });
+      return false;
+    }
+    const current = frame as MutableFrame;
+    current.completedEncodeOperators.add(identity.operatorId);
+    if (Array.from(current.expectedEncodeOperators)
+      .every((operatorId) => current.completedEncodeOperators.has(operatorId))) {
+      current.phase = 'ready';
+      this.emitChanged(current, 'all expected encodes completed');
+    }
+    return true;
+  }
+
+  failEncodeResult(identity: EncodeResultIdentity, reason: string): FrameLease | null {
+    const frame = this.frames.get(identity.frameId);
+    const intent = frame?.intents.get(identity.operatorId);
+    const staleReason = this.getEncodeStaleReason(frame, intent, identity);
+    if (staleReason) {
+      this.staleCallbackDiscardCount += 1;
+      this.emit('staleCallbackDiscarded', { ...identity, reason: staleReason });
+      return null;
+    }
+    this.cancelFrameInternal(frame as MutableFrame, reason);
+    return this.snapshot(frame as MutableFrame);
+  }
+
+  prepareFrameForHandover(frameId: string, participantOperatorIds?: string[]): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    if (!frame || frame.phase !== 'ready') return frame ? this.snapshot(frame) : null;
+    if (participantOperatorIds) frame.participantOperatorIds = Array.from(new Set(participantOperatorIds));
+    frame.phase = 'prepared';
+    this.emitChanged(frame, 'immutable mixed frame prepared');
+    return this.snapshot(frame);
+  }
+
+  commitFrame(frameId: string): FrameLease | null {
+    return this.transition(frameId, new Set(['prepared']), 'committed', 'physical handover committed');
+  }
+
+  markOnAir(frameId: string): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    if (!frame || frame.phase !== 'committed') return frame ? this.snapshot(frame) : null;
+    frame.phase = 'on_air';
+    const predecessor = frame.replacesFrameId ? this.frames.get(frame.replacesFrameId) : undefined;
+    this.physicalFrameBySlot.set(frame.slotId, frame.frameId);
+    if (this.candidateFrameBySlot.get(frame.slotId) === frame.frameId) {
+      this.candidateFrameBySlot.delete(frame.slotId);
+    }
+    this.emitChanged(frame, 'physical PTT and audio confirmed');
+    if (predecessor && predecessor.frameId !== frame.frameId
+      && predecessor.phase !== 'terminal' && predecessor.phase !== 'cancelled') {
+      predecessor.superseded = true;
+      this.terminalize(predecessor, 'physical lease handed over to replacement');
+    }
+    return this.snapshot(frame);
+  }
+
+  markDraining(frameId: string): FrameLease | null {
+    return this.transition(frameId, new Set(['on_air']), 'draining', 'audio drain started');
+  }
+
+  completeFrame(frameId: string, reason: string): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    if (!frame) return null;
+    if (frame.phase === 'terminal' || frame.phase === 'cancelled') return this.snapshot(frame);
+    if (CANDIDATE_PHASES.has(frame.phase)) this.cancelFrameInternal(frame, reason);
+    else this.terminalize(frame, reason);
+    return this.snapshot(frame);
+  }
+
+  cancelFrame(frameId: string, reason: string): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    if (!frame || !CANDIDATE_PHASES.has(frame.phase)) return frame ? this.snapshot(frame) : null;
+    this.cancelFrameInternal(frame, reason);
+    return this.snapshot(frame);
+  }
+
+  deferFrame(frameId: string, reason: string): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    if (!frame || (!CANDIDATE_PHASES.has(frame.phase) && frame.phase !== 'committed')) {
+      return frame ? this.snapshot(frame) : null;
+    }
+    this.cancelFrameInternal(frame, reason);
+    return this.snapshot(frame);
+  }
+
+  requestStrategyStop(operatorId: string, reason: string): 'cancelled' | 'deferred' | 'not-found' {
+    const frame = this.findLatestFrameForOperator(operatorId);
+    if (!frame) return 'not-found';
+    if (CANDIDATE_PHASES.has(frame.phase)) {
+      this.cancelFrameInternal(frame, reason);
+      return 'cancelled';
+    }
+    return 'deferred';
+  }
+
+  prepareParticipantRemoval(frameId: string, operatorId: string, reason: string): PreparedParticipantRemoval {
+    const source = this.frames.get(frameId);
+    if (!source || !source.participantOperatorIds.includes(operatorId)) {
+      return {
+        action: 'not-found',
+        replacedFrame: source ? this.snapshot(source) : null,
+        frame: null,
+        remainingOperatorIds: source?.participantOperatorIds ?? [],
+        reason: 'operator is not part of the physical frame',
+      };
+    }
+    const remainingOperatorIds = source.participantOperatorIds.filter((id) => id !== operatorId);
+    if (remainingOperatorIds.length === 0) {
+      return {
+        action: 'stop-physical',
+        replacedFrame: this.snapshot(source),
+        frame: null,
+        remainingOperatorIds,
+        reason,
+      };
+    }
+    if (!LIVE_PHASES.has(source.phase) || source.phase === 'draining') {
+      return {
+        action: 'deferred',
+        replacedFrame: this.snapshot(source),
+        frame: null,
+        remainingOperatorIds,
+        reason: `physical frame phase is ${source.phase}`,
+      };
+    }
+    const pending = this.getMutableCandidateFrame(source.slotId);
+    if (pending && pending.frameId !== source.frameId && CANDIDATE_PHASES.has(pending.phase)) {
+      pending.superseded = true;
+      this.cancelFrameInternal(pending, 'superseded by explicit participant removal');
+    }
+    const intents = remainingOperatorIds
+      .map((id) => source.intents.get(id))
+      .filter((intent): intent is TransmissionIntent => Boolean(intent))
+      .map((intent) => this.materializeIntent({
+        operatorId: intent.operatorId!,
+        source: intent.source,
+        reason,
+        text: intent.text,
+        decisionEpoch: intent.decisionEpoch,
+      }, source.slotId, source.frameId));
+    if (intents.length !== remainingOperatorIds.length) {
+      return {
+        action: 'deferred',
+        replacedFrame: this.snapshot(source),
+        frame: null,
+        remainingOperatorIds,
+        reason: 'one or more retained participants have no transmission intent',
+      };
+    }
+    const replacement: MutableFrame = {
+      frameId: this.idFactory(),
+      slotId: source.slotId,
+      participantOperatorIds: remainingOperatorIds,
+      decisionEpoch: Math.max(...intents.map((intent) => intent.decisionEpoch)),
+      revision: this.nextSlotRevision(source.slotId),
+      phase: 'ready',
+      terminalEmitted: false,
+      superseded: false,
+      intents: new Map(intents.map((intent) => [intent.operatorId!, intent])),
+      expectedEncodeOperators: new Set(),
+      completedEncodeOperators: new Set(),
+      preparationAction: 'restart-current',
+      slotEndMs: source.slotEndMs,
+      expectedDurationMs: source.expectedDurationMs,
+      playbackStartMs: source.playbackStartMs,
+      replacesFrameId: source.frameId,
+    };
+    this.frames.set(replacement.frameId, replacement);
+    this.candidateFrameBySlot.set(replacement.slotId, replacement.frameId);
+    this.emitChanged(replacement, 'participant removal replacement ready');
+    return {
+      action: 'replace-current',
+      replacedFrame: this.snapshot(source),
+      frame: this.snapshot(replacement),
+      remainingOperatorIds,
+      reason,
+    };
+  }
+
+  getFrame(frameId: string): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    return frame ? this.snapshot(frame) : null;
+  }
+
+  getSlotEndMs(frameId: string): number | undefined {
+    return this.frames.get(frameId)?.slotEndMs;
+  }
+
+  getCurrentFrameForSlot(slotId: string): FrameLease | null {
+    const frame = this.getMutableCandidateFrame(slotId) ?? this.getMutablePhysicalFrame(slotId);
+    return frame ? this.snapshot(frame) : null;
+  }
+
+  getPhysicalFrameForSlot(slotId: string): FrameLease | null {
+    const frame = this.getMutablePhysicalFrame(slotId);
+    return frame ? this.snapshot(frame) : null;
+  }
+
+  getCandidateFrameForSlot(slotId: string): FrameLease | null {
+    const frame = this.getMutableCandidateFrame(slotId);
+    return frame ? this.snapshot(frame) : null;
+  }
+
+  getCurrentFrameForOperator(operatorId: string): FrameLease | null {
+    const frame = this.findLatestFrameForOperator(operatorId);
+    return frame ? this.snapshot(frame) : null;
+  }
+
+  cancelPreCommitFramesOutsideSlot(slotId: string, reason: string): FrameLease[] {
+    const cancelled: FrameLease[] = [];
+    for (const frame of this.frames.values()) {
+      if (frame.slotId === slotId || !CANDIDATE_PHASES.has(frame.phase)) continue;
+      this.cancelFrameInternal(frame, reason);
+      cancelled.push(this.snapshot(frame));
+    }
+    return cancelled;
+  }
+
+  cancelAllPreCommitFrames(reason: string): FrameLease[] {
+    const cancelled: FrameLease[] = [];
+    for (const frame of this.frames.values()) {
+      if (!CANDIDATE_PHASES.has(frame.phase)) continue;
+      this.cancelFrameInternal(frame, reason);
+      cancelled.push(this.snapshot(frame));
+    }
+    return cancelled;
+  }
+
+  getIntentRequests(frameId: string): TransmissionIntentRequest[] {
+    const frame = this.frames.get(frameId);
+    if (!frame) return [];
+    return Array.from(frame.intents.values()).map((intent) => ({
+      operatorId: intent.operatorId!,
+      source: intent.source,
+      reason: intent.reason,
+      text: intent.text,
+      decisionEpoch: intent.decisionEpoch,
+    }));
+  }
+
+  getStaleCallbackDiscardCount(): number {
+    return this.staleCallbackDiscardCount;
+  }
+
+  getPreparationAction(frameId: string): FramePreparationAction | null {
+    return this.frames.get(frameId)?.preparationAction ?? null;
+  }
+
+  hasCompleteFrameBudget(frameId: string, nowMs: number, actualDurationMs: number): boolean {
+    const frame = this.frames.get(frameId);
+    if (!frame?.slotEndMs) return true;
+    const expectedRemaining = frame.expectedDurationMs === undefined
+      ? 0
+      : Math.max(0, frame.expectedDurationMs - this.getPlaybackOffset(frame, nowMs));
+    const durationMs = Math.max(expectedRemaining, actualDurationMs);
+    return frame.slotEndMs - nowMs >= durationMs + this.physicalStartBudgetMs + this.tailHoldMs;
+  }
+
+  getPlaybackOffsetMs(frameId: string, nowMs: number): number {
+    const frame = this.frames.get(frameId);
+    return frame ? this.getPlaybackOffset(frame, nowMs) : 0;
+  }
+
+  getIntentText(frameId: string, operatorId: string): string | undefined {
+    return this.frames.get(frameId)?.intents.get(operatorId)?.text;
+  }
+
+  getReplacedFrameId(frameId: string): string | undefined {
+    return this.frames.get(frameId)?.replacesFrameId;
+  }
+
+  private resolvePreparationAction(
+    predecessor: MutableFrame | null,
+    candidate: MutableFrame | null,
+    request: PrepareDigitalFrameRequest,
+    nowMs: number,
+  ): FramePreparationAction {
+    if (!predecessor) {
+      if (!candidate || CANDIDATE_PHASES.has(candidate.phase)) return 'encode';
+      predecessor = candidate;
+    }
+    if (predecessor.phase === 'draining') return 'defer-next-slot';
+    if (candidate && candidate.frameId !== predecessor.frameId && candidate.phase === 'committed') {
+      return 'defer-next-slot';
+    }
+    if (request.expectedDurationMs === undefined || request.slotEndMs === undefined) {
+      return 'defer-next-slot';
+    }
+    const requiredMs = Math.max(0, request.expectedDurationMs - this.getPlaybackOffset(predecessor, nowMs))
+      + this.physicalStartBudgetMs
+      + this.tailHoldMs;
+    return request.slotEndMs - nowMs >= requiredMs ? 'restart-current' : 'defer-next-slot';
+  }
+
+  private getEncodeStaleReason(
+    frame: MutableFrame | undefined,
+    intent: TransmissionIntent | undefined,
+    identity: EncodeResultIdentity,
+  ): string | null {
+    if (!frame) return 'frame not found';
+    if (frame.phase !== 'encoding') return `frame phase is ${frame.phase}`;
+    if (frame.revision !== identity.revision) return 'frame revision changed';
+    if (!intent || intent.decisionEpoch !== identity.decisionEpoch) return 'decision epoch changed';
+    return null;
+  }
+
+  private materializeIntent(
+    request: TransmissionIntentRequest,
+    slotId: string,
+    replacesFrameId?: string,
+  ): TransmissionIntent {
+    return {
+      operatorId: request.operatorId,
+      source: request.source,
+      reason: request.reason,
+      slotId,
+      text: request.text,
+      decisionEpoch: request.decisionEpoch,
+      replacesFrameId,
+    };
+  }
+
+  private transition(
+    frameId: string,
+    allowed: Set<FramePhase>,
+    next: FramePhase,
+    reason: string,
+  ): FrameLease | null {
+    const frame = this.frames.get(frameId);
+    if (!frame || !allowed.has(frame.phase)) return frame ? this.snapshot(frame) : null;
+    frame.phase = next;
+    this.emitChanged(frame, reason);
+    return this.snapshot(frame);
+  }
+
+  private cancelFrameInternal(frame: MutableFrame, reason: string): void {
+    if (frame.phase === 'cancelled' || frame.phase === 'terminal') return;
+    frame.phase = 'cancelled';
+    this.emitChanged(frame, reason);
+    this.emitTerminalOnce(frame, reason);
+    this.releaseIndexes(frame);
+    this.retainTerminalFrame(frame);
+  }
+
+  private terminalize(frame: MutableFrame, reason: string): void {
+    if (frame.phase === 'terminal' || frame.phase === 'cancelled') return;
+    frame.phase = 'terminal';
+    this.emitChanged(frame, reason);
+    this.emitTerminalOnce(frame, reason);
+    this.releaseIndexes(frame);
+    this.retainTerminalFrame(frame);
+  }
+
+  private releaseIndexes(frame: MutableFrame): void {
+    if (this.candidateFrameBySlot.get(frame.slotId) === frame.frameId) {
+      this.candidateFrameBySlot.delete(frame.slotId);
+    }
+    if (this.physicalFrameBySlot.get(frame.slotId) === frame.frameId) {
+      this.physicalFrameBySlot.delete(frame.slotId);
+    }
+  }
+
+  private emitTerminalOnce(frame: MutableFrame, reason: string): void {
+    if (frame.terminalEmitted) return;
+    frame.terminalEmitted = true;
+    this.emit('terminal', this.snapshot(frame), reason);
+  }
+
+  private emitChanged(frame: MutableFrame, reason: string): void {
+    this.emit('frameChanged', this.snapshot(frame), reason);
+  }
+
+  private retainTerminalFrame(frame: MutableFrame): void {
+    this.terminalFrameIds.push(frame.frameId);
+    while (this.terminalFrameIds.length > this.maxRetainedFrames) {
+      const expired = this.terminalFrameIds.shift();
+      if (expired) this.frames.delete(expired);
+    }
+  }
+
+  private nextSlotRevision(slotId: string): number {
+    const revision = (this.slotRevisions.get(slotId) ?? 0) + 1;
+    this.slotRevisions.set(slotId, revision);
+    return revision;
+  }
+
+  private getMutablePhysicalFrame(slotId: string): MutableFrame | null {
+    const frameId = this.physicalFrameBySlot.get(slotId);
+    return frameId ? this.frames.get(frameId) ?? null : null;
+  }
+
+  private getMutableCandidateFrame(slotId: string): MutableFrame | null {
+    const frameId = this.candidateFrameBySlot.get(slotId);
+    return frameId ? this.frames.get(frameId) ?? null : null;
+  }
+
+  private findLatestFrameForOperator(operatorId: string): MutableFrame | null {
+    return Array.from(this.frames.values()).reverse().find((frame) =>
+      frame.participantOperatorIds.includes(operatorId)
+      && frame.phase !== 'terminal'
+      && frame.phase !== 'cancelled') ?? null;
+  }
+
+  private getPlaybackOffset(frame: MutableFrame, nowMs: number): number {
+    return frame.playbackStartMs === undefined ? 0 : Math.max(0, nowMs - frame.playbackStartMs);
+  }
+
+  private snapshot(frame: MutableFrame): FrameLease {
+    return {
+      frameId: frame.frameId,
+      slotId: frame.slotId,
+      participantOperatorIds: [...frame.participantOperatorIds],
+      decisionEpoch: frame.decisionEpoch,
+      revision: frame.revision,
+      phase: frame.phase,
+      terminalEmitted: frame.terminalEmitted,
+      superseded: frame.superseded,
+    };
+  }
+}

--- a/packages/server/src/transmission/OperatorIntentCoordinator.ts
+++ b/packages/server/src/transmission/OperatorIntentCoordinator.ts
@@ -1,0 +1,191 @@
+export type OperatorCommandSource = 'manual' | 'plugin' | 'late-decode' | 'slot-auto';
+
+export interface OperatorCommandToken {
+  operatorId: string;
+  epoch: number;
+  source: OperatorCommandSource;
+  priority: number;
+}
+
+export type OperatorIntentOutcome<T> =
+  | { status: 'completed'; token: OperatorCommandToken; value: T }
+  | { status: 'superseded'; token: OperatorCommandToken };
+
+interface IntentJob<T = unknown> {
+  token: OperatorCommandToken;
+  controller: AbortController;
+  run: (token: OperatorCommandToken, signal: AbortSignal) => T | Promise<T>;
+  resolve: (outcome: OperatorIntentOutcome<T>) => void;
+  reject: (error: unknown) => void;
+  completion: Promise<void>;
+}
+
+interface OperatorLane {
+  nextEpoch: number;
+  authoritativeEpoch: number;
+  active?: IntentJob;
+  pending?: IntentJob;
+  takeover?: Promise<void>;
+}
+
+const PRIORITY: Record<OperatorCommandSource, number> = {
+  'slot-auto': 10,
+  'late-decode': 20,
+  plugin: 90,
+  manual: 100,
+};
+
+/** Serializes operator mutations while letting newer, higher-priority intent revoke stale work. */
+export class OperatorIntentCoordinator {
+  private readonly lanes = new Map<string, OperatorLane>();
+
+  constructor(
+    private readonly options: {
+      abortGraceMs?: number;
+      onAbortTimeout?: (token: OperatorCommandToken) => void;
+    } = {},
+  ) {}
+
+  submit<T>(
+    operatorId: string,
+    source: OperatorCommandSource,
+    run: (token: OperatorCommandToken, signal: AbortSignal) => T | Promise<T>,
+  ): Promise<OperatorIntentOutcome<T>> {
+    const lane = this.getLane(operatorId);
+    const token: OperatorCommandToken = {
+      operatorId,
+      epoch: ++lane.nextEpoch,
+      source,
+      priority: PRIORITY[source],
+    };
+
+    return new Promise<OperatorIntentOutcome<T>>((resolve, reject) => {
+      const job: IntentJob<T> = {
+        token,
+        controller: new AbortController(),
+        run,
+        resolve,
+        reject,
+        completion: Promise.resolve(),
+      };
+      this.enqueue(lane, job as IntentJob);
+    });
+  }
+
+  isCurrent(token: OperatorCommandToken): boolean {
+    return this.lanes.get(token.operatorId)?.authoritativeEpoch === token.epoch;
+  }
+
+  getCurrentEpoch(operatorId: string): number {
+    return this.getLane(operatorId).authoritativeEpoch;
+  }
+
+  abortOperator(operatorId: string, reason: string): number {
+    const lane = this.getLane(operatorId);
+    const epoch = ++lane.nextEpoch;
+    lane.authoritativeEpoch = epoch;
+    if (lane.pending) {
+      lane.pending.resolve({ status: 'superseded', token: lane.pending.token });
+      lane.pending = undefined;
+    }
+    lane.active?.controller.abort(reason);
+    return epoch;
+  }
+
+  removeOperator(operatorId: string, reason = 'operator removed'): void {
+    this.abortOperator(operatorId, reason);
+    this.lanes.delete(operatorId);
+  }
+
+  clear(reason = 'intent coordinator cleared'): void {
+    for (const operatorId of this.lanes.keys()) this.abortOperator(operatorId, reason);
+    this.lanes.clear();
+  }
+
+  private enqueue(lane: OperatorLane, job: IntentJob): void {
+    const active = lane.active;
+    if (!active) {
+      this.start(lane, job);
+      return;
+    }
+
+    const supersedesActive = job.token.priority >= active.token.priority;
+    if (lane.pending) {
+      if (lane.pending.token.priority > job.token.priority) {
+        job.resolve({ status: 'superseded', token: job.token });
+        return;
+      }
+      lane.pending.resolve({ status: 'superseded', token: lane.pending.token });
+    }
+    lane.pending = job;
+
+    if (!supersedesActive) return;
+    lane.authoritativeEpoch = job.token.epoch;
+    active.controller.abort(`superseded by ${job.token.source} epoch ${job.token.epoch}`);
+    this.ensureTakeover(lane, active);
+  }
+
+  private start(lane: OperatorLane, job: IntentJob): void {
+    lane.active = job;
+    lane.authoritativeEpoch = job.token.epoch;
+    let execution: Promise<unknown>;
+    try {
+      execution = Promise.resolve(job.run(job.token, job.controller.signal));
+    } catch (error) {
+      execution = Promise.reject(error);
+    }
+
+    job.completion = execution.then(
+      (value) => {
+        if (this.isCurrent(job.token) && !job.controller.signal.aborted) {
+          job.resolve({ status: 'completed', token: job.token, value });
+        } else {
+          job.resolve({ status: 'superseded', token: job.token });
+        }
+      },
+      (error) => {
+        if (job.controller.signal.aborted || !this.isCurrent(job.token)) {
+          job.resolve({ status: 'superseded', token: job.token });
+        } else {
+          job.reject(error);
+        }
+      },
+    ).finally(() => {
+      if (lane.active !== job) return;
+      lane.active = undefined;
+      const next = lane.pending;
+      lane.pending = undefined;
+      if (next) this.start(lane, next);
+    });
+  }
+
+  private ensureTakeover(lane: OperatorLane, active: IntentJob): void {
+    if (lane.takeover) return;
+    const abortGraceMs = this.options.abortGraceMs ?? 1_000;
+    lane.takeover = Promise.race([
+      active.completion.then(() => false),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(true), abortGraceMs)),
+    ]).then((timedOut) => {
+      if (!timedOut || lane.active !== active) return;
+      this.options.onAbortTimeout?.(active.token);
+      lane.active = undefined;
+      const next = lane.pending;
+      lane.pending = undefined;
+      if (next) this.start(lane, next);
+    }).finally(() => {
+      lane.takeover = undefined;
+      if (lane.active?.controller.signal.aborted && lane.pending) {
+        this.ensureTakeover(lane, lane.active);
+      }
+    });
+  }
+
+  private getLane(operatorId: string): OperatorLane {
+    let lane = this.lanes.get(operatorId);
+    if (!lane) {
+      lane = { nextEpoch: 0, authoritativeEpoch: 0 };
+      this.lanes.set(operatorId, lane);
+    }
+    return lane;
+  }
+}

--- a/packages/server/src/transmission/PhysicalTxCoordinator.ts
+++ b/packages/server/src/transmission/PhysicalTxCoordinator.ts
@@ -1,0 +1,1199 @@
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'eventemitter3';
+import type { PlaybackKind, PlayAudioOptions } from '../audio/AudioStreamManager.js';
+import type {
+  PhysicalTxPhase,
+  PhysicalTxSnapshot,
+  PhysicalTxSource,
+} from './TransmissionIntent.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('PhysicalTxCoordinator');
+
+export interface PhysicalTxCoordinatorEvents {
+  phaseChanged: (snapshot: PhysicalTxSnapshot) => void;
+  terminal: (result: PhysicalTxResult) => void;
+  staleCallbackDiscarded: (data: { leaseId: string; epoch: number; callback: string }) => void;
+}
+
+export interface PhysicalTxCoordinatorDeps {
+  isRadioConnected: () => boolean;
+  setPTT: (active: boolean) => Promise<void>;
+  playAudio: (audioData: Float32Array, sampleRate: number, options?: PlayAudioOptions) => Promise<void>;
+  stopCurrentPlayback: (options?: { kind?: PlaybackKind }) => Promise<number>;
+  prepareAudioPlayback?: (kind: PlaybackKind) => Promise<boolean>;
+  isAudioPlaying?: (kind?: PlaybackKind) => boolean;
+  setTxDialOffset?: (shiftHz: number) => Promise<unknown>;
+  clearTxDialOffset?: () => Promise<unknown>;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface PhysicalTxLeaseRequest {
+  source: PhysicalTxSource;
+  operatorIds?: string[];
+  frameId?: string;
+  frameRevision?: number;
+  reason: string;
+  txDialShiftHz?: number;
+  deferActiveUntilAudio?: boolean;
+  playbackKind?: PlaybackKind;
+  beforeStart?: () => Promise<void>;
+  afterAudioDrain?: () => Promise<void>;
+  validateStart?: () => void | Promise<void>;
+  assertPtt?: boolean;
+  interrupt?: () => Promise<void>;
+}
+
+export interface PhysicalAudioTransmissionRequest extends PhysicalTxLeaseRequest {
+  audioData: Float32Array;
+  sampleRate: number;
+  playbackKind: PlaybackKind;
+  playbackOptions?: Omit<PlayAudioOptions, 'playbackKind'>;
+  tailHoldMs?: number;
+}
+
+export interface PhysicalAudioPlaybackRequest {
+  audioData: Float32Array;
+  sampleRate: number;
+  playbackKind: PlaybackKind;
+  frameId?: string;
+  operatorIds?: string[];
+  reason?: string;
+  playbackOptions?: Omit<PlayAudioOptions, 'playbackKind'>;
+  tailHoldMs?: number;
+  frameRevision?: number;
+}
+
+export interface PhysicalAudioReplacementRequest {
+  frameId: string;
+  frameRevision?: number;
+  operatorIds: string[];
+  reason: string;
+  playbackKind: PlaybackKind;
+  audioData: Float32Array;
+  sampleRate: number;
+  playbackOptions?: Omit<PlayAudioOptions, 'playbackKind'>;
+  tailHoldMs?: number;
+  /** Wall-clock instant represented by the first sample in audioData. */
+  waveformStartMs: number;
+  /** No replacement may begin if its complete remaining waveform cannot fit. */
+  slotEndMs?: number;
+  expectedLeaseEpoch: number;
+  expectedPlaybackGeneration: number;
+  expectedFrameId?: string;
+  onHandoverCommitted?: () => PhysicalAudioHandoverCommitResult;
+  onPlaybackStarted?: () => void;
+}
+
+export type PhysicalAudioHandoverCommitResult =
+  | { status: 'committed' }
+  | { status: 'superseded'; reason: string };
+
+export interface PhysicalTxResult {
+  leaseId: string;
+  frameId?: string;
+  frameRevision?: number;
+  source: PhysicalTxSource;
+  operatorIds: string[];
+  success: boolean;
+  reason: string;
+  error?: string;
+  physicalConfirmed: boolean;
+  /** A newer audio generation owns the same physical PTT lease. */
+  leaseContinues?: boolean;
+}
+
+export interface PhysicalTxMaintenanceRequest {
+  reason: string;
+  /** Scheduled/background work never interrupts an existing physical lease. */
+  busyPolicy?: 'reject';
+}
+
+interface MutablePhysicalPlayback {
+  generation: number;
+  frameId?: string;
+  frameRevision?: number;
+  operatorIds: string[];
+  playbackKind: PlaybackKind;
+  completion: Promise<void>;
+}
+
+interface PhysicalPlaybackIdentity {
+  frameId?: string;
+  frameRevision?: number;
+  operatorIds?: string[];
+  playbackKind: PlaybackKind;
+  reason?: string;
+}
+
+interface MutablePhysicalLease {
+  leaseId: string;
+  frameId?: string;
+  frameRevision?: number;
+  source: PhysicalTxSource;
+  operatorIds: string[];
+  reason: string;
+  epoch: number;
+  phase: PhysicalTxPhase;
+  startedAt: number;
+  pttConfirmed: boolean;
+  everPttConfirmed: boolean;
+  stopRequested: boolean;
+  terminalEmitted: boolean;
+  playbackKind?: PlaybackKind;
+  pttStartPromise?: Promise<void>;
+  pttStartSettlementPromise?: Promise<void>;
+  dialOffsetStartPromise?: Promise<unknown>;
+  dialOffsetSettlementPromise?: Promise<void>;
+  dialOffsetApplied: boolean;
+  releasePromise?: Promise<PhysicalTxResult>;
+  assertPtt: boolean;
+  interrupt?: () => Promise<void>;
+  playbackGeneration: number;
+  drainingGeneration?: number;
+  playbackTransition: Promise<void>;
+  activePlayback?: MutablePhysicalPlayback;
+  activationPromise: Promise<void>;
+  resolveActivation: () => void;
+  rejectActivation: (error: unknown) => void;
+  activationSettled: boolean;
+}
+
+export class PhysicalTxBusyError extends Error {
+  constructor(message = 'physical transmitter is busy') {
+    super(message);
+    this.name = 'PhysicalTxBusyError';
+  }
+}
+
+export class PhysicalTxInterruptedError extends Error {
+  constructor(message = 'physical transmission interrupted') {
+    super(message);
+    this.name = 'PhysicalTxInterruptedError';
+  }
+}
+
+export class PhysicalTxPreparationError extends Error {
+  constructor(message: string, public readonly preparationCause?: unknown) {
+    super(message);
+    this.name = 'PhysicalTxPreparationError';
+  }
+}
+
+export class PhysicalTxCoordinator extends EventEmitter<PhysicalTxCoordinatorEvents> {
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly idFactory: () => string;
+  private readonly operationTimeoutMs: number;
+  private readonly audioStartTimeoutMs: number;
+  private readonly cleanupTimeoutMs: number;
+  private activeLease: MutablePhysicalLease | null = null;
+  private epoch = 0;
+  private staleCallbackDiscardCount = 0;
+  private readonly pendingOperationFences = new Set<Promise<void>>();
+  private maintenanceReason: string | null = null;
+
+  constructor(
+    private readonly deps: PhysicalTxCoordinatorDeps,
+    options: {
+      idFactory?: () => string;
+      operationTimeoutMs?: number;
+      audioStartTimeoutMs?: number;
+      cleanupTimeoutMs?: number;
+    } = {},
+  ) {
+    super();
+    this.now = deps.now ?? Date.now;
+    this.sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.idFactory = options.idFactory ?? randomUUID;
+    this.operationTimeoutMs = options.operationTimeoutMs ?? 15_000;
+    this.audioStartTimeoutMs = options.audioStartTimeoutMs ?? this.operationTimeoutMs;
+    this.cleanupTimeoutMs = options.cleanupTimeoutMs ?? 2_000;
+  }
+
+  getSnapshot(): PhysicalTxSnapshot {
+    return this.snapshot(this.activeLease);
+  }
+
+  getStaleCallbackDiscardCount(): number {
+    return this.staleCallbackDiscardCount;
+  }
+
+  /**
+   * Runs a hardware mutation while the transmitter is confirmed idle. The
+   * fence is installed synchronously, before user code runs, so digital,
+   * voice, CW, tune and manual sources all observe the same exclusion point.
+   */
+  async runIdleMaintenance<T>(
+    request: PhysicalTxMaintenanceRequest,
+    operation: () => T | Promise<T>,
+  ): Promise<T> {
+    if (this.activeLease || this.maintenanceReason || this.pendingOperationFences.size > 0) {
+      throw new PhysicalTxBusyError(
+        this.activeLease
+          ? `physical transmitter is ${this.activeLease.phase}`
+          : this.maintenanceReason
+            ? `physical transmitter maintenance is active: ${this.maintenanceReason}`
+            : 'physical transmitter cleanup is still settling',
+      );
+    }
+
+    this.maintenanceReason = request.reason;
+    let operationSettled = false;
+    let operationPromise: Promise<T>;
+    try {
+      operationPromise = Promise.resolve(operation());
+    } catch (error) {
+      operationPromise = Promise.reject(error);
+    }
+    void operationPromise.then(
+      () => { operationSettled = true; },
+      () => { operationSettled = true; },
+    );
+
+    try {
+      return await this.withTimeout(operationPromise, request.reason);
+    } catch (error) {
+      // A timed-out CAT/network command may still reach the radio later. Keep
+      // all new leases fenced until the actual backend promise settles.
+      if (!operationSettled) this.trackPendingOperation(operationPromise);
+      throw error;
+    } finally {
+      this.maintenanceReason = null;
+    }
+  }
+
+  async acquireLease(request: PhysicalTxLeaseRequest): Promise<string> {
+    if (this.activeLease || this.maintenanceReason || this.pendingOperationFences.size > 0) {
+      throw new PhysicalTxBusyError(
+        this.activeLease
+          ? 'physical transmitter is busy'
+          : this.maintenanceReason
+            ? `physical transmitter maintenance is active: ${this.maintenanceReason}`
+            : 'physical transmitter cleanup is still settling',
+      );
+    }
+
+    let resolveActivation!: () => void;
+    let rejectActivation!: (error: unknown) => void;
+    const activationPromise = new Promise<void>((resolve, reject) => {
+      resolveActivation = resolve;
+      rejectActivation = reject;
+    });
+    void activationPromise.catch(() => undefined);
+    const lease: MutablePhysicalLease = {
+      leaseId: this.idFactory(),
+      frameId: request.frameId,
+      frameRevision: request.frameRevision,
+      source: request.source,
+      operatorIds: [...new Set(request.operatorIds ?? [])],
+      reason: request.reason,
+      epoch: ++this.epoch,
+      phase: 'starting',
+      startedAt: this.now(),
+      pttConfirmed: false,
+      everPttConfirmed: false,
+      stopRequested: false,
+      terminalEmitted: false,
+      playbackKind: request.playbackKind,
+      dialOffsetApplied: false,
+      assertPtt: request.assertPtt !== false,
+      interrupt: request.interrupt,
+      playbackGeneration: 0,
+      playbackTransition: Promise.resolve(),
+      activationPromise,
+      resolveActivation,
+      rejectActivation,
+      activationSettled: false,
+    };
+    this.activeLease = lease;
+    this.emitPhase(lease);
+
+    try {
+      if (request.beforeStart) {
+        let beforeStartSettled = false;
+        const beforeStartPromise = Promise.resolve().then(request.beforeStart);
+        void beforeStartPromise.then(
+          () => { beforeStartSettled = true; },
+          () => { beforeStartSettled = true; },
+        );
+        try {
+          await this.withTimeout(beforeStartPromise, 'pre-start cleanup');
+        } catch (error) {
+          // A timed-out cleanup may still be running in a native/audio
+          // backend. Keep its fence so a new lease cannot race the late
+          // callback into the next frame.
+          if (!beforeStartSettled) this.trackPendingOperation(beforeStartPromise);
+          throw error;
+        }
+      }
+      this.assertLeaseCanContinue(lease, 'interrupted during pre-start cleanup');
+
+      if (request.playbackKind) {
+        await this.preparePlaybackOutput(lease, request.playbackKind, request.afterAudioDrain);
+      }
+
+      await request.validateStart?.();
+      this.assertLeaseCanContinue(lease, 'interrupted after start validation');
+      if (lease.assertPtt && !this.deps.isRadioConnected()) {
+        throw new Error('radio not connected');
+      }
+      if (request.txDialShiftHz) {
+        const rawDialOffsetStart = Promise.resolve().then(
+          () => this.deps.setTxDialOffset?.(request.txDialShiftHz!),
+        );
+        lease.dialOffsetStartPromise = rawDialOffsetStart;
+        lease.dialOffsetSettlementPromise = rawDialOffsetStart.then(async (applied) => {
+          lease.dialOffsetApplied = applied !== false;
+          if (!this.isCurrent(lease) || lease.stopRequested) {
+            await this.deps.clearTxDialOffset?.();
+            lease.dialOffsetApplied = false;
+          }
+        }, () => undefined);
+        const applied = await this.withTimeout(rawDialOffsetStart, 'TX dial offset');
+        if (applied === false) {
+          throw new Error('TX dial offset was not applied');
+        }
+        this.assertLeaseCanContinue(lease, 'interrupted while setting TX dial offset');
+        await request.validateStart?.();
+        this.assertLeaseCanContinue(lease, 'interrupted after TX dial offset validation');
+      }
+
+      if (lease.assertPtt) {
+        const rawStart = this.deps.setPTT(true);
+        lease.pttStartPromise = rawStart;
+        lease.pttStartSettlementPromise = rawStart.then(
+          () => this.handleLatePttStart(lease),
+          () => undefined,
+        );
+        await this.withTimeout(rawStart, 'PTT start');
+        await request.validateStart?.();
+      }
+
+      if (!this.isCurrent(lease) || lease.stopRequested) {
+        await this.ensureReleased(lease, 'interrupted while PTT was starting', false);
+        throw new PhysicalTxInterruptedError();
+      }
+
+      lease.pttConfirmed = lease.assertPtt;
+      lease.everPttConfirmed = lease.assertPtt;
+      this.resolveLeaseActivation(lease);
+      if (!request.deferActiveUntilAudio) {
+        lease.phase = 'active';
+        this.emitPhase(lease);
+      }
+      return lease.leaseId;
+    } catch (error) {
+      this.rejectLeaseActivation(lease, error);
+      if (this.isCurrent(lease) && lease.phase !== 'unknown') {
+        await this.ensureReleased(lease, 'PTT start failed', false, error);
+      }
+      throw error;
+    }
+  }
+
+  async transmitAudio(request: PhysicalAudioTransmissionRequest): Promise<PhysicalTxResult> {
+    const leaseId = await this.acquireLease({
+      ...request,
+      playbackKind: request.playbackKind,
+      deferActiveUntilAudio: true,
+    });
+    return this.playAudioOnLease(leaseId, request);
+  }
+
+  async playAudioOnLease(
+    leaseId: string,
+    request: PhysicalAudioPlaybackRequest,
+  ): Promise<PhysicalTxResult> {
+    const lease = this.requireCurrentLease(leaseId);
+    const started = await this.runPlaybackTransition(lease, async () => {
+      if (request.frameId && lease.frameId && request.frameId !== lease.frameId) {
+        return {
+          started: false,
+          completion: Promise.resolve(this.toPlaybackResult(
+            lease,
+            request,
+            false,
+            'audio generation superseded before start',
+            undefined,
+            true,
+          )),
+        };
+      }
+      if (lease.activePlayback) {
+        throw new PhysicalTxBusyError('physical lease already has an active audio generation');
+      }
+      return this.startPlaybackGenerationLocked(lease, request, ++lease.playbackGeneration);
+    });
+    return started.completion;
+  }
+
+  /**
+   * Replaces digital audio while retaining the existing physical PTT lease.
+   * The old playback generation is fenced before it is stopped, so its late
+   * completion cannot release PTT or overwrite the replacement frame state.
+   */
+  async replaceAudioOnLease(
+    leaseId: string,
+    request: PhysicalAudioReplacementRequest,
+  ): Promise<PhysicalTxResult> {
+    const lease = this.requireCurrentLease(leaseId);
+    try {
+      const started = await this.runPlaybackTransition(lease, async () => {
+        this.assertLeaseCanContinue(lease, 'interrupted before audio replacement');
+        if (lease.epoch !== request.expectedLeaseEpoch
+          || lease.playbackGeneration !== request.expectedPlaybackGeneration
+          || (request.expectedFrameId !== undefined && lease.frameId !== request.expectedFrameId)) {
+          return {
+            started: false,
+            completion: Promise.resolve(this.toPlaybackResult(
+              lease,
+              request,
+              false,
+              'audio replacement precondition changed',
+              undefined,
+              true,
+            )),
+          };
+        }
+
+        if (!lease.activationSettled || (lease.assertPtt && !lease.pttConfirmed)) {
+          // The candidate is not the physical owner until its audio-start
+          // acknowledgement. Keep the starting lease identity immutable while
+          // waiting so UI and competing transitions still see the predecessor.
+          await this.withTimeout(lease.activationPromise, 'pending physical activation');
+          this.assertLeaseCanContinue(lease, 'interrupted while waiting to replace audio');
+          if (lease.assertPtt && !lease.pttConfirmed) {
+            throw new PhysicalTxInterruptedError('PTT start is not yet confirmed');
+          }
+        }
+
+        const preparedAudio = this.resynchronizeReplacementAudio(request, this.now());
+        const remainingDurationMs = (preparedAudio.length / request.sampleRate) * 1_000;
+        if (preparedAudio.length === 0
+          || (request.slotEndMs !== undefined
+            && this.now() + remainingDurationMs + (request.tailHoldMs ?? 0) > request.slotEndMs)) {
+          return {
+            started: false,
+            completion: Promise.resolve(this.toPlaybackResult(
+              lease,
+              request,
+              false,
+              'complete replacement no longer fits before handover commit',
+              undefined,
+              true,
+            )),
+          };
+        }
+
+        const previousPlayback = lease.activePlayback;
+        const handover = request.onHandoverCommitted?.();
+        if (handover?.status === 'superseded') {
+          return {
+            started: false,
+            completion: Promise.resolve(this.toPlaybackResult(
+              lease,
+              request,
+              false,
+              handover.reason,
+              undefined,
+              true,
+            )),
+          };
+        }
+        const generation = ++lease.playbackGeneration;
+        lease.drainingGeneration = undefined;
+        if (previousPlayback) {
+          const stopPromise = Promise.resolve().then(
+            () => this.deps.stopCurrentPlayback({ kind: previousPlayback.playbackKind }),
+          );
+          try {
+            await this.withTimeout(stopPromise, 'audio replacement stop', this.cleanupTimeoutMs);
+          } catch (error) {
+            this.trackPendingOperation(stopPromise);
+            throw error;
+          }
+        }
+        this.assertLeaseCanContinue(lease, 'interrupted after stopping replaced audio');
+        lease.activePlayback = undefined;
+
+        // stopCurrentPlayback only fences the producer. The native backend may
+        // still own submitted samples, so the same output-preparation contract
+        // used by a new lease must run before this lease starts a generation.
+        await this.preparePlaybackOutput(lease, request.playbackKind);
+        this.assertLeaseCanContinue(lease, 'interrupted while draining replaced audio');
+
+        const handoverStartMs = this.now();
+        const resynchronizedAudio = this.resynchronizeReplacementAudio(request, handoverStartMs);
+        const resynchronizedDurationMs = (resynchronizedAudio.length / request.sampleRate) * 1_000;
+        if (resynchronizedAudio.length === 0
+          || (request.slotEndMs !== undefined
+            && handoverStartMs + resynchronizedDurationMs + (request.tailHoldMs ?? 0) > request.slotEndMs)) {
+          throw new PhysicalTxPreparationError(
+            'complete replacement no longer fits after audio output drain',
+          );
+        }
+
+        const started = await this.startPlaybackGenerationLocked(lease, {
+          audioData: resynchronizedAudio,
+          sampleRate: request.sampleRate,
+          playbackKind: request.playbackKind,
+          playbackOptions: request.playbackOptions,
+          tailHoldMs: request.tailHoldMs,
+          frameId: request.frameId,
+          frameRevision: request.frameRevision,
+          operatorIds: request.operatorIds,
+          reason: request.reason,
+        }, generation);
+        if (started.started) request.onPlaybackStarted?.();
+        return started;
+      });
+      return started.completion;
+    } catch (error) {
+      if (this.isCurrent(lease)) {
+        return this.ensureReleased(lease, 'audio replacement failed', false, error);
+      }
+      return this.toPlaybackResult(
+        lease,
+        { playbackKind: request.playbackKind, frameId: request.frameId, operatorIds: request.operatorIds },
+        false,
+        'audio replacement failed',
+        error,
+      );
+    }
+  }
+
+  private async preparePlaybackOutput(
+    lease: MutablePhysicalLease,
+    playbackKind: PlaybackKind,
+    afterAudioDrain?: () => Promise<void>,
+  ): Promise<boolean> {
+    if (!this.deps.prepareAudioPlayback) return false;
+
+    let preparationSettled = false;
+    const preparationPromise = Promise.resolve()
+      .then(() => this.deps.prepareAudioPlayback!(playbackKind));
+    void preparationPromise.then(
+      () => { preparationSettled = true; },
+      () => { preparationSettled = true; },
+    );
+
+    let waitedForDrain: boolean;
+    try {
+      waitedForDrain = await this.withTimeout(preparationPromise, 'audio output preparation');
+    } catch (error) {
+      if (!preparationSettled) this.trackPendingOperation(preparationPromise);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new PhysicalTxPreparationError(`audio output preparation failed: ${message}`, error);
+    }
+    this.assertLeaseCanContinue(lease, 'interrupted during audio output preparation');
+
+    if (waitedForDrain && afterAudioDrain) {
+      let refreshSettled = false;
+      const refreshPromise = Promise.resolve()
+        .then(afterAudioDrain)
+        .finally(() => { refreshSettled = true; });
+      try {
+        await this.withTimeout(refreshPromise, 'post-drain audio refresh');
+      } catch (error) {
+        if (!refreshSettled) this.trackPendingOperation(refreshPromise);
+        throw error;
+      }
+      this.assertLeaseCanContinue(lease, 'interrupted during post-drain audio refresh');
+    }
+
+    return waitedForDrain;
+  }
+
+  private resynchronizeReplacementAudio(
+    request: PhysicalAudioReplacementRequest,
+    nowMs: number,
+  ): Float32Array {
+    const elapsedSincePreparationMs = Math.max(0, nowMs - request.waveformStartMs);
+    const additionalSamples = Math.min(
+      request.audioData.length,
+      Math.floor((elapsedSincePreparationMs / 1_000) * request.sampleRate),
+    );
+    return additionalSamples > 0
+      ? request.audioData.subarray(additionalSamples)
+      : request.audioData;
+  }
+
+  private async runPlaybackTransition<T>(
+    lease: MutablePhysicalLease,
+    transition: () => Promise<T>,
+  ): Promise<T> {
+    const previous = lease.playbackTransition;
+    let releaseTransition!: () => void;
+    const current = new Promise<void>((resolve) => { releaseTransition = resolve; });
+    lease.playbackTransition = previous.then(() => current, () => current);
+    await previous.catch(() => undefined);
+    try {
+      this.assertLeaseCanContinue(lease, 'physical lease ended before audio transition');
+      return await transition();
+    } finally {
+      releaseTransition();
+    }
+  }
+
+  private async startPlaybackGenerationLocked(
+    lease: MutablePhysicalLease,
+    request: PhysicalAudioPlaybackRequest,
+    generation: number,
+  ): Promise<{ started: boolean; completion: Promise<PhysicalTxResult> }> {
+    this.assertLeaseCanContinue(lease, 'interrupted before starting audio generation');
+    lease.playbackKind = request.playbackKind;
+    let audioStarted = false;
+    let resolveAudioStarted!: () => void;
+    let rejectAudioStarted!: (error: unknown) => void;
+    const audioStartPromise = new Promise<void>((resolve, reject) => {
+      resolveAudioStarted = resolve;
+      rejectAudioStarted = reject;
+    });
+    const audioPromise = Promise.resolve().then(() => this.deps.playAudio(
+      request.audioData,
+      request.sampleRate,
+      {
+        ...request.playbackOptions,
+        playbackKind: request.playbackKind,
+        onPlaybackStarted: () => {
+          audioStarted = true;
+          resolveAudioStarted();
+        },
+      },
+    ));
+    void audioPromise.then(() => {
+      if (!audioStarted) {
+        rejectAudioStarted(new Error('audio playback completed without hardware start acknowledgement'));
+      }
+    }, rejectAudioStarted);
+
+    try {
+      await this.withTimeout(audioStartPromise, 'audio start', this.audioStartTimeoutMs);
+      this.assertLeaseCanContinue(lease, 'interrupted before audio start');
+      if (lease.playbackGeneration !== generation) {
+        return {
+          started: false,
+          completion: Promise.resolve(this.toPlaybackResult(
+            lease,
+            request,
+            false,
+            'audio generation superseded during start',
+            undefined,
+            true,
+          )),
+        };
+      }
+      if (this.deps.isAudioPlaying && !this.deps.isAudioPlaying(request.playbackKind)) {
+        throw new Error('audio playback did not enter playing state');
+      }
+
+      if (request.frameId) lease.frameId = request.frameId;
+      if (request.frameRevision !== undefined) lease.frameRevision = request.frameRevision;
+      if (request.operatorIds) lease.operatorIds = [...new Set(request.operatorIds)];
+      if (request.reason) lease.reason = request.reason;
+      const playback: MutablePhysicalPlayback = {
+        generation,
+        frameId: request.frameId ?? lease.frameId,
+        frameRevision: request.frameRevision ?? lease.frameRevision,
+        operatorIds: [...(request.operatorIds ?? lease.operatorIds)],
+        playbackKind: request.playbackKind,
+        completion: audioPromise,
+      };
+      lease.activePlayback = playback;
+      lease.phase = 'active';
+      this.emitPhase(lease);
+      return {
+        started: true,
+        completion: this.observePlaybackGeneration(lease, playback, request),
+      };
+    } catch (error) {
+      this.trackPendingOperation(audioPromise);
+      if (!lease.stopRequested) {
+        const stopPromise = Promise.resolve().then(
+          () => this.deps.stopCurrentPlayback({ kind: request.playbackKind }),
+        );
+        try {
+          await this.withTimeout(stopPromise, 'audio cleanup', this.cleanupTimeoutMs);
+        } catch {
+          this.trackPendingOperation(stopPromise);
+        }
+      }
+      return {
+        started: false,
+        completion: this.ensureReleased(lease, 'audio transmission failed', false, error),
+      };
+    }
+  }
+
+  private async observePlaybackGeneration(
+    lease: MutablePhysicalLease,
+    playback: MutablePhysicalPlayback,
+    request: PhysicalAudioPlaybackRequest,
+  ): Promise<PhysicalTxResult> {
+    try {
+      await playback.completion;
+    } catch (error) {
+      if (!this.isPlaybackCurrent(lease, playback)) {
+        this.discardStale(lease, `audio-generation-${playback.generation}-error`);
+        return this.toPlaybackResult(
+          lease,
+          playback,
+          false,
+          'audio generation replaced',
+          error,
+          true,
+        );
+      }
+      if (lease.stopRequested) {
+        return this.ensureReleased(lease, lease.reason || 'interrupted during playback', false, error);
+      }
+      if (!lease.stopRequested) {
+        const stopPromise = Promise.resolve().then(
+          () => this.deps.stopCurrentPlayback({ kind: playback.playbackKind }),
+        );
+        try {
+          await this.withTimeout(stopPromise, 'audio cleanup', this.cleanupTimeoutMs);
+        } catch {
+          this.trackPendingOperation(stopPromise);
+        }
+      }
+      return this.ensureReleased(lease, 'audio transmission failed', false, error);
+    }
+
+    if (!this.isPlaybackCurrent(lease, playback)) {
+      this.discardStale(lease, `audio-generation-${playback.generation}-complete`);
+      return this.toPlaybackResult(
+        lease,
+        playback,
+        false,
+        'audio generation replaced',
+        undefined,
+        true,
+      );
+    }
+    if (lease.stopRequested) {
+      return this.ensureReleased(lease, 'interrupted during playback', false);
+    }
+
+    lease.activePlayback = undefined;
+    lease.drainingGeneration = playback.generation;
+    lease.phase = 'draining';
+    this.emitPhase(lease);
+    if ((request.tailHoldMs ?? 0) > 0) {
+      await this.sleep(request.tailHoldMs!);
+    }
+    if (!this.isCurrent(lease)
+      || lease.playbackGeneration !== playback.generation
+      || lease.drainingGeneration !== playback.generation
+      || lease.activePlayback) {
+      this.discardStale(lease, `audio-generation-${playback.generation}-tail`);
+      return this.toPlaybackResult(
+        lease,
+        playback,
+        false,
+        'audio generation replaced during tail hold',
+        undefined,
+        true,
+      );
+    }
+    lease.drainingGeneration = undefined;
+    return this.ensureReleased(lease, 'audio completed', true);
+  }
+
+  private isPlaybackCurrent(lease: MutablePhysicalLease, playback: MutablePhysicalPlayback): boolean {
+    return this.isCurrent(lease)
+      && lease.playbackGeneration === playback.generation
+      && lease.activePlayback?.generation === playback.generation;
+  }
+
+  private toPlaybackResult(
+    lease: MutablePhysicalLease,
+    playback: PhysicalPlaybackIdentity,
+    success: boolean,
+    reason: string,
+    error?: unknown,
+    leaseContinues = false,
+  ): PhysicalTxResult {
+    return {
+      leaseId: lease.leaseId,
+      frameId: playback.frameId,
+      frameRevision: playback.frameRevision,
+      source: lease.source,
+      operatorIds: [...(playback.operatorIds ?? lease.operatorIds)],
+      success,
+      reason,
+      error: error instanceof Error ? error.message : error === undefined ? undefined : String(error),
+      physicalConfirmed: lease.everPttConfirmed,
+      leaseContinues: leaseContinues || undefined,
+    };
+  }
+
+  async releaseLease(leaseId: string, reason: string): Promise<PhysicalTxResult> {
+    const lease = this.requireCurrentLease(leaseId);
+    return this.ensureReleased(lease, reason, true);
+  }
+
+  markSelfKeyedLeaseActive(leaseId: string): void {
+    const lease = this.requireCurrentLease(leaseId);
+    if (lease.assertPtt) {
+      throw new Error('only self-keyed leases can be confirmed by their source');
+    }
+    if (lease.stopRequested) throw new PhysicalTxInterruptedError();
+    lease.pttConfirmed = true;
+    lease.everPttConfirmed = true;
+    lease.phase = 'active';
+    this.emitPhase(lease);
+  }
+
+  markStreamingLeaseActive(leaseId: string): void {
+    const lease = this.requireCurrentLease(leaseId);
+    if (!lease.assertPtt || !lease.pttConfirmed) {
+      throw new Error('streaming lease cannot become active before PTT is confirmed');
+    }
+    if (lease.stopRequested) throw new PhysicalTxInterruptedError();
+    lease.phase = 'active';
+    this.emitPhase(lease);
+  }
+
+  requestNormalStop(reason: string): 'idle' | 'deferred' {
+    const lease = this.activeLease;
+    if (!lease) return 'idle';
+    lease.reason = reason;
+    return 'deferred';
+  }
+
+  async forceInterrupt(reason: string): Promise<PhysicalTxResult | null> {
+    const lease = this.activeLease;
+    if (!lease) return null;
+    if (lease.releasePromise) return lease.releasePromise;
+
+    lease.stopRequested = true;
+    lease.reason = reason;
+    lease.phase = 'stopping';
+    this.emitPhase(lease);
+
+    const cleanupTasks: Promise<unknown>[] = [];
+    if (lease.interrupt) cleanupTasks.push(Promise.resolve().then(() => lease.interrupt!()));
+    if (lease.playbackKind) {
+      cleanupTasks.push(Promise.resolve().then(() => this.deps.stopCurrentPlayback({ kind: lease.playbackKind })));
+    }
+    let interruptError: unknown;
+    if (cleanupTasks.length > 0) {
+      let cleanupSettled = false;
+      const cleanupPromise = Promise.allSettled(cleanupTasks).then((results) => {
+        const rejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+        if (rejected) throw rejected.reason;
+      }).finally(() => {
+        cleanupSettled = true;
+      });
+      try {
+        await this.withTimeout(
+          cleanupPromise,
+          'source cleanup',
+          this.cleanupTimeoutMs,
+        );
+      } catch (error) {
+        interruptError = error;
+        if (!cleanupSettled) this.trackPendingOperation(cleanupPromise);
+      }
+    }
+    return this.ensureReleased(lease, reason, false, interruptError);
+  }
+
+  async forceInterruptLease(leaseId: string, reason: string): Promise<PhysicalTxResult | null> {
+    if (this.activeLease?.leaseId !== leaseId) {
+      return null;
+    }
+    return this.forceInterrupt(reason);
+  }
+
+  async retryUnknownStop(reason: string): Promise<PhysicalTxResult | null> {
+    const lease = this.activeLease;
+    if (!lease || lease.phase !== 'unknown') return null;
+    lease.releasePromise = undefined;
+    lease.stopRequested = true;
+    return this.ensureReleased(lease, reason, false);
+  }
+
+  private ensureReleased(
+    lease: MutablePhysicalLease,
+    reason: string,
+    success: boolean,
+    cause?: unknown,
+  ): Promise<PhysicalTxResult> {
+    if (lease.releasePromise) return lease.releasePromise;
+    lease.releasePromise = this.releaseInternal(lease, reason, success, cause);
+    return lease.releasePromise;
+  }
+
+  private async releaseInternal(
+    lease: MutablePhysicalLease,
+    reason: string,
+    success: boolean,
+    cause?: unknown,
+  ): Promise<PhysicalTxResult> {
+    lease.stopRequested = true;
+    this.rejectLeaseActivation(lease, new PhysicalTxInterruptedError(reason));
+    lease.phase = 'stopping';
+    this.emitPhaseIfCurrent(lease);
+
+    let pttReleaseError: unknown;
+    try {
+      if (lease.assertPtt && lease.pttStartPromise && !lease.pttConfirmed) {
+        try {
+          await this.withTimeout(lease.pttStartPromise, 'pending PTT start');
+          lease.pttConfirmed = true;
+          lease.everPttConfirmed = true;
+        } catch {
+          // A rejected start is safe once the explicit stop below succeeds. A
+          // timed-out start remains unsafe because its late completion is still
+          // fenced by pttStartSettlementPromise.
+        }
+      }
+      if (lease.assertPtt && (lease.pttStartPromise || lease.pttConfirmed)) {
+        let stopSettled = false;
+        const stopPromise = Promise.resolve().then(() => this.deps.setPTT(false));
+        void stopPromise.then(
+          () => { stopSettled = true; },
+          () => { stopSettled = true; },
+        );
+        try {
+          await this.withTimeout(stopPromise, 'PTT stop');
+        } catch (error) {
+          if (!stopSettled) this.trackPendingOperation(stopPromise);
+          throw error;
+        }
+      }
+      if (lease.pttStartSettlementPromise) {
+        await this.withTimeout(lease.pttStartSettlementPromise, 'pending PTT compensation');
+      }
+    } catch (error) {
+      pttReleaseError = error;
+    }
+
+    if (pttReleaseError) {
+      lease.phase = 'unknown';
+      lease.reason = `${reason}: PTT release unconfirmed`;
+      this.emitPhaseIfCurrent(lease);
+      const result = this.toResult(lease, false, lease.reason, pttReleaseError);
+      this.emitTerminalOnce(lease, result);
+      return result;
+    }
+
+    if (lease.dialOffsetSettlementPromise) {
+      const settlementPromise = lease.dialOffsetSettlementPromise;
+      try {
+        await this.withTimeout(settlementPromise, 'pending TX dial offset compensation');
+      } catch (error) {
+        // Do not immediately issue a second clear while the late native
+        // compensation is still settling. Expose unknown and require the
+        // explicit recovery path; otherwise a retry can race the old clear
+        // and make the dial state of a newer frame ambiguous.
+        lease.dialOffsetSettlementPromise = undefined;
+        this.trackPendingOperation(settlementPromise);
+        logger.warn('Deferred TX dial offset compensation did not settle cleanly', {
+          leaseId: lease.leaseId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        lease.phase = 'unknown';
+        lease.reason = `${reason}: TX dial offset cleanup unconfirmed`;
+        this.emitPhaseIfCurrent(lease);
+        const result = this.toResult(lease, false, lease.reason, error);
+        this.emitTerminalOnce(lease, result);
+        return result;
+      }
+    }
+
+    let dialCleanupError: unknown;
+    try {
+      let dialCleanupSettled = false;
+      const dialCleanupPromise = Promise.resolve().then(() => this.deps.clearTxDialOffset?.());
+      void dialCleanupPromise.then(
+        () => { dialCleanupSettled = true; },
+        () => { dialCleanupSettled = true; },
+      );
+      try {
+        await this.withTimeout(dialCleanupPromise, 'TX dial offset cleanup');
+      } catch (error) {
+        if (!dialCleanupSettled) this.trackPendingOperation(dialCleanupPromise);
+        throw error;
+      }
+      lease.dialOffsetApplied = false;
+    } catch (error) {
+      dialCleanupError = error;
+      logger.warn('Failed to clear TX dial offset after PTT release', {
+        leaseId: lease.leaseId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    if (dialCleanupError) {
+      lease.phase = 'unknown';
+      lease.reason = `${reason}: TX dial offset cleanup unconfirmed`;
+      this.emitPhaseIfCurrent(lease);
+      const result = this.toResult(lease, false, lease.reason, dialCleanupError);
+      this.emitTerminalOnce(lease, result);
+      return result;
+    }
+
+    lease.pttConfirmed = false;
+    lease.reason = reason;
+    const result = this.toResult(lease, success && !cause, reason, cause);
+    this.emitTerminalOnce(lease, result);
+    if (this.isCurrent(lease)) {
+      this.activeLease = null;
+      this.emit('phaseChanged', this.snapshot(null, reason));
+    }
+    return result;
+  }
+
+  private async handleLatePttStart(lease: MutablePhysicalLease): Promise<void> {
+    if (this.isCurrent(lease) && !lease.stopRequested) return;
+    this.discardStale(lease, 'ptt-start');
+    if (this.activeLease && !this.isCurrent(lease)) {
+      logger.error('Refusing stale PTT compensation while a newer lease is active', {
+        staleLeaseId: lease.leaseId,
+        activeLeaseId: this.activeLease.leaseId,
+      });
+      return;
+    }
+    try {
+      // Do not abandon the underlying stop after a timeout. A late hardware
+      // completion could otherwise turn off the next lease. The release path
+      // remains bounded and exposes unknown until this promise really settles.
+      await this.deps.setPTT(false);
+      if (this.isCurrent(lease) && lease.phase === 'unknown') {
+        lease.pttConfirmed = false;
+        const result = this.toResult(lease, false, 'late PTT start compensated');
+        this.emitTerminalOnce(lease, result);
+        this.activeLease = null;
+        this.emit('phaseChanged', this.snapshot(null, 'late PTT start compensated'));
+      }
+    } catch {
+      // Keep the lease unknown. A user/device recovery must retry the stop.
+    }
+  }
+
+  private requireCurrentLease(leaseId: string): MutablePhysicalLease {
+    const lease = this.activeLease;
+    if (!lease || lease.leaseId !== leaseId) {
+      throw new PhysicalTxInterruptedError('physical transmission lease is no longer current');
+    }
+    return lease;
+  }
+
+  private assertLeaseCanContinue(lease: MutablePhysicalLease, message: string): void {
+    if (!this.isCurrent(lease) || lease.stopRequested) {
+      throw new PhysicalTxInterruptedError(message);
+    }
+  }
+
+  private resolveLeaseActivation(lease: MutablePhysicalLease): void {
+    if (lease.activationSettled) return;
+    lease.activationSettled = true;
+    lease.resolveActivation();
+  }
+
+  private rejectLeaseActivation(lease: MutablePhysicalLease, error: unknown): void {
+    if (lease.activationSettled) return;
+    lease.activationSettled = true;
+    lease.rejectActivation(error);
+  }
+
+  private findLease(leaseId: string): MutablePhysicalLease | null {
+    return this.activeLease?.leaseId === leaseId ? this.activeLease : null;
+  }
+
+  private isCurrent(lease: MutablePhysicalLease): boolean {
+    return this.activeLease === lease && this.activeLease.epoch === lease.epoch;
+  }
+
+  private trackPendingOperation(operation: Promise<unknown>): void {
+    const fence = operation.then(() => undefined, () => undefined);
+    this.pendingOperationFences.add(fence);
+    void fence.finally(() => {
+      this.pendingOperationFences.delete(fence);
+    });
+  }
+
+  private emitPhase(lease: MutablePhysicalLease): void {
+    this.emit('phaseChanged', this.snapshot(lease));
+  }
+
+  private emitPhaseIfCurrent(lease: MutablePhysicalLease): void {
+    if (this.isCurrent(lease)) this.emitPhase(lease);
+  }
+
+  private emitTerminalOnce(lease: MutablePhysicalLease, result: PhysicalTxResult): void {
+    if (lease.terminalEmitted) return;
+    lease.terminalEmitted = true;
+    this.emit('terminal', result);
+  }
+
+  private discardStale(lease: MutablePhysicalLease, callback: string): void {
+    this.staleCallbackDiscardCount += 1;
+    this.emit('staleCallbackDiscarded', { leaseId: lease.leaseId, epoch: lease.epoch, callback });
+  }
+
+  private snapshot(lease: MutablePhysicalLease | null, reason?: string): PhysicalTxSnapshot {
+    if (!lease) {
+      return {
+        leaseId: null,
+        operatorIds: [],
+        phase: 'idle',
+        epoch: this.epoch,
+        playbackGeneration: 0,
+        pttConfirmed: false,
+        reason,
+      };
+    }
+    return {
+      leaseId: lease.leaseId,
+      frameId: lease.frameId,
+      frameRevision: lease.frameRevision,
+      source: lease.source,
+      operatorIds: [...lease.operatorIds],
+      phase: lease.phase,
+      epoch: lease.epoch,
+      playbackGeneration: lease.playbackGeneration,
+      pttConfirmed: lease.pttConfirmed,
+      startedAt: lease.startedAt,
+      reason: lease.reason,
+    };
+  }
+
+  private toResult(
+    lease: MutablePhysicalLease,
+    success: boolean,
+    reason: string,
+    error?: unknown,
+  ): PhysicalTxResult {
+    return {
+      leaseId: lease.leaseId,
+      frameId: lease.frameId,
+      frameRevision: lease.frameRevision,
+      source: lease.source,
+      operatorIds: [...lease.operatorIds],
+      success,
+      reason,
+      error: error instanceof Error ? error.message : error === undefined ? undefined : String(error),
+      physicalConfirmed: lease.everPttConfirmed,
+    };
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = this.operationTimeoutMs): Promise<T> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<T>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/packages/server/src/transmission/TargetReservationCoordinator.ts
+++ b/packages/server/src/transmission/TargetReservationCoordinator.ts
@@ -1,0 +1,77 @@
+import { normalizeCallsign } from '../utils/callsign.js';
+
+interface TargetReservation {
+  stationCallsign: string;
+  targetCallsign: string;
+  operatorId: string;
+  epoch: number;
+}
+
+function normalize(value: string): string {
+  const upper = value.trim().toUpperCase();
+  return normalizeCallsign(upper) || upper;
+}
+
+/** Atomic in-process ownership for targets shared by same-callsign operators. */
+export class TargetReservationCoordinator {
+  private readonly reservations = new Map<string, TargetReservation>();
+
+  isReservedByOther(stationCallsign: string, targetCallsign: string, operatorId: string): boolean {
+    const reservation = this.reservations.get(this.key(stationCallsign, targetCallsign));
+    return Boolean(reservation && reservation.operatorId !== operatorId);
+  }
+
+  tryTransition(input: {
+    stationCallsign: string;
+    targetCallsign?: string;
+    operatorId: string;
+    epoch: number;
+  }): boolean {
+    const stationCallsign = normalize(input.stationCallsign);
+    const targetCallsign = input.targetCallsign ? normalize(input.targetCallsign) : '';
+    if (!stationCallsign) return false;
+
+    if (targetCallsign) {
+      const targetKey = this.key(stationCallsign, targetCallsign);
+      const current = this.reservations.get(targetKey);
+      if (current && current.operatorId !== input.operatorId) return false;
+    }
+
+    for (const [key, reservation] of this.reservations) {
+      if (reservation.stationCallsign !== stationCallsign
+          || reservation.operatorId !== input.operatorId
+          || reservation.epoch > input.epoch) {
+        continue;
+      }
+      if (!targetCallsign || reservation.targetCallsign !== targetCallsign) {
+        this.reservations.delete(key);
+      }
+    }
+
+    if (targetCallsign) {
+      this.reservations.set(this.key(stationCallsign, targetCallsign), {
+        stationCallsign,
+        targetCallsign,
+        operatorId: input.operatorId,
+        epoch: input.epoch,
+      });
+    }
+    return true;
+  }
+
+  releaseOperator(operatorId: string, epoch = Number.MAX_SAFE_INTEGER): void {
+    for (const [key, reservation] of this.reservations) {
+      if (reservation.operatorId === operatorId && reservation.epoch <= epoch) {
+        this.reservations.delete(key);
+      }
+    }
+  }
+
+  clear(): void {
+    this.reservations.clear();
+  }
+
+  private key(stationCallsign: string, targetCallsign: string): string {
+    return `${normalize(stationCallsign)}\0${normalize(targetCallsign)}`;
+  }
+}

--- a/packages/server/src/transmission/TransmissionIntent.ts
+++ b/packages/server/src/transmission/TransmissionIntent.ts
@@ -1,0 +1,71 @@
+export type TransmissionIntentSource =
+  | 'standard-qso'
+  | 'plugin'
+  | 'late-decode'
+  | 'operator-edit'
+  | 'manual'
+  | 'persistence'
+  | 'device';
+
+export interface TransmissionIntent {
+  operatorId?: string;
+  source: TransmissionIntentSource;
+  reason: string;
+  slotId?: string;
+  text?: string;
+  decisionEpoch: number;
+  replacesFrameId?: string;
+}
+
+export type FramePhase =
+  | 'requested'
+  | 'encoding'
+  | 'ready'
+  | 'prepared'
+  | 'committed'
+  | 'on_air'
+  | 'draining'
+  | 'terminal'
+  | 'cancelled';
+
+export interface FrameLease {
+  frameId: string;
+  slotId: string;
+  participantOperatorIds: string[];
+  decisionEpoch: number;
+  revision: number;
+  phase: FramePhase;
+  terminalEmitted: boolean;
+  superseded: boolean;
+}
+
+export type PhysicalTxSource =
+  | 'digital'
+  | 'voice'
+  | 'voice-keyer'
+  | 'cw'
+  | 'tune-tone'
+  | 'manual'
+  | 'test';
+
+export type PhysicalTxPhase =
+  | 'idle'
+  | 'starting'
+  | 'active'
+  | 'draining'
+  | 'stopping'
+  | 'unknown';
+
+export interface PhysicalTxSnapshot {
+  leaseId: string | null;
+  frameId?: string;
+  frameRevision?: number;
+  source?: PhysicalTxSource;
+  operatorIds: string[];
+  phase: PhysicalTxPhase;
+  epoch: number;
+  playbackGeneration: number;
+  pttConfirmed: boolean;
+  startedAt?: number;
+  reason?: string;
+}

--- a/packages/server/src/transmission/__tests__/DigitalFrameCoordinator.test.ts
+++ b/packages/server/src/transmission/__tests__/DigitalFrameCoordinator.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DigitalFrameCoordinator } from '../DigitalFrameCoordinator.js';
+
+function createCoordinator() {
+  let id = 0;
+  return new DigitalFrameCoordinator({
+    idFactory: () => `frame-${++id}`,
+    physicalStartBudgetMs: 300,
+    tailHoldMs: 500,
+  });
+}
+
+function commitFrame(coordinator: DigitalFrameCoordinator, frameId: string): void {
+  expect(coordinator.prepareFrameForHandover(frameId)?.phase).toBe('prepared');
+  expect(coordinator.commitFrame(frameId)?.phase).toBe('committed');
+}
+
+describe('DigitalFrameCoordinator', () => {
+  it('tombstones a pre-commit frame and rejects its late encode callback', () => {
+    const coordinator = createCoordinator();
+    const terminal = vi.fn();
+    coordinator.on('terminal', terminal);
+
+    const first = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'initial', text: 'CQ A', decisionEpoch: 1 }],
+    });
+    coordinator.beginEncoding(first.frame!.frameId);
+
+    const replacement = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'late-decode', reason: 'late decode', text: 'B A R-10', decisionEpoch: 2 }],
+    });
+
+    expect(first.frame?.frameId).toBe('frame-1');
+    expect(replacement.frame?.frameId).toBe('frame-2');
+    expect(coordinator.getFrame('frame-1')).toMatchObject({ phase: 'cancelled', superseded: true });
+    expect(terminal).toHaveBeenCalledTimes(1);
+
+    expect(coordinator.acceptEncodeResult({
+      frameId: 'frame-1',
+      operatorId: 'a',
+      decisionEpoch: first.intents[0].decisionEpoch,
+      revision: first.frame!.revision,
+    })).toBe(false);
+    expect(coordinator.getStaleCallbackDiscardCount()).toBe(1);
+  });
+
+  it('freezes multiple operators into one frame and becomes ready only after all encodes', () => {
+    const coordinator = createCoordinator();
+    const prepared = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [
+        { operatorId: 'a', source: 'plugin', reason: 'slot', text: 'CQ A', decisionEpoch: 1 },
+        { operatorId: 'b', source: 'plugin', reason: 'slot', text: 'CQ B', decisionEpoch: 1 },
+      ],
+    });
+    const frame = prepared.frame!;
+    coordinator.beginEncoding(frame.frameId);
+
+    expect(coordinator.acceptEncodeResult({
+      frameId: frame.frameId,
+      operatorId: 'a',
+      decisionEpoch: prepared.intents[0].decisionEpoch,
+      revision: frame.revision,
+    })).toBe(true);
+    expect(coordinator.getFrame(frame.frameId)?.phase).toBe('encoding');
+
+    expect(coordinator.acceptEncodeResult({
+      frameId: frame.frameId,
+      operatorId: 'b',
+      decisionEpoch: prepared.intents[1].decisionEpoch,
+      revision: frame.revision,
+    })).toBe(true);
+    expect(coordinator.getFrame(frame.frameId)).toMatchObject({
+      phase: 'ready',
+      participantOperatorIds: ['a', 'b'],
+    });
+  });
+
+  it('restarts an on-air frame only when a complete replacement fits the slot', () => {
+    const coordinator = createCoordinator();
+    const first = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'initial', decisionEpoch: 1 }],
+    });
+    const frame = first.frame!;
+    coordinator.beginEncoding(frame.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: frame.frameId,
+      operatorId: 'a',
+      decisionEpoch: first.intents[0].decisionEpoch,
+      revision: frame.revision,
+    });
+    commitFrame(coordinator, frame.frameId);
+    coordinator.markOnAir(frame.frameId);
+
+    const restart = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'late-decode', reason: 'correction', decisionEpoch: 2 }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+    });
+    expect(restart.action).toBe('restart-current');
+    expect(restart.frame?.frameId).toBe('frame-2');
+    expect(coordinator.getFrame(frame.frameId)).toMatchObject({ phase: 'on_air', superseded: false });
+    expect(coordinator.getPhysicalFrameForSlot('slot-1')?.frameId).toBe(frame.frameId);
+    expect(coordinator.getCandidateFrameForSlot('slot-1')?.frameId).toBe('frame-2');
+  });
+
+  it('defers a late correction when a complete frame cannot fit', () => {
+    const coordinator = createCoordinator();
+    const first = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'initial', decisionEpoch: 1 }],
+    });
+    const frame = first.frame!;
+    coordinator.beginEncoding(frame.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: frame.frameId,
+      operatorId: 'a',
+      decisionEpoch: first.intents[0].decisionEpoch,
+      revision: frame.revision,
+    });
+    commitFrame(coordinator, frame.frameId);
+    coordinator.markOnAir(frame.frameId);
+
+    const deferred = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'late-decode', reason: 'too late', decisionEpoch: 2 }],
+      nowMs: 2_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+    });
+    expect(deferred.action).toBe('defer-next-slot');
+    expect(deferred.frame?.frameId).toBe(frame.frameId);
+    expect(coordinator.getFrame(frame.frameId)).toMatchObject({ phase: 'on_air', superseded: false });
+  });
+
+  it('rechecks the complete-frame budget after encoding and mixing delays', () => {
+    const coordinator = createCoordinator();
+    const prepared = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'late-decode', reason: 'correction', decisionEpoch: 1 }],
+      nowMs: 0,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+    });
+
+    expect(coordinator.hasCompleteFrameBudget(prepared.frame!.frameId, 1_000, 12_640)).toBe(true);
+    expect(coordinator.hasCompleteFrameBudget(prepared.frame!.frameId, 2_000, 12_640)).toBe(false);
+  });
+
+  it('accounts for the elapsed waveform when enabling TX mid-slot', () => {
+    const coordinator = createCoordinator();
+    const prepared = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'operator-edit', reason: 'TX enabled mid-slot', decisionEpoch: 1 }],
+      nowMs: 5_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+      playbackStartMs: 500,
+    });
+
+    expect(coordinator.getPlaybackOffsetMs(prepared.frame!.frameId, 5_000)).toBe(4_500);
+    expect(coordinator.hasCompleteFrameBudget(prepared.frame!.frameId, 5_000, 8_140)).toBe(true);
+  });
+
+  it('emits terminal exactly once and defers ordinary stop after commit', () => {
+    const coordinator = createCoordinator();
+    const terminal = vi.fn();
+    coordinator.on('terminal', terminal);
+    const prepared = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'initial', decisionEpoch: 1 }],
+    });
+    const frame = prepared.frame!;
+    coordinator.beginEncoding(frame.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: frame.frameId,
+      operatorId: 'a',
+      decisionEpoch: prepared.intents[0].decisionEpoch,
+      revision: frame.revision,
+    });
+    commitFrame(coordinator, frame.frameId);
+
+    expect(coordinator.requestStrategyStop('a', 'strategy complete')).toBe('deferred');
+    coordinator.markOnAir(frame.frameId);
+    coordinator.completeFrame(frame.frameId, 'audio complete');
+    coordinator.completeFrame(frame.frameId, 'duplicate callback');
+    expect(terminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives a ready replacement from retained encoded participants', () => {
+    const coordinator = createCoordinator();
+    const prepared = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [
+        { operatorId: 'a', source: 'plugin', reason: 'mixed frame', text: 'CQ A', decisionEpoch: 1 },
+        { operatorId: 'b', source: 'plugin', reason: 'mixed frame', text: 'CQ B', decisionEpoch: 1 },
+      ],
+      playbackStartMs: 500,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+    });
+    coordinator.beginEncoding(prepared.frame!.frameId);
+    prepared.intents.forEach((intent) => coordinator.acceptEncodeResult({
+      frameId: prepared.frame!.frameId,
+      operatorId: intent.operatorId!,
+      decisionEpoch: intent.decisionEpoch,
+      revision: prepared.frame!.revision,
+    }));
+    commitFrame(coordinator, prepared.frame!.frameId);
+    coordinator.markOnAir(prepared.frame!.frameId);
+
+    const removal = coordinator.prepareParticipantRemoval(
+      prepared.frame!.frameId,
+      'a',
+      'operator a stopped',
+    );
+
+    expect(removal).toMatchObject({
+      action: 'replace-current',
+      remainingOperatorIds: ['b'],
+      frame: {
+        frameId: 'frame-2',
+        revision: 2,
+        phase: 'ready',
+        participantOperatorIds: ['b'],
+      },
+    });
+    expect(coordinator.getFrame(prepared.frame!.frameId)).toMatchObject({
+      phase: 'on_air',
+      superseded: false,
+    });
+    expect(coordinator.getReplacedFrameId('frame-2')).toBe(prepared.frame!.frameId);
+    expect(coordinator.getPlaybackOffsetMs('frame-2', 4_500)).toBe(4_000);
+  });
+
+  it('tombstones unfinished frames when a new slot begins', () => {
+    const coordinator = createCoordinator();
+    const prepared = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'slow encode', text: 'CQ A', decisionEpoch: 1 }],
+    });
+    coordinator.beginEncoding(prepared.frame!.frameId);
+
+    const cancelled = coordinator.cancelPreCommitFramesOutsideSlot('slot-2', 'slot boundary');
+    expect(cancelled).toMatchObject([{ frameId: prepared.frame!.frameId, phase: 'cancelled' }]);
+    expect(coordinator.acceptEncodeResult({
+      frameId: prepared.frame!.frameId,
+      operatorId: 'a',
+      decisionEpoch: prepared.intents[0].decisionEpoch,
+      revision: prepared.frame!.revision,
+    })).toBe(false);
+  });
+
+  it('keeps the physical slot owner when a replacement candidate fails', () => {
+    const coordinator = createCoordinator();
+    const first = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'initial', text: 'CQ A', decisionEpoch: 1 }],
+      playbackStartMs: 500,
+    });
+    coordinator.beginEncoding(first.frame!.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: first.frame!.frameId,
+      operatorId: 'a',
+      decisionEpoch: first.intents[0].decisionEpoch,
+      revision: first.frame!.revision,
+    });
+    commitFrame(coordinator, first.frame!.frameId);
+    coordinator.markOnAir(first.frame!.frameId);
+
+    const failed = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'late-decode', reason: 'first correction', text: 'B A R-10', decisionEpoch: 2 }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+      playbackStartMs: 500,
+    });
+    coordinator.beginEncoding(failed.frame!.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: failed.frame!.frameId,
+      operatorId: 'a',
+      decisionEpoch: failed.intents[0].decisionEpoch,
+      revision: failed.frame!.revision,
+    });
+    coordinator.prepareFrameForHandover(failed.frame!.frameId);
+    coordinator.deferFrame(failed.frame!.frameId, 'candidate mix failed');
+
+    expect(coordinator.getPhysicalFrameForSlot('slot-1')).toMatchObject({
+      frameId: first.frame!.frameId,
+      phase: 'on_air',
+    });
+    expect(coordinator.getCandidateFrameForSlot('slot-1')).toBeNull();
+
+    const retry = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'late-decode', reason: 'retry correction', text: 'B A RR73', decisionEpoch: 3 }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+      playbackStartMs: 500,
+    });
+    expect(retry).toMatchObject({ action: 'restart-current', frame: { revision: 3 } });
+  });
+
+  it('cancels every pre-commit frame without touching the physical owner', () => {
+    const coordinator = createCoordinator();
+    const physical = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'plugin', reason: 'initial', text: 'CQ A', decisionEpoch: 1 }],
+      playbackStartMs: 500,
+    });
+    coordinator.beginEncoding(physical.frame!.frameId);
+    coordinator.acceptEncodeResult({
+      frameId: physical.frame!.frameId,
+      operatorId: 'a',
+      decisionEpoch: physical.intents[0].decisionEpoch,
+      revision: physical.frame!.revision,
+    });
+    commitFrame(coordinator, physical.frame!.frameId);
+    coordinator.markOnAir(physical.frame!.frameId);
+
+    const candidate = coordinator.prepareFrame({
+      slotId: 'slot-1',
+      intents: [{ operatorId: 'a', source: 'operator-edit', reason: 'edit', text: 'B A RR73', decisionEpoch: 2 }],
+      nowMs: 1_000,
+      slotEndMs: 15_000,
+      expectedDurationMs: 12_640,
+      playbackStartMs: 500,
+    });
+    coordinator.beginEncoding(candidate.frame!.frameId);
+
+    expect(coordinator.cancelAllPreCommitFrames('mode change')).toMatchObject([
+      { frameId: candidate.frame!.frameId, phase: 'cancelled' },
+    ]);
+    expect(coordinator.getPhysicalFrameForSlot('slot-1')).toMatchObject({
+      frameId: physical.frame!.frameId,
+      phase: 'on_air',
+    });
+  });
+});

--- a/packages/server/src/transmission/__tests__/OperatorIntentCoordinator.test.ts
+++ b/packages/server/src/transmission/__tests__/OperatorIntentCoordinator.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OperatorIntentCoordinator } from '../OperatorIntentCoordinator.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => { resolve = next; });
+  return { promise, resolve };
+}
+
+describe('OperatorIntentCoordinator', () => {
+  it('runs different operators independently', async () => {
+    const coordinator = new OperatorIntentCoordinator();
+    const a = deferred<string>();
+    const results: string[] = [];
+    const aRun = coordinator.submit('a', 'slot-auto', async () => {
+      results.push('a-start');
+      return a.promise;
+    });
+    const bRun = coordinator.submit('b', 'slot-auto', () => {
+      results.push('b');
+      return 'b-done';
+    });
+
+    await expect(bRun).resolves.toMatchObject({ status: 'completed', value: 'b-done' });
+    expect(results).toEqual(['a-start', 'b']);
+    a.resolve('a-done');
+    await expect(aRun).resolves.toMatchObject({ status: 'completed', value: 'a-done' });
+  });
+
+  it('coalesces automatic work and rejects stale completion', async () => {
+    const coordinator = new OperatorIntentCoordinator();
+    const first = deferred<string>();
+    const firstRun = coordinator.submit('a', 'slot-auto', () => first.promise);
+    const secondRun = coordinator.submit('a', 'slot-auto', () => 'latest');
+
+    first.resolve('stale');
+    await expect(firstRun).resolves.toMatchObject({ status: 'superseded' });
+    await expect(secondRun).resolves.toMatchObject({ status: 'completed', value: 'latest' });
+  });
+
+  it('lets a manual command revoke an automatic command before commit', async () => {
+    const coordinator = new OperatorIntentCoordinator();
+    const first = deferred<void>();
+    let automaticTokenCurrent = true;
+    const automatic = coordinator.submit('a', 'slot-auto', async (token, signal) => {
+      await first.promise;
+      automaticTokenCurrent = coordinator.isCurrent(token) && !signal.aborted;
+    });
+    const manual = coordinator.submit('a', 'manual', () => 'manual');
+
+    first.resolve();
+    await expect(automatic).resolves.toMatchObject({ status: 'superseded' });
+    await expect(manual).resolves.toMatchObject({ status: 'completed', value: 'manual' });
+    expect(automaticTokenCurrent).toBe(false);
+  });
+
+  it('continues after quarantining work that ignores abort', async () => {
+    vi.useFakeTimers();
+    const onAbortTimeout = vi.fn();
+    const coordinator = new OperatorIntentCoordinator({ abortGraceMs: 1_000, onAbortTimeout });
+    void coordinator.submit('a', 'slot-auto', () => new Promise(() => {}));
+    const manual = coordinator.submit('a', 'manual', () => 'manual');
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(manual).resolves.toMatchObject({ status: 'completed', value: 'manual' });
+    expect(onAbortTimeout).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/packages/server/src/transmission/__tests__/PhysicalTxCoordinator.test.ts
+++ b/packages/server/src/transmission/__tests__/PhysicalTxCoordinator.test.ts
@@ -1,0 +1,790 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PhysicalTxCoordinator } from '../PhysicalTxCoordinator.js';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createHarness(options: {
+  pttStart?: Promise<void>;
+  pttStop?: Promise<void>;
+  pttStopSequence?: Promise<void>[];
+  audioStop?: Promise<void>;
+  txDialStart?: Promise<unknown>;
+  txDialResult?: unknown;
+  clearTxDialOffset?: () => Promise<void>;
+  operationTimeoutMs?: number;
+  cleanupTimeoutMs?: number;
+  audioPreparation?: Promise<boolean>;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+} = {}) {
+  let playing = false;
+  let pttStopIndex = 0;
+  const audioDones = [deferred<void>()];
+  let playbackIndex = 0;
+  const setPTT = vi.fn(async (active: boolean) => {
+    if (active && options.pttStart) await options.pttStart;
+    if (!active) {
+      const stop = options.pttStopSequence?.[pttStopIndex++] ?? options.pttStop;
+      if (stop) await stop;
+    }
+  });
+  const playAudio = vi.fn((_audioData: Float32Array, _sampleRate: number, options?: { onPlaybackStarted?: () => void }) => {
+    const audio = audioDones[playbackIndex] ?? (audioDones[playbackIndex] = deferred<void>());
+    playbackIndex += 1;
+    playing = true;
+    options?.onPlaybackStarted?.();
+    return audio.promise.finally(() => {
+      if (playbackIndex <= 1 || audio === audioDones[playbackIndex - 1]) playing = false;
+    });
+  });
+  const stopCurrentPlayback = vi.fn(async () => {
+    if (options.audioStop) await options.audioStop;
+    playing = false;
+    audioDones[Math.max(0, playbackIndex - 1)].reject(new Error('playback interrupted'));
+    return 0;
+  });
+  const prepareAudioPlayback = vi.fn(async () => options.audioPreparation
+    ? options.audioPreparation
+    : false);
+  const coordinator = new PhysicalTxCoordinator({
+    isRadioConnected: () => true,
+    setPTT,
+    playAudio,
+    stopCurrentPlayback,
+    prepareAudioPlayback,
+    isAudioPlaying: () => playing,
+    setTxDialOffset: vi.fn(async () => options.txDialStart
+      ? options.txDialStart
+      : options.txDialResult),
+    clearTxDialOffset: options.clearTxDialOffset ?? vi.fn(async () => undefined),
+    now: options.now ?? (() => 0),
+    sleep: options.sleep ?? vi.fn(async () => undefined),
+  }, {
+    idFactory: (() => {
+      let id = 0;
+      return () => `lease-${++id}`;
+    })(),
+    operationTimeoutMs: options.operationTimeoutMs ?? 100,
+    cleanupTimeoutMs: options.cleanupTimeoutMs ?? 100,
+  });
+  return {
+    coordinator,
+    setPTT,
+    playAudio,
+    stopCurrentPlayback,
+    prepareAudioPlayback,
+    audio: audioDones[0],
+    getAudio: (index: number) => audioDones[index] ?? (audioDones[index] = deferred<void>()),
+  };
+}
+
+function preparedReplacement(
+  harness: ReturnType<typeof createHarness>,
+  input: {
+    frameId: string;
+    operatorIds: string[];
+    reason: string;
+    audioData?: Float32Array;
+    sampleRate?: number;
+    tailHoldMs?: number;
+    slotEndMs?: number;
+    waveformStartMs?: number;
+  },
+) {
+  const snapshot = harness.coordinator.getSnapshot();
+  return {
+    frameId: input.frameId,
+    operatorIds: input.operatorIds,
+    reason: input.reason,
+    playbackKind: 'digital' as const,
+    audioData: input.audioData ?? new Float32Array(12),
+    sampleRate: input.sampleRate ?? 12_000,
+    tailHoldMs: input.tailHoldMs,
+    waveformStartMs: input.waveformStartMs ?? 0,
+    slotEndMs: input.slotEndMs,
+    expectedLeaseEpoch: snapshot.epoch,
+    expectedPlaybackGeneration: snapshot.playbackGeneration,
+    expectedFrameId: snapshot.frameId,
+  };
+}
+
+describe('PhysicalTxCoordinator', () => {
+  it('fences every physical source while idle maintenance is running', async () => {
+    const operation = deferred<void>();
+    const harness = createHarness();
+    const maintenance = harness.coordinator.runIdleMaintenance(
+      { reason: 'scheduled band switch' },
+      () => operation.promise,
+    );
+
+    await expect(harness.coordinator.acquireLease({ source: 'voice', reason: 'voice PTT' }))
+      .rejects.toThrow('maintenance is active');
+    expect(harness.setPTT).not.toHaveBeenCalled();
+
+    operation.resolve();
+    await maintenance;
+    const leaseId = await harness.coordinator.acquireLease({ source: 'manual', reason: 'after maintenance' });
+    await harness.coordinator.releaseLease(leaseId, 'done');
+  });
+
+  it('rejects background maintenance without interrupting an active lease', async () => {
+    const harness = createHarness();
+    const leaseId = await harness.coordinator.acquireLease({ source: 'cw', reason: 'CW keyer' });
+    const operation = vi.fn(async () => undefined);
+
+    await expect(harness.coordinator.runIdleMaintenance(
+      { reason: 'scheduled band switch' },
+      operation,
+    )).rejects.toThrow('physical transmitter is active');
+    expect(operation).not.toHaveBeenCalled();
+    expect(harness.coordinator.getSnapshot()).toMatchObject({ leaseId, phase: 'active' });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    await harness.coordinator.releaseLease(leaseId, 'done');
+  });
+
+  it('waits for previous output drain before asserting PTT for an audio lease', async () => {
+    const audioPreparation = deferred<boolean>();
+    const harness = createHarness({ audioPreparation: audioPreparation.promise });
+
+    const transmission = harness.coordinator.transmitAudio({
+      source: 'digital',
+      frameId: 'frame-after-drain',
+      reason: 'replacement',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.prepareAudioPlayback).toHaveBeenCalledWith('digital'));
+
+    expect(harness.setPTT).not.toHaveBeenCalledWith(true);
+    expect(harness.playAudio).not.toHaveBeenCalled();
+
+    audioPreparation.resolve(true);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    harness.audio.resolve();
+    await expect(transmission).resolves.toMatchObject({ success: true });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('does not pulse PTT when audio output preparation fails', async () => {
+    const audioPreparation = deferred<boolean>();
+    const harness = createHarness({ audioPreparation: audioPreparation.promise });
+    const transmission = harness.coordinator.transmitAudio({
+      source: 'digital',
+      frameId: 'frame-drain-failed',
+      reason: 'replacement',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.prepareAudioPlayback).toHaveBeenCalledOnce());
+    audioPreparation.reject(new Error('RtAudio output drain timed out after 20ms'));
+
+    await expect(transmission).rejects.toThrow('audio output preparation failed');
+    expect(harness.setPTT).not.toHaveBeenCalled();
+    expect(harness.playAudio).not.toHaveBeenCalled();
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('publishes active only after PTT is confirmed and audio starts', async () => {
+    const harness = createHarness();
+    const phases: string[] = [];
+    const terminals = vi.fn();
+    harness.coordinator.on('phaseChanged', (snapshot) => phases.push(snapshot.phase));
+    harness.coordinator.on('terminal', terminals);
+
+    const transmission = harness.coordinator.transmitAudio({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'slot',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+      tailHoldMs: 500,
+    });
+
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    expect(phases).toEqual(['starting', 'active']);
+    harness.audio.resolve();
+    const result = await transmission;
+
+    expect(result).toMatchObject({ success: true, physicalConfirmed: true, frameId: 'frame-1' });
+    expect(phases).toEqual(['starting', 'active', 'draining', 'stopping', 'idle']);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(terminals).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces digital audio generations without releasing the physical PTT lease', async () => {
+    const harness = createHarness();
+    const leaseId = await harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a', 'b'],
+      reason: 'mixed frame',
+      playbackKind: 'digital',
+      deferActiveUntilAudio: true,
+    });
+    const first = harness.coordinator.playAudioOnLease(leaseId, {
+      frameId: 'frame-1',
+      operatorIds: ['a', 'b'],
+      reason: 'initial audio',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    const replacement = harness.coordinator.replaceAudioOnLease(leaseId, preparedReplacement(harness, {
+      frameId: 'frame-2',
+      operatorIds: ['b'],
+      reason: 'operator a removed',
+      audioData: new Float32Array(8),
+    }));
+
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+    await expect(first).resolves.toMatchObject({
+      success: false,
+      frameId: 'frame-1',
+      leaseContinues: true,
+    });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.coordinator.getSnapshot()).toMatchObject({
+      leaseId,
+      frameId: 'frame-2',
+      operatorIds: ['b'],
+      phase: 'active',
+      pttConfirmed: true,
+    });
+
+    harness.getAudio(1).resolve();
+    await expect(replacement).resolves.toMatchObject({ success: true, frameId: 'frame-2' });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('drains the stopped output and resynchronizes prepared audio before replacing on the same lease', async () => {
+    let nowMs = 1_000;
+    const outputDrain = deferred<boolean>();
+    const harness = createHarness({ now: () => nowMs });
+    const leaseId = await harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'initial audio',
+      playbackKind: 'digital',
+      deferActiveUntilAudio: true,
+    });
+    const first = harness.coordinator.playAudioOnLease(leaseId, {
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      audioData: new Float32Array(12_000),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    harness.prepareAudioPlayback.mockReturnValueOnce(outputDrain.promise);
+    const replacement = harness.coordinator.replaceAudioOnLease(leaseId, preparedReplacement(harness, {
+      frameId: 'frame-2',
+      operatorIds: ['a'],
+      reason: 'frequency changed on air',
+      audioData: new Float32Array(12_000),
+      sampleRate: 12_000,
+      waveformStartMs: nowMs,
+      slotEndMs: 5_000,
+    }));
+
+    await vi.waitFor(() => expect(harness.stopCurrentPlayback).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(harness.prepareAudioPlayback).toHaveBeenCalledTimes(2));
+    expect(harness.playAudio).toHaveBeenCalledTimes(1);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+
+    nowMs = 1_250;
+    outputDrain.resolve(true);
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+    expect(harness.playAudio.mock.calls[1]?.[0]).toHaveLength(9_000);
+    await expect(first).resolves.toMatchObject({ frameId: 'frame-1', leaseContinues: true });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+
+    harness.getAudio(1).resolve();
+    await expect(replacement).resolves.toMatchObject({ frameId: 'frame-2', success: true });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('releases PTT exactly once when replacement output drain fails after handover commit', async () => {
+    const harness = createHarness();
+    const terminals = vi.fn();
+    harness.coordinator.on('terminal', terminals);
+    const leaseId = await harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'initial audio',
+      playbackKind: 'digital',
+      deferActiveUntilAudio: true,
+    });
+    const first = harness.coordinator.playAudioOnLease(leaseId, {
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      audioData: new Float32Array(12_000),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledOnce());
+
+    harness.prepareAudioPlayback.mockRejectedValueOnce(
+      new Error('RtAudio output drain timed out after 20ms'),
+    );
+    const replacement = harness.coordinator.replaceAudioOnLease(leaseId, preparedReplacement(harness, {
+      frameId: 'frame-2',
+      operatorIds: ['a'],
+      reason: 'frequency changed on air',
+      audioData: new Float32Array(12_000),
+      sampleRate: 12_000,
+    }));
+
+    await expect(first).resolves.toMatchObject({ frameId: 'frame-1', leaseContinues: true });
+    await expect(replacement).resolves.toMatchObject({
+      frameId: 'frame-1',
+      success: false,
+      error: expect.stringContaining('audio output preparation failed'),
+    });
+    expect(harness.playAudio).toHaveBeenCalledTimes(1);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(terminals).toHaveBeenCalledTimes(1);
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('lets a replacement take ownership while the same PTT lease is still starting', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({
+      pttStart: pttStart.promise,
+      operationTimeoutMs: 5_000,
+    });
+    const acquiring = harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'slow PTT start',
+      playbackKind: 'digital',
+      deferActiveUntilAudio: true,
+    });
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    const leaseId = harness.coordinator.getSnapshot().leaseId!;
+    const replacement = harness.coordinator.replaceAudioOnLease(leaseId, preparedReplacement(harness, {
+      frameId: 'frame-2',
+      operatorIds: ['a'],
+      reason: 'correction arrived during PTT start',
+      audioData: new Float32Array(8),
+    }));
+    expect(harness.playAudio).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(harness.coordinator.getSnapshot()).toMatchObject({
+        leaseId,
+        frameId: 'frame-1',
+        phase: 'starting',
+        pttConfirmed: false,
+      });
+    });
+
+    pttStart.resolve();
+    await acquiring;
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.coordinator.getSnapshot()).toMatchObject({
+      frameId: 'frame-2',
+      phase: 'active',
+      pttConfirmed: true,
+    });
+
+    harness.audio.resolve();
+    await expect(replacement).resolves.toMatchObject({ success: true });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('does not start replacement audio after a force interrupt wins during remix', async () => {
+    const audioStop = deferred<void>();
+    const harness = createHarness({ audioStop: audioStop.promise });
+    const leaseId = await harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'initial',
+      playbackKind: 'digital',
+      deferActiveUntilAudio: true,
+    });
+    const first = harness.coordinator.playAudioOnLease(leaseId, {
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    const replacement = harness.coordinator.replaceAudioOnLease(leaseId, preparedReplacement(harness, {
+      frameId: 'frame-2',
+      operatorIds: ['a'],
+      reason: 'handover interrupted after old audio stop began',
+      audioData: new Float32Array(8),
+    }));
+    await vi.waitFor(() => expect(harness.stopCurrentPlayback).toHaveBeenCalled());
+
+    const forced = harness.coordinator.forceInterrupt('emergency during remix');
+    audioStop.resolve();
+
+    await expect(first).resolves.toMatchObject({ leaseContinues: true });
+    await expect(replacement).resolves.toMatchObject({ success: false });
+    await expect(forced).resolves.toMatchObject({ success: false });
+    expect(harness.playAudio).toHaveBeenCalledTimes(1);
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('does not let an old tail-hold generation release a replacement generation', async () => {
+    const oldTail = deferred<void>();
+    let sleepCalls = 0;
+    const harness = createHarness({
+      sleep: async () => {
+        sleepCalls += 1;
+        if (sleepCalls === 1) await oldTail.promise;
+      },
+    });
+    const leaseId = await harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      frameRevision: 1,
+      operatorIds: ['a'],
+      reason: 'initial',
+      playbackKind: 'digital',
+      deferActiveUntilAudio: true,
+    });
+    const first = harness.coordinator.playAudioOnLease(leaseId, {
+      frameId: 'frame-1',
+      frameRevision: 1,
+      operatorIds: ['a'],
+      reason: 'initial audio',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+      tailHoldMs: 500,
+    });
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+    harness.audio.resolve();
+    await vi.waitFor(() => expect(harness.coordinator.getSnapshot().phase).toBe('draining'));
+
+    const replacement = harness.coordinator.replaceAudioOnLease(leaseId, preparedReplacement(harness, {
+      frameId: 'frame-2',
+      operatorIds: ['a'],
+      reason: 'replacement during old tail hold',
+      audioData: new Float32Array(8),
+    }));
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(2));
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.coordinator.getSnapshot()).toMatchObject({
+      frameId: 'frame-2',
+      playbackGeneration: 2,
+      phase: 'active',
+    });
+
+    oldTail.resolve();
+    await expect(first).resolves.toMatchObject({
+      frameId: 'frame-1',
+      frameRevision: 1,
+      success: false,
+      leaseContinues: true,
+    });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true]);
+    expect(harness.coordinator.getSnapshot()).toMatchObject({ frameId: 'frame-2', phase: 'active' });
+
+    harness.getAudio(1).resolve();
+    await expect(replacement).resolves.toMatchObject({ frameId: 'frame-2', success: true });
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('bounds a playback backend that never acknowledges its first write', async () => {
+    const stopCurrentPlayback = vi.fn(async () => 0);
+    const setPTT = vi.fn(async (_active: boolean) => undefined);
+    const coordinator = new PhysicalTxCoordinator({
+      isRadioConnected: () => true,
+      setPTT,
+      playAudio: vi.fn(() => new Promise<void>(() => undefined)),
+      stopCurrentPlayback,
+    }, {
+      idFactory: () => 'lease-audio-start-timeout',
+      operationTimeoutMs: 100,
+      audioStartTimeoutMs: 20,
+    });
+
+    await expect(coordinator.transmitAudio({
+      source: 'digital',
+      frameId: 'frame-audio-start-timeout',
+      reason: 'slot',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    })).resolves.toMatchObject({ success: false, physicalConfirmed: true });
+
+    expect(stopCurrentPlayback).toHaveBeenCalledWith({ kind: 'digital' });
+    expect(setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+    expect(coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('does not let an ordinary stop preempt the protected starting phase', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({ pttStart: pttStart.promise });
+    const acquiring = harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'slot',
+    });
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+
+    expect(harness.coordinator.requestNormalStop('strategy stop')).toBe('deferred');
+    expect(harness.setPTT).not.toHaveBeenCalledWith(false);
+
+    pttStart.resolve();
+    const leaseId = await acquiring;
+    expect(harness.coordinator.getSnapshot().phase).toBe('active');
+    await harness.coordinator.releaseLease(leaseId, 'frame complete');
+    expect(harness.setPTT.mock.calls.map(([active]) => active)).toEqual([true, false]);
+  });
+
+  it('compensates a late PTT start when force interrupt happens during starting', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({ pttStart: pttStart.promise });
+    const phases: string[] = [];
+    harness.coordinator.on('phaseChanged', (snapshot) => phases.push(snapshot.phase));
+
+    const acquiring = harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      operatorIds: ['a'],
+      reason: 'slot',
+    });
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    const forced = harness.coordinator.forceInterrupt('emergency');
+    pttStart.resolve();
+
+    await expect(acquiring).rejects.toThrow('interrupted');
+    const result = await forced;
+    expect(result?.success).toBe(false);
+    expect(harness.setPTT.mock.calls.filter(([active]) => !active).length).toBeGreaterThanOrEqual(1);
+    expect(phases).not.toContain('active');
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('does not assert PTT after force interrupt wins during pre-start work', async () => {
+    const beforeStart = deferred<void>();
+    const harness = createHarness();
+    const acquiring = harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      reason: 'delayed device preparation',
+      beforeStart: () => beforeStart.promise,
+    });
+    await vi.waitFor(() => expect(harness.coordinator.getSnapshot().phase).toBe('starting'));
+
+    const forced = harness.coordinator.forceInterrupt('shutdown');
+    beforeStart.resolve();
+
+    await expect(acquiring).rejects.toThrow('interrupted');
+    await forced;
+    expect(harness.setPTT).not.toHaveBeenCalledWith(true);
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('keeps a late PTT compensation fenced before allowing the next lease', async () => {
+    const pttStart = deferred<void>();
+    const pttStop = deferred<void>();
+    const harness = createHarness({
+      pttStart: pttStart.promise,
+      pttStop: pttStop.promise,
+      operationTimeoutMs: 250,
+    });
+    const acquiring = harness.coordinator.acquireLease({
+      source: 'digital',
+      frameId: 'frame-1',
+      reason: 'old frame',
+    });
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    const forced = harness.coordinator.forceInterrupt('replace old frame');
+    pttStart.resolve();
+
+    await expect(acquiring).rejects.toThrow('interrupted');
+    await expect(forced).resolves.toMatchObject({ success: false });
+    expect(harness.coordinator.getSnapshot().phase).toBe('unknown');
+    await expect(harness.coordinator.acquireLease({ source: 'manual', reason: 'too early' }))
+      .rejects.toThrow('busy');
+
+    pttStop.resolve();
+    await vi.waitFor(() => expect(harness.coordinator.getSnapshot().phase).toBe('idle'));
+    const nextLease = await harness.coordinator.acquireLease({ source: 'manual', reason: 'new lease' });
+    expect(harness.setPTT.mock.calls.at(-1)).toEqual([true]);
+    await Promise.resolve();
+    expect(harness.setPTT.mock.calls.at(-1)).toEqual([true]);
+    await harness.coordinator.releaseLease(nextLease, 'done');
+  });
+
+  it('continues to PTT-off when source cleanup never settles', async () => {
+    const audioStop = deferred<void>();
+    const harness = createHarness({ audioStop: audioStop.promise, cleanupTimeoutMs: 20 });
+    const transmission = harness.coordinator.transmitAudio({
+      source: 'digital',
+      frameId: 'frame-1',
+      reason: 'slot',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(harness.playAudio).toHaveBeenCalledTimes(1));
+
+    const result = await harness.coordinator.forceInterrupt('emergency');
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining('source cleanup timed out') });
+    expect(harness.setPTT).toHaveBeenCalledWith(false);
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+    await expect(harness.coordinator.acquireLease({ source: 'manual', reason: 'too early' }))
+      .rejects.toThrow('cleanup is still settling');
+
+    audioStop.resolve();
+    harness.audio.resolve();
+    await expect(transmission).resolves.toMatchObject({ success: false });
+    await vi.waitFor(async () => {
+      const leaseId = await harness.coordinator.acquireLease({ source: 'manual', reason: 'cleanup settled' });
+      await harness.coordinator.releaseLease(leaseId, 'done');
+    });
+  });
+
+  it('reports unknown when dial-offset cleanup fails after PTT-off', async () => {
+    const harness = createHarness({
+      clearTxDialOffset: vi.fn().mockRejectedValue(new Error('CAT cleanup failed')),
+    });
+    const leaseId = await harness.coordinator.acquireLease({ source: 'manual', reason: 'manual PTT' });
+    const result = await harness.coordinator.releaseLease(leaseId, 'manual release');
+
+    expect(result).toMatchObject({ success: false, physicalConfirmed: true });
+    expect(result.reason).toContain('TX dial offset cleanup unconfirmed');
+    expect(harness.coordinator.getSnapshot().phase).toBe('unknown');
+    await expect(harness.coordinator.acquireLease({ source: 'manual', reason: 'unsafe retry' }))
+      .rejects.toThrow('physical transmitter is busy');
+  });
+
+  it('returns to idle when PTT start rejects and an explicit stop succeeds', async () => {
+    const pttStart = deferred<void>();
+    const harness = createHarness({ pttStart: pttStart.promise });
+    const acquiring = harness.coordinator.acquireLease({ source: 'digital', reason: 'slot' });
+    await vi.waitFor(() => expect(harness.setPTT).toHaveBeenCalledWith(true));
+    pttStart.reject(new Error('radio rejected PTT'));
+
+    await expect(acquiring).rejects.toThrow('radio rejected PTT');
+    expect(harness.setPTT).toHaveBeenCalledWith(false);
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('does not assert PTT when a required dial offset was not applied', async () => {
+    const harness = createHarness({ txDialResult: false });
+
+    await expect(harness.coordinator.acquireLease({
+      source: 'digital',
+      reason: 'shifted frame',
+      txDialShiftHz: 681,
+    })).rejects.toThrow('TX dial offset was not applied');
+
+    expect(harness.setPTT).not.toHaveBeenCalledWith(true);
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('allows self-keyed leases without a CAT connection', async () => {
+    const setPTT = vi.fn(async () => undefined);
+    const coordinator = new PhysicalTxCoordinator({
+      isRadioConnected: () => false,
+      setPTT,
+      playAudio: vi.fn(async () => undefined),
+      stopCurrentPlayback: vi.fn(async () => 0),
+    }, { idFactory: () => 'self-keyed-lease' });
+
+    const leaseId = await coordinator.acquireLease({
+      source: 'cw',
+      reason: 'serial keyer owns RF',
+      assertPtt: false,
+    });
+    expect(coordinator.getSnapshot()).toMatchObject({ leaseId, phase: 'active', pttConfirmed: false });
+    await coordinator.releaseLease(leaseId, 'keyer complete');
+    expect(setPTT).not.toHaveBeenCalled();
+  });
+
+  it('can retry a failed late dial-offset compensation', async () => {
+    const dialStart = deferred<boolean>();
+    const clearTxDialOffset = vi.fn()
+      .mockRejectedValueOnce(new Error('late compensation failed'))
+      .mockResolvedValue(undefined);
+    const harness = createHarness({
+      txDialStart: dialStart.promise,
+      clearTxDialOffset,
+      operationTimeoutMs: 50,
+    });
+    const acquiring = harness.coordinator.acquireLease({
+      source: 'digital',
+      reason: 'delayed dial setup',
+      txDialShiftHz: 681,
+    });
+    await vi.waitFor(() => expect(harness.coordinator.getSnapshot().phase).toBe('starting'));
+    const forced = harness.coordinator.forceInterrupt('shutdown during dial setup');
+    dialStart.resolve(true);
+
+    await expect(acquiring).rejects.toThrow('interrupted');
+    await expect(forced).resolves.toMatchObject({ success: false });
+    expect(harness.coordinator.getSnapshot().phase).toBe('unknown');
+
+    const retryResult = await harness.coordinator.retryUnknownStop('retry dial cleanup');
+    expect(retryResult).toMatchObject({ success: false });
+    expect(clearTxDialOffset).toHaveBeenCalledTimes(2);
+    expect(harness.coordinator.getSnapshot().phase).toBe('idle');
+  });
+
+  it('keeps the state unknown when PTT release cannot be confirmed', async () => {
+    const pttStop = deferred<void>();
+    const harness = createHarness({ pttStop: pttStop.promise });
+    const leaseId = await harness.coordinator.acquireLease({
+      source: 'manual',
+      reason: 'manual PTT',
+    });
+
+    const result = await harness.coordinator.releaseLease(leaseId, 'manual release');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('PTT stop timed out');
+    expect(harness.coordinator.getSnapshot()).toMatchObject({ phase: 'unknown', pttConfirmed: true });
+  });
+
+  it('does not let an old audio completion close a newer lease', async () => {
+    const first = createHarness();
+    const oldTransmission = first.coordinator.transmitAudio({
+      source: 'digital',
+      frameId: 'frame-1',
+      reason: 'old',
+      audioData: new Float32Array(12),
+      sampleRate: 12_000,
+      playbackKind: 'digital',
+    });
+    await vi.waitFor(() => expect(first.playAudio).toHaveBeenCalledTimes(1));
+    await first.coordinator.forceInterrupt('replace complete frame');
+    await expect(oldTransmission).resolves.toMatchObject({ success: false });
+
+    const secondLease = await first.coordinator.acquireLease({
+      source: 'manual',
+      reason: 'new lease',
+    });
+    expect(first.coordinator.getSnapshot()).toMatchObject({ leaseId: secondLease, phase: 'active' });
+    await Promise.resolve();
+    expect(first.coordinator.getSnapshot()).toMatchObject({ leaseId: secondLease, phase: 'active' });
+    await first.coordinator.releaseLease(secondLease, 'done');
+  });
+});

--- a/packages/server/src/transmission/__tests__/TargetReservationCoordinator.test.ts
+++ b/packages/server/src/transmission/__tests__/TargetReservationCoordinator.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { TargetReservationCoordinator } from '../TargetReservationCoordinator.js';
+
+describe('TargetReservationCoordinator', () => {
+  it('atomically assigns one same-station operator per target', () => {
+    const coordinator = new TargetReservationCoordinator();
+    expect(coordinator.tryTransition({
+      stationCallsign: 'BI7ALG', targetCallsign: 'BG4JLJ', operatorId: 'op-a', epoch: 1,
+    })).toBe(true);
+    expect(coordinator.tryTransition({
+      stationCallsign: 'BI7ALG', targetCallsign: 'BG4JLJ', operatorId: 'op-b', epoch: 1,
+    })).toBe(false);
+    expect(coordinator.isReservedByOther('BI7ALG', 'BG4JLJ', 'op-b')).toBe(true);
+  });
+
+  it('does not let an old epoch release a newer reservation', () => {
+    const coordinator = new TargetReservationCoordinator();
+    coordinator.tryTransition({
+      stationCallsign: 'BI7ALG', targetCallsign: 'BG4JLJ', operatorId: 'op-a', epoch: 2,
+    });
+    coordinator.releaseOperator('op-a', 1);
+    expect(coordinator.isReservedByOther('BI7ALG', 'BG4JLJ', 'op-b')).toBe(true);
+  });
+});

--- a/packages/server/src/voice/VoiceKeyerManager.ts
+++ b/packages/server/src/voice/VoiceKeyerManager.ts
@@ -222,7 +222,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     });
 
     try {
-      await this.deps.audioStreamManager.stopCurrentPlayback();
+      await this.deps.audioStreamManager.stopCurrentPlayback({ kind: 'voice-keyer' });
     } catch {
       // stopCurrentPlayback may report that no complete clip is active; PTT cleanup below is authoritative.
     }
@@ -356,7 +356,7 @@ export class VoiceKeyerManager extends EventEmitter<VoiceKeyerManagerEvents> {
     this.setStatus(this.statusFor(active, 'repeat-waiting', null));
 
     try {
-      await this.deps.audioStreamManager.stopCurrentPlayback();
+      await this.deps.audioStreamManager.stopCurrentPlayback({ kind: 'voice-keyer' });
     } catch {
       // The lead-in/tail path may not have an audio clip in flight yet.
     }

--- a/packages/server/src/voice/VoiceSessionManager.ts
+++ b/packages/server/src/voice/VoiceSessionManager.ts
@@ -3,6 +3,7 @@ import type { VoicePTTLock } from '@tx5dr/contracts';
 import { VoicePTTLockManager } from './VoicePTTLockManager.js';
 import type { PhysicalRadioManager } from '../radio/PhysicalRadioManager.js';
 import type { AudioStreamManager } from '../audio/AudioStreamManager.js';
+import type { PhysicalTxCoordinator } from '../transmission/PhysicalTxCoordinator.js';
 import { ConfigManager } from '../config/config-manager.js';
 import { createLogger } from '../utils/logger.js';
 import {
@@ -24,6 +25,7 @@ export interface VoiceSessionManagerDeps {
   radioManager: PhysicalRadioManager;
   audioStreamManager: AudioStreamManager;
   onBeforeStartPTT?: () => Promise<void>;
+  physicalTxCoordinator: PhysicalTxCoordinator;
 }
 
 /**
@@ -36,6 +38,8 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
   private audioStreamManager: AudioStreamManager;
   private isStarted = false;
   private diagnostics = new VoiceTxDiagnostics();
+  private physicalLeaseId: string | null = null;
+  private transmitGeneration = 0;
 
   constructor(private readonly deps: VoiceSessionManagerDeps) {
     super();
@@ -106,14 +110,36 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
     }
 
     try {
+      const transmitGeneration = ++this.transmitGeneration;
       this.audioStreamManager.clearVoicePlaybackQueue();
       this.audioStreamManager.setVoiceTxOutputEnabled(false);
       this.diagnostics.startSession(clientId, label);
 
-      // 2. Activate radio PTT
-      await this.deps.onBeforeStartPTT?.();
-      await this.radioManager.setPTT(true);
+      // 2. Acquire the single physical PTT lease.
+      const leaseId = await this.deps.physicalTxCoordinator.acquireLease({
+        source: this.getPttSource(clientId),
+        reason: `voice transmit: ${label}`,
+        beforeStart: this.deps.onBeforeStartPTT,
+        deferActiveUntilAudio: true,
+        interrupt: async () => {
+          this.audioStreamManager.setVoiceTxOutputEnabled(false);
+          this.audioStreamManager.clearVoicePlaybackQueue();
+          if (this.getPttSource(clientId) === 'voice-keyer') {
+            await this.audioStreamManager.stopCurrentPlayback({ kind: 'voice-keyer' });
+          }
+        },
+      });
+      if (this.transmitGeneration !== transmitGeneration
+        || this.pttLockManager.getLockHolder() !== clientId) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          leaseId,
+          'voice transmission cancelled while starting',
+        );
+        return { success: false, reason: 'Voice transmission was cancelled while starting' };
+      }
+      this.physicalLeaseId = leaseId;
       this.audioStreamManager.setVoiceTxOutputEnabled(true);
+      this.deps.physicalTxCoordinator.markStreamingLeaseActive(leaseId);
 
       // 3. Broadcast PTT status (frontend handles monitor muting via gain node)
       this.emit('pttStatusChanged', { isTransmitting: true, operatorIds: [], source: this.getPttSource(clientId) });
@@ -123,7 +149,13 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
     } catch (err) {
       // Rollback on failure
       logger.error('Failed to start voice transmission, rolling back', err);
-      try { await this.radioManager.setPTT(false); } catch { /* best effort */ }
+      if (this.physicalLeaseId) {
+        await this.deps.physicalTxCoordinator.forceInterruptLease(
+          this.physicalLeaseId,
+          'voice start rollback',
+        ).catch(() => undefined);
+        this.physicalLeaseId = null;
+      }
       this.pttLockManager.releaseLock(clientId);
       this.audioStreamManager.setVoiceTxOutputEnabled(false);
       this.audioStreamManager.clearVoicePlaybackQueue();
@@ -274,11 +306,19 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
   // ---- Private helpers ----
 
   private async stopTransmitInternal(reason: string): Promise<void> {
-    // 1. Deactivate radio PTT
-    try {
-      await this.radioManager.setPTT(false);
-    } catch (err) {
-      logger.error('Failed to deactivate radio PTT', err);
+    ++this.transmitGeneration;
+    // 1. Release only the lease owned by this voice session.
+    let pttStillUncertain = false;
+    if (this.physicalLeaseId) {
+      try {
+        const result = await this.deps.physicalTxCoordinator.releaseLease(this.physicalLeaseId, reason);
+        pttStillUncertain = !result.success
+          && this.deps.physicalTxCoordinator.getSnapshot().phase === 'unknown';
+        if (!pttStillUncertain) this.physicalLeaseId = null;
+      } catch (err) {
+        pttStillUncertain = this.deps.physicalTxCoordinator.getSnapshot().phase === 'unknown';
+        logger.error('Failed to release voice PTT lease', err);
+      }
     }
 
     this.audioStreamManager.setVoiceTxOutputEnabled(false);
@@ -287,7 +327,7 @@ export class VoiceSessionManager extends EventEmitter<VoiceSessionManagerEvents>
 
     // 2. Broadcast PTT status (frontend handles monitor unmuting via gain node)
     this.emit('pttStatusChanged', {
-      isTransmitting: false,
+      isTransmitting: pttStillUncertain,
       operatorIds: [],
       source: this.getPttSource(this.pttLockManager.getLockHolder()),
     });

--- a/packages/server/src/voice/__tests__/VoiceSessionManager.radioMode.test.ts
+++ b/packages/server/src/voice/__tests__/VoiceSessionManager.radioMode.test.ts
@@ -15,6 +15,7 @@ function createManager(supportedModes: string[]) {
   const manager = new VoiceSessionManager({
     radioManager: radioManager as never,
     audioStreamManager: audioStreamManager as never,
+    physicalTxCoordinator: {} as never,
   });
 
   return { manager, radioManager };

--- a/packages/server/src/websocket/WSServer.ts
+++ b/packages/server/src/websocket/WSServer.ts
@@ -1374,7 +1374,11 @@ export class WSServer extends WSMessageHandler {
             } as SlotInfo,
           }
         : this.digitalRadioEngine.getSlotPackManager().getLastMessageFromCallsign(callsign, operatorId);
-      this.digitalRadioEngine.pluginManager.requestCall(operatorId, callsign, lastMessage);
+      this.digitalRadioEngine.pluginManager.requestCall(operatorId, callsign, lastMessage, {
+        submitCurrentFrame: true,
+        source: 'operator-edit',
+        reason: 'UI requestCall updated operator context',
+      });
       this.digitalRadioEngine.operatorManager.emitOperatorStatusUpdate(operatorId);
     } catch (error) {
       this.handleCommandError(error, 'operatorRequestCall');

--- a/packages/web/src/components/radio/automation/AutomationSettingsPanel.test.ts
+++ b/packages/web/src/components/radio/automation/AutomationSettingsPanel.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import type { PluginStatus } from '@tx5dr/contracts';
 import { pluginMatchesAutomationFilter } from './automationFilters';
 
-function createPlugin(permissions: PluginStatus['permissions'] = []): PluginStatus {
+function createPlugin(
+  permissions: PluginStatus['permissions'] = [],
+  capabilities: PluginStatus['capabilities'] = [],
+): PluginStatus {
   return {
     name: 'test-plugin',
     type: 'utility',
@@ -14,6 +17,7 @@ function createPlugin(permissions: PluginStatus['permissions'] = []): PluginStat
     autoDisabled: false,
     errorCount: 0,
     permissions,
+    capabilities,
   };
 }
 
@@ -23,7 +27,14 @@ describe('AutomationSettingsPanel filtering', () => {
   });
 
   it('keeps only transmit-control plugins in the operator auto-call popover', () => {
-    expect(pluginMatchesAutomationFilter(createPlugin(['operator:transmit-control']), 'transmit-control')).toBe(true);
+    expect(pluginMatchesAutomationFilter(
+      createPlugin(['operator:transmit-control'], ['auto_call_control']),
+      'transmit-control',
+    )).toBe(true);
+    expect(pluginMatchesAutomationFilter(
+      createPlugin(['network', 'operator:transmit-control']),
+      'transmit-control',
+    )).toBe(false);
     expect(pluginMatchesAutomationFilter(createPlugin(['network']), 'transmit-control')).toBe(false);
     expect(pluginMatchesAutomationFilter(createPlugin(), 'transmit-control')).toBe(false);
   });

--- a/packages/web/src/components/radio/automation/automationFilters.ts
+++ b/packages/web/src/components/radio/automation/automationFilters.ts
@@ -7,7 +7,8 @@ export function pluginMatchesAutomationFilter(
   filter: AutomationPanelFilter = 'all',
 ): boolean {
   if (filter === 'transmit-control') {
-    return plugin.permissions?.includes('operator:transmit-control') ?? false;
+    return (plugin.permissions?.includes('operator:transmit-control') ?? false)
+      && (plugin.capabilities?.includes('auto_call_control') ?? false);
   }
   return true;
 }

--- a/packages/web/src/components/radio/digital/MyRelatedFramesTable.tsx
+++ b/packages/web/src/components/radio/digital/MyRelatedFramesTable.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import type { WSSelectedFrame } from '@tx5dr/contracts';
 import { useTranslation } from 'react-i18next';
 import { FramesTable, type FrameDisplayMessage, type FrameGroup } from './FramesTable';
+import { resolveFrameCallsign } from './frameCallsign';
 import {
   useConnection,
   useCurrentOperatorId,
@@ -81,8 +82,9 @@ export const MyRelatedFramesTable: React.FC<MyRelatedFT8TableProps> = ({ classNa
   };
 
   const handleRowDoubleClick = (message: FrameDisplayMessage, group: FrameGroup) => {
-    const callsign = message.logbookAnalysis?.callsign;
-    if (!currentOperatorId || !callsign || activeOperatorCallsigns.includes(callsign)) {
+    const callsign = resolveFrameCallsign(message);
+    const ownCallsigns = new Set(activeOperatorCallsigns.map((call) => call.toUpperCase()));
+    if (!currentOperatorId || !callsign || ownCallsigns.has(callsign.toUpperCase())) {
       return;
     }
 

--- a/packages/web/src/components/radio/digital/SlotPacksMessageDisplay.tsx
+++ b/packages/web/src/components/radio/digital/SlotPacksMessageDisplay.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { FramesTable, FrameGroup, FrameDisplayMessage } from './FramesTable';
+import { resolveFrameCallsign } from './frameCallsign';
 import { parseFT8LocationInfo, FT8MessageParser, evaluateCallsignFilter, evaluateDxccBlocklist, getBandFromFrequency, CycleUtils, resolveGridLocation } from '@tx5dr/core';
 import { useConnection, useCurrentOperatorId, useMyRelatedTimeline, useRadioState, useSlotPacks } from '../../../store/radioStore';
 import type { FrameMessage, WSSelectedFrame } from '@tx5dr/contracts';
@@ -187,8 +188,9 @@ export const SlotPacksMessageDisplay: React.FC<SlotPacksMessageDisplayProps> = (
   };
 
   const handleRowDoubleClick = (message: FrameDisplayMessage, _group: FrameGroup) => {
-    const callsign = message.logbookAnalysis?.callsign;
-    if (currentOperatorId && callsign && !getMyCallsigns().includes(callsign)) {
+    const callsign = resolveFrameCallsign(message);
+    const ownCallsigns = new Set(getMyCallsigns().map((call) => call.toUpperCase()));
+    if (currentOperatorId && callsign && !ownCallsigns.has(callsign.toUpperCase())) {
       myRelatedTimeline.seedSelectedRx({
         message,
         group: _group,

--- a/packages/web/src/components/radio/digital/frameCallsign.test.ts
+++ b/packages/web/src/components/radio/digital/frameCallsign.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFrameCallsign } from './frameCallsign';
+
+describe('resolveFrameCallsign', () => {
+  it('uses the decoded sender when logbook analysis is unavailable', () => {
+    expect(resolveFrameCallsign({ message: 'CQ JA1ABC PM95' })).toBe('JA1ABC');
+    expect(resolveFrameCallsign({ message: 'BG5DRB JA1ABC -10' })).toBe('JA1ABC');
+  });
+
+  it('prefers the server analysis identity when present', () => {
+    expect(resolveFrameCallsign({
+      message: 'CQ JA1ABC PM95',
+      logbookAnalysis: { callsign: 'JA1ABC/P' },
+    })).toBe('JA1ABC/P');
+  });
+
+  it('does not turn an undecoded placeholder into an actionable target', () => {
+    expect(resolveFrameCallsign({ message: '<...> BG5DRB RR73' })).toBeUndefined();
+    expect(resolveFrameCallsign({ message: 'NOT AN FT8 MESSAGE' })).toBeUndefined();
+  });
+});

--- a/packages/web/src/components/radio/digital/frameCallsign.ts
+++ b/packages/web/src/components/radio/digital/frameCallsign.ts
@@ -1,0 +1,23 @@
+import { FT8MessageParser } from '@tx5dr/core';
+
+export interface FrameCallsignSource {
+  message: string;
+  logbookAnalysis?: { callsign?: string };
+}
+
+/** Resolve only a structured sender; never guess an RF target from raw tokens. */
+export function resolveFrameCallsign(frame: FrameCallsignSource): string | undefined {
+  const analyzedCallsign = frame.logbookAnalysis?.callsign?.trim();
+  if (analyzedCallsign) return analyzedCallsign;
+
+  try {
+    const parsed = FT8MessageParser.parseMessage(frame.message);
+    if (parsed && 'senderCallsign' in parsed && typeof parsed.senderCallsign === 'string') {
+      const callsign = parsed.senderCallsign.trim();
+      return callsign || undefined;
+    }
+  } catch {
+    // Malformed and free-text rows are intentionally not actionable.
+  }
+  return undefined;
+}

--- a/packages/web/src/components/radio/operators/RadioOperator.autocall.test.ts
+++ b/packages/web/src/components/radio/operators/RadioOperator.autocall.test.ts
@@ -27,6 +27,7 @@ describe('RadioOperator auto-call indicator', () => {
     expect(hasActiveTransmitControlPlugin([
       createPlugin({
         permissions: ['operator:transmit-control'],
+        capabilities: ['auto_call_control'],
         autoCallEnabledOperatorIds: ['operator-1'],
       }),
     ], 'operator-1')).toBe(true);
@@ -34,6 +35,7 @@ describe('RadioOperator auto-call indicator', () => {
     expect(hasActiveTransmitControlPlugin([
       createPlugin({
         permissions: ['operator:transmit-control'],
+        capabilities: ['auto_call_control'],
         autoCallEnabledOperatorIds: ['operator-2'],
       }),
     ], 'operator-1')).toBe(false);
@@ -50,6 +52,7 @@ describe('RadioOperator auto-call indicator', () => {
     const activePlugin = createPlugin({
       name: 'active-autocall',
       permissions: ['operator:transmit-control'],
+      capabilities: ['auto_call_control'],
       autoCallEnabledOperatorIds: ['operator-1'],
     });
     const plugins = [
@@ -57,6 +60,7 @@ describe('RadioOperator auto-call indicator', () => {
       createPlugin({
         name: 'other-operator',
         permissions: ['operator:transmit-control'],
+        capabilities: ['auto_call_control'],
         autoCallEnabledOperatorIds: ['operator-2'],
       }),
       createPlugin({
@@ -73,6 +77,7 @@ describe('RadioOperator auto-call indicator', () => {
     const pausedPlugin = createPlugin({
       name: 'paused-autocall',
       permissions: ['operator:transmit-control'],
+      capabilities: ['auto_call_control'],
       autoCallEnabledOperatorIds: ['operator-1'],
       pausedOperatorIds: ['operator-1'],
     });
@@ -80,5 +85,17 @@ describe('RadioOperator auto-call indicator', () => {
     expect(getActiveTransmitControlPlugins([pausedPlugin], 'operator-1')).toEqual([]);
     expect(hasActiveTransmitControlPlugin([pausedPlugin], 'operator-1')).toBe(false);
     expect(getPausedTransmitControlPlugins([pausedPlugin], 'operator-1')).toEqual([pausedPlugin]);
+  });
+
+  it('does not classify an integration with operator commands as an auto-call plugin', () => {
+    const udpIntegration = createPlugin({
+      name: 'qso-udp-broadcast',
+      permissions: ['network', 'operator:transmit-control'],
+      autoCallEnabledOperatorIds: ['operator-1'],
+      pausedOperatorIds: ['operator-1'],
+    });
+
+    expect(getActiveTransmitControlPlugins([udpIntegration], 'operator-1')).toEqual([]);
+    expect(getPausedTransmitControlPlugins([udpIntegration], 'operator-1')).toEqual([]);
   });
 });

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -16,6 +16,7 @@ import {
   getRadioOperatorProgressAnimation,
   shouldRadioOperatorPropsBeEqual,
 } from './radioOperatorProgress';
+import { resolveRadioOperatorCyclePresentation } from './radioOperatorPresentation';
 import {
   OPERATOR_FORCE_STOP_REQUESTED_EVENT,
   type OperatorForceStopRequestedDetail,
@@ -688,13 +689,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
     setOperatorTransmitCycles(transmitCycles);
   };
 
-  // 获取当前发射内容
-  const getCurrentTransmissionContent = () => {
-    if (operatorStatus.slots && operatorStatus.currentSlot) {
-      return operatorStatus.slots[operatorStatus.currentSlot as keyof typeof operatorStatus.slots] || '';
-    }
-    return '';
-  };
+  const cyclePresentation = resolveRadioOperatorCyclePresentation(
+    operatorStatus,
+    currentSlotInfo,
+    isCurrentTransmitCycle,
+  );
 
   // 处理立即停止发射：移除当前操作员的音频并重混音
   const handleForceStop = () => {
@@ -703,22 +702,6 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       connection.state.radioService.removeOperatorFromTransmission(operatorStatus.id);
       setIsForceStopPopoverOpen(false);
     }
-  };
-
-  // 获取进度条颜色 - 颜色变化用 CSS transition 平滑过渡
-  const getProgressColor = (): string => {
-    if (!currentSlotInfo) {
-      return 'var(--ft8-cycle-even-bg)';
-    }
-
-    const isActuallyTransmitting = operatorStatus.isInActivePTT === true;
-
-    if (isActuallyTransmitting) {
-      return 'hsl(var(--heroui-danger) / 0.15)';
-    }
-
-    const isEvenCycle = CycleUtils.isEvenCycle(currentSlotInfo.cycleNumber);
-    return isEvenCycle ? 'var(--ft8-cycle-even-bg)' : 'var(--ft8-cycle-odd-bg)';
   };
 
   // 进度条动画由全局 slotStart 驱动，operatorStatusUpdate 不会重置周期进度。
@@ -933,7 +916,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
         {radio.state.isDecoding && (
           <div
             className="absolute inset-0 transition-colors duration-200"
-            style={{ backgroundColor: getProgressColor() }}
+            style={{ backgroundColor: cyclePresentation.progressColor }}
           />
         )}
         {/* 进度条遮罩层 - 仅在解码时显示 */}
@@ -966,16 +949,9 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
                 );
               }
 
-              const isActuallyTransmitting = operatorStatus.isInActivePTT === true;
-              const isPreparingTransmission = operatorStatus.isTransmitting && isCurrentTransmitCycle;
-
-              return isActuallyTransmitting ? (
+              return cyclePresentation.isTransmit ? (
                 <div className="font-bold font-mono text-lg text-danger">
-                  {getCurrentTransmissionContent() || t('operator.preparingTx')}
-                </div>
-              ) : isPreparingTransmission ? (
-                <div className="font-bold font-mono text-lg text-foreground opacity-65">
-                  {t('operator.preparingTx')}
+                  {cyclePresentation.transmitContent || t('operator.preparingTx')}
                 </div>
               ) : (
                 <div className="text-foreground opacity-65 font-bold font-mono text-lg">

--- a/packages/web/src/components/radio/operators/__tests__/RadioOperator.test.ts
+++ b/packages/web/src/components/radio/operators/__tests__/RadioOperator.test.ts
@@ -6,6 +6,7 @@ import {
   shouldRadioOperatorPropsBeEqual,
 } from '../radioOperatorProgress';
 import { pickManualIdleFrequency } from '../radioOperatorIdleFrequency';
+import { resolveRadioOperatorCyclePresentation } from '../radioOperatorPresentation';
 
 function createOperatorStatus(overrides: Partial<OperatorStatus> = {}): OperatorStatus {
   return {
@@ -113,6 +114,51 @@ describe('RadioOperator memo comparison', () => {
     const next = createOperatorStatus({ transmitCycles: [1] });
 
     expect(shouldRadioOperatorPropsBeEqual(prev, next)).toBe(false);
+  });
+});
+
+describe('RadioOperator transmit content', () => {
+  it('uses one TX presentation before physical PTT becomes active', () => {
+    const operator = createOperatorStatus({
+      isTransmitting: true,
+      isInActivePTT: false,
+      currentSlot: 'TX6',
+      slots: { TX6: 'CQ BG5DRB PM01' },
+    });
+    const presentation = resolveRadioOperatorCyclePresentation(
+      operator,
+      createSlotInfo({ cycleNumber: 42 }),
+      true,
+    );
+
+    expect(presentation).toEqual({
+      isTransmit: true,
+      transmitContent: 'CQ BG5DRB PM01',
+      progressColor: 'hsl(var(--heroui-danger) / 0.15)',
+    });
+  });
+
+  it('keeps the preparing fallback available when no transmit text exists', () => {
+    const operator = createOperatorStatus({
+      currentSlot: 'TX5',
+      slots: { TX5: '' },
+    });
+
+    expect(resolveRadioOperatorCyclePresentation(operator, createSlotInfo(), true).transmitContent)
+      .toBe('');
+  });
+
+  it('uses the normal cycle presentation outside the operator TX cycle', () => {
+    const operator = createOperatorStatus({
+      isTransmitting: true,
+      isInActivePTT: false,
+    });
+    const slotInfo = createSlotInfo({ cycleNumber: 42 });
+
+    expect(resolveRadioOperatorCyclePresentation(operator, slotInfo, false)).toMatchObject({
+      isTransmit: false,
+      progressColor: 'var(--ft8-cycle-even-bg)',
+    });
   });
 });
 

--- a/packages/web/src/components/radio/operators/radioOperatorAutomation.ts
+++ b/packages/web/src/components/radio/operators/radioOperatorAutomation.ts
@@ -1,7 +1,8 @@
 import type { PluginStatus } from '@tx5dr/contracts';
 
 export function isTransmitControlPlugin(plugin: PluginStatus): boolean {
-  return plugin.permissions?.includes('operator:transmit-control') ?? false;
+  return (plugin.permissions?.includes('operator:transmit-control') ?? false)
+    && (plugin.capabilities?.includes('auto_call_control') ?? false);
 }
 
 export function isTransmitControlPluginAutoCallEnabled(plugin: PluginStatus, operatorId: string): boolean {

--- a/packages/web/src/components/radio/operators/radioOperatorPresentation.ts
+++ b/packages/web/src/components/radio/operators/radioOperatorPresentation.ts
@@ -1,0 +1,38 @@
+import type { OperatorStatus, SlotInfo } from '@tx5dr/contracts';
+import { CycleUtils } from '@tx5dr/core';
+
+export interface RadioOperatorCyclePresentation {
+  isTransmit: boolean;
+  transmitContent: string;
+  progressColor: string;
+}
+
+export function resolveRadioOperatorCyclePresentation(
+  operatorStatus: OperatorStatus,
+  slotInfo: SlotInfo | null | undefined,
+  isCurrentTransmitCycle: boolean,
+): RadioOperatorCyclePresentation {
+  const isTransmit = operatorStatus.isInActivePTT === true
+    || (operatorStatus.isTransmitting && isCurrentTransmitCycle);
+  const transmitContent = operatorStatus.slots && operatorStatus.currentSlot
+    ? operatorStatus.slots[
+      operatorStatus.currentSlot as keyof NonNullable<OperatorStatus['slots']>
+    ] || ''
+    : '';
+
+  if (isTransmit) {
+    return {
+      isTransmit,
+      transmitContent,
+      progressColor: 'hsl(var(--heroui-danger) / 0.15)',
+    };
+  }
+
+  return {
+    isTransmit,
+    transmitContent,
+    progressColor: !slotInfo || CycleUtils.isEvenCycle(slotInfo.cycleNumber)
+      ? 'var(--ft8-cycle-even-bg)'
+      : 'var(--ft8-cycle-odd-bg)',
+  };
+}

--- a/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
+++ b/packages/web/src/components/radio/profile/RadioDeviceSettings.tsx
@@ -437,7 +437,7 @@ export const RadioDeviceSettings = forwardRef<RadioDeviceSettingsRef, RadioDevic
         </div>
         <Select
           label={t('radio.digitalModeRadioModeLabel')}
-          selectedKeys={[config.digitalModeRadioMode ?? 'none']}
+          selectedKeys={[config.digitalModeRadioMode ?? 'usb']}
           onSelectionChange={(keys) => {
             const selected = Array.from(keys)[0] as DigitalModeRadioModePreference | undefined;
             if (!selected) return;

--- a/packages/web/src/store/radio/myRelatedTimeline.ts
+++ b/packages/web/src/store/radio/myRelatedTimeline.ts
@@ -54,6 +54,11 @@ export interface MyRelatedTimelineState {
 
 export interface MyRelatedTransmissionLog {
   operatorId: string;
+  frameId?: string;
+  revision?: number;
+  playbackGeneration?: number;
+  phase?: 'on_air';
+  physicalConfirmed?: true;
   myCallsign?: string;
   headerContextKey?: string;
   time: string;

--- a/packages/web/src/store/radio/provider.tsx
+++ b/packages/web/src/store/radio/provider.tsx
@@ -446,6 +446,14 @@ export const RadioProvider = ({ children }: { children: ReactNode }) => {
 
     const wsClient = radioService.wsClientInstance;
     const handleTransmissionLog = (data: MyRelatedTransmissionLog) => {
+      if (data?.phase !== 'on_air' || data?.physicalConfirmed !== true) {
+        logger.warn('Ignoring transmissionLog without physical on-air confirmation', {
+          operatorId: data?.operatorId,
+          frameId: data?.frameId,
+          phase: data?.phase,
+        });
+        return;
+      }
       if (!isValidTimestampMs(data?.slotStartMs)) {
         logger.warn('Ignoring invalid transmissionLog payload', {
           operatorId: data?.operatorId,

--- a/packages/web/src/store/radio/reducers.ts
+++ b/packages/web/src/store/radio/reducers.ts
@@ -409,7 +409,10 @@ export function radioReducer(state: RadioState, action: RadioAction): RadioState
         ...state,
         pttStatus: {
           isTransmitting: action.payload.isTransmitting,
-          operatorIds: action.payload.operatorIds
+          operatorIds: action.payload.operatorIds,
+          phase: action.payload.phase,
+          frameId: action.payload.frameId,
+          source: action.payload.source,
         }
       };
 

--- a/packages/web/src/store/radio/types.ts
+++ b/packages/web/src/store/radio/types.ts
@@ -33,6 +33,7 @@ import type {
   SlotInfo,
   TuneToneStatus,
   CWKeyerStatus,
+  PTTStatus,
   CWKeyerConfig,
 } from '@tx5dr/contracts';
 import { RadioConnectionStatus } from '@tx5dr/contracts';
@@ -69,10 +70,7 @@ export interface RadioState {
   radioConnectionStatus: RadioConnectionStatus;
   radioInfo: RadioInfo | null;
   radioConfig: HamlibConfig;
-  pttStatus: {
-    isTransmitting: boolean;
-    operatorIds: string[];
-  };
+  pttStatus: PTTStatus;
   tuneToneStatus: TuneToneStatus;
   meterData: MeterData | null;
   hasReceivedMeterData: boolean;
@@ -169,7 +167,7 @@ export type RadioAction =
   | { type: 'operatorStatusUpdate'; payload: OperatorStatus }
   | { type: 'setCurrentOperator'; payload: string | null }
   | { type: 'radioStatusUpdate'; payload: { radioConnected: boolean; status: RadioConnectionStatus; radioInfo: RadioInfo | null; radioConfig?: HamlibConfig; radioConnectionHealth?: ConnectionHealthInfo; reconnectProgress?: ReconnectProgress | null; coreCapabilities?: CoreRadioCapabilities; coreCapabilityDiagnostics?: CoreCapabilityDiagnostics; meterCapabilities?: MeterCapabilities; tunerCapabilities?: TunerCapabilities } }
-  | { type: 'pttStatusChanged'; payload: { isTransmitting: boolean; operatorIds: string[] } }
+  | { type: 'pttStatusChanged'; payload: PTTStatus }
   | { type: 'tuneToneStatusChanged'; payload: TuneToneStatus }
   | { type: 'meterData'; payload: MeterData }
   | { type: 'squelchStatusChanged'; payload: SquelchStatus }

--- a/scripts/dev-runtime.js
+++ b/scripts/dev-runtime.js
@@ -78,7 +78,15 @@ async function startTurbo() {
   console.log(`[dev-runtime] Server ready file: ${serverReadyFile}`);
   console.log(`[dev-runtime] rtc-data-audio UDP port: ${process.env.RTC_DATA_AUDIO_UDP_PORT || '50110'}`);
 
-  const args = ['turbo', 'run', 'dev', '--parallel', '--filter=!@tx5dr/client-tools'];
+  // Preserve Turbo's dependency graph so workspace packages are built before
+  // the server imports their dist entrypoints.
+  const args = [
+    'turbo',
+    'run',
+    'dev',
+    '--concurrency=20',
+    '--filter=!@tx5dr/client-tools',
+  ];
   if (mode === 'web') {
     args.push('--filter=!@tx5dr/electron-main');
   }


### PR DESCRIPTION
## 背景

这次重构来自连续多轮真实设备事故与回归：

- RR73/73 偶发显示正在发射但电台未真正发射，或刚进入 TX 就立即退出；
- 晚到解码、人工双击消息、中途改频率和多操作员移除会触发非事务重混音，旧播放完成回调可能误关新 generation 的 PTT；
- 日志持久化失败或延迟曾与 RF 停止语义耦合，已提交帧可能被业务回调截断；
- CW / FT8 / Voice 模式切换会销毁并重建电台连接，CAT operating state 可能在断线窗口中丢失；
- UI、SlotPack 历史和策略 runtime 曾分别维护“正在发射”的事实，导致排队、编码和真实 on-air 状态混淆。

本 PR 将数字帧、物理 PTT、操作员命令、插件决策和 QSO durability 拆成独立生命周期，并通过明确的 epoch / revision / generation 收敛所有旧异步回调。

## 核心架构

### 事务化数字帧与物理发射

- 新增 `DigitalFrameCoordinator`、`PhysicalTxCoordinator`、`OperatorIntentCoordinator` 和 `TargetReservationCoordinator`。
- 明确区分 physical frame、candidate frame 与 next-slot intent；candidate 在实际 audio-start acknowledgement 前不会覆盖 physical owner。
- 引入 frame revision、host command epoch、playback generation、tail/drain token 和 terminal-once 约束。
- replacement 使用两阶段 handover：编码、完整混音、输出准备和预算检查全部在停止旧音频前完成；临界区内只执行波形切片和新播放启动。
- 旧 generation 的 completion、tail hold 或 drain 回调无法释放已经被新 generation 接管的 PTT lease。
- `transmissionLog` 收窄为物理 audio start 后的 on-air 事实；queued / encoding / ready 只作为 phase telemetry。

### Frame-scoped 音频与多操作员行为

- 新增 `FrameAudioRepository`，音轨按 `frameId + revision + operatorId` 隔离。
- `AudioMixer` 改为对不可变 frame snapshot 进行纯混音，不再维护隐式 current frame 或决定业务停止。
- 多操作员共享一个物理帧：移除或修改单个操作员时整体重建 mixed frame；只有最后一个 contribution 被移除时才释放 PTT。
- 周期中开启 TX、人工双击消息、晚到解码和发射中改音频频率，都从当前完整波形进度进行安全 handover，不产生半截局部混音。
- fake-frequency 与频率变更绑定 frame revision，candidate 失败不会污染旧 physical frame 的音轨或索引。

### 决策、插件和 QSO 生命周期

- Plugin API 升级到 v2：strategy runtime 使用 checkpoint / restore、AbortSignal 和声明式 decision result。
- 新增 capability 派生 context 和 `PluginInvocationGuard`；插件 timeout、reload、disable 或 shutdown 后的旧 continuation 会被撤销。
- 内置 transmit-control 插件迁移到统一 host intent，定时切波段通过 physical-idle maintenance API 执行。
- Standard QSO completion 从 speculative state transition 移到 committed effect。
- QSO lifecycle generation 贯穿 decision、record、persistence、unsaved attempt 和 completion notification；旧 QSO Promise 不能暂停或重置新的 runtime。
- durability 失败只暂停下一次自动化并保留 unsaved attempt，不截断已经 committed / on-air 的 RF 帧。
- 修正插件能力识别：QSO UDP 广播等非起呼插件不再出现在“自动起呼已暂停”的列表中。
- 保留声明式 capability 开放机制，插件需要显式声明相关能力后才获得对应接口；本 PR 的发布阻塞范围以自带插件完整迁移为准。

### 物理电台会话与模式 runtime 解耦

- `EngineLifecycle` 将 mode runtime 停止与完整 engine / CAT 断开分离。
- 普通 CW -> FT8 -> Voice -> FT4 切换复用同一 `PhysicalRadioManager` connection generation，不再通过断开重连完成模式切换。
- 模式切换进入 maintenance gate，先确认 PTT-off，再在同一 radio session mutation queue 内应用目标 operating state 并启动候选 runtime。
- runtime 启动失败时恢复旧 runtime 与旧 operating state；Profile、Power、显式断开、真实掉线和 shutdown 仍保持完整断开语义。
- reconnect 后统一恢复当前已提交模式的 frequency / mode / split 等 operating state。
- 旧配置缺少 `digitalModeRadioMode` 时迁移为 `usb`；显式 `none` 仍保持“不写 CAT mode、不告警”。
- 不修改 Hamlib、ICOM WLAN、TCI 的底层协议实现。

### UI、事件与开发体验

- TX 周期内操作员卡片统一显示红色进度条和红色加粗的最终发送内容；全局描边继续表示真实 PTT。
- UI 不再把 queued / encoding 显示为 on-air，物理状态未知时也不会伪装成 RX。
- WebSocket 命令支持可关联回执；旧 Android 请求缺少 `requestId` 时仍可执行。
- 修正开发模式 Turbo persistent task concurrency，恢复 `yarn dev:electron` 启动。
- 更新 Plugin API README、插件系统文档和 server 生命周期说明。

## 测试整理

本 PR 同时收紧了测试范围，删除 16 个重复或低价值用例（约 500 行）：

- 删除同一 cleanup / fence 超时在多个内部阶段的重复排列；
- 删除已经由 `PhysicalTxCoordinator` 覆盖的 RtAudio + PTT 跨层重复集成；
- 删除纯 getter、透传、preset tie-breaker 和低价值类型重复测试；
- 保留所有事故级不变量和用户真实通联路径。

仍明确覆盖：

- RR73 / 73、late decode、连续人工双击和中途频率修改；
- tail generation、replacement handover、PTT starting / unknown；
- A+B 同帧混音、单人移除、最后一人停止和 candidate failure；
- plugin invocation / decision / QSO epoch；
- QSO durability 延迟或失败不干扰 RF；
- 模式切换、CAT connection 复用和 operating-state 恢复。

## 验证

- `yarn workspace @tx5dr/server test`：167 files / 1,578 tests passed
- ADIF 70K performance fixture：passed（约 23 秒）
- 受影响 server 定向回归：5 files / 150 tests passed
- Plugin API capability tests：1 file / 4 tests passed
- `yarn build`：12 / 12 packages passed
- `yarn lint`：0 errors；9 个既有 warnings
- `git diff --cached --check`：passed
- 真实设备人工测试：RR73 / 73、中途切换消息、改频率、停止与 CW / FT8 模式切换通过

验证说明：monorepo 聚合 `yarn test` 在多包 Turbo 并行时曾有 4 个 `ADIFLogProvider` 用例触发 5 秒资源竞争超时；随后 server 独立全量 1,578 项和 ADIF 70K benchmark 均通过，未发现功能失败。

## 明确边界

- 不修改 `.adi`、backup、FileStore 或 durability 契约；
- 不引入第二日志事实源、journal、WAL、跨进程锁或长期 feature flag；
- 不修改 Hamlib / ICOM / TCI 的底层串口与网络协议；
- `stopEngine`、Profile 切换、Power、显式断开和 shutdown 的完整断开语义保持不变；
- 高功率导致 USB 不稳定仍按硬件 PTT timeout / unknown 处理，软件不会伪装停止成功。
