### PR TITLE
fix(qso): adapt RST logging repair to Plugin API v2

### DIFF
--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
@@ -384,6 +384,53 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
     expect(snapshot.context?.reportReceived).toBe(2);
     expect(snapshot.context?.reportSent).toBe(-16);
   });
+
+  it('overwrites a cached reportReceived of 0 when answering a fresh SIGNAL_REPORT', async () => {
+    // Reproduces issue #70: cached/UI sentinel 0 must not replace the air report (-15).
+    const operator = createOperator({ myCallsign: 'BG5FRH', myGrid: 'PL09' });
+    const runtime = new StandardQSOPluginRuntime(operator);
+
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      targetGrid: 'NO26',
+      reportSent: -2,
+      reportReceived: 0,
+    });
+    runtime.clearQSOContext();
+    runtime.setState('TX6');
+
+    await runtime.decide([
+      createParsedMessage('BG5FRH RW9HSB -15', { snr: -2, slotId: 'slot-issue-70' }),
+    ]);
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.currentState).toBe('TX3');
+    expect(snapshot.context?.targetCallsign).toBe('RW9HSB');
+    expect(snapshot.context?.reportReceived).toBe(-15);
+    expect(snapshot.context?.reportSent).toBe(-2);
+    expect(snapshot.slots?.TX3).toBe('RW9HSB BG5FRH R-02');
+  });
+
+  it('overwrites a stale reportReceived of 0 when TX2 receives a ROGER_REPORT', async () => {
+    const operator = createOperator({ myCallsign: 'BG5FRH', myGrid: 'PL09' });
+    const runtime = new StandardQSOPluginRuntime(operator);
+
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      reportSent: -2,
+      reportReceived: 0,
+    });
+    runtime.setState('TX2');
+
+    await runtime.decide([
+      createParsedMessage('BG5FRH RW9HSB R-15', { snr: -3, slotId: 'slot-roger-overwrite' }),
+    ]);
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.currentState).toBe('TX4');
+    expect(snapshot.context?.reportReceived).toBe(-15);
+    expect(snapshot.context?.reportSent).toBe(-3);
+  });
 });
 
 describe('StandardQSOPluginRuntime partial-decode `<...>` handling', () => {

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.test.ts
@@ -401,7 +401,7 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
 
     await runtime.decide([
       createParsedMessage('BG5FRH RW9HSB -15', { snr: -2, slotId: 'slot-issue-70' }),
-    ]);
+    ], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX3');
@@ -424,12 +424,56 @@ describe('StandardQSOPluginRuntime nonstandard callsign slots', () => {
 
     await runtime.decide([
       createParsedMessage('BG5FRH RW9HSB R-15', { snr: -3, slotId: 'slot-roger-overwrite' }),
-    ]);
+    ], decisionMeta());
 
     const snapshot = runtime.getSnapshot();
     expect(snapshot.currentState).toBe('TX4');
     expect(snapshot.context?.reportReceived).toBe(-15);
     expect(snapshot.context?.reportSent).toBe(-3);
+  });
+
+  it('clears stale cached reports when answering a CALL after restoreContext', async () => {
+    const operator = createOperator({ myCallsign: 'BG5FRH', myGrid: 'PL09' });
+    const runtime = new StandardQSOPluginRuntime(operator);
+
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      targetGrid: 'NO26',
+      reportSent: -8,
+      reportReceived: 0,
+    });
+    runtime.clearQSOContext();
+    runtime.setState('TX6');
+
+    await runtime.decide([
+      createParsedMessage('BG5FRH RW9HSB NO26', { snr: -5, slotId: 'slot-call-clear' }),
+    ], decisionMeta());
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.currentState).toBe('TX2');
+    expect(snapshot.context?.targetCallsign).toBe('RW9HSB');
+    expect(snapshot.context?.targetGrid).toBe('NO26');
+    expect(snapshot.context?.reportSent).toBe(-5);
+    expect(snapshot.context?.reportReceived).toBeUndefined();
+  });
+
+  it('clears reports when patchContext receives explicit undefined properties', () => {
+    const runtime = new StandardQSOPluginRuntime(createOperator());
+    runtime.patchContext({
+      targetCallsign: 'RW9HSB',
+      reportSent: -12,
+      reportReceived: -8,
+    });
+    runtime.patchContext({
+      reportSent: undefined,
+      reportReceived: undefined,
+    });
+
+    const snapshot = runtime.getSnapshot();
+    expect(snapshot.context?.targetCallsign).toBe('RW9HSB');
+    expect(snapshot.context?.reportSent).toBeUndefined();
+    expect(snapshot.context?.reportReceived).toBeUndefined();
+    expect(snapshot.slots?.TX2).toBe('RW9HSB BG5DRB +00');
   });
 });
 

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
@@ -270,12 +270,16 @@ async function trySwitchToDirectedProtocol(
 
         if (msg.type === FT8MessageType.CALL) {
             strategy.logger.debug(`${prefix}: switching to direct call ${callsign} (SNR: ${directCall.snr})`);
-            if (!strategy.restoreContext(callsign)) {
-                strategy.context.reportSent = directCall.snr;
-                strategy.context.targetGrid = (msg as FT8MessageCall).grid;
-                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                    strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
-                }
+            const callMsg = msg as FT8MessageCall;
+            // Restore grid/frequency cache, but always refresh SNR and clear stale received reports.
+            strategy.restoreContext(callsign);
+            if (callMsg.grid) {
+                strategy.context.targetGrid = callMsg.grid;
+            }
+            strategy.context.reportSent = directCall.snr;
+            strategy.context.reportReceived = undefined;
+            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
             }
             strategy.updateSlots();
             return { changeState: 'TX2' };
@@ -432,14 +436,15 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             // 切换到新呼号
                             strategy.beginQsoWithTarget(newCallsign, 'TX1 direct-call handoff');
 
-                            // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
-                            if (!strategy.restoreContext(newCallsign)) {
-                                strategy.context.reportSent = newCall.snr;
+                            // Restore grid/frequency cache, but always refresh SNR and clear stale received reports.
+                            strategy.restoreContext(newCallsign);
+                            if (callMsg.grid) {
                                 strategy.context.targetGrid = callMsg.grid;
-                                // 记录实际通联频率
-                                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                                    strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
-                                }
+                            }
+                            strategy.context.reportSent = newCall.snr;
+                            strategy.context.reportReceived = undefined;
+                            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                                strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
                             }
 
                             strategy.updateSlots();
@@ -972,15 +977,15 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             }
                             strategy.beginQsoWithTarget(callsign, 'TX6 CQ reply');
 
-                            // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
-                            if (!strategy.restoreContext(callsign)) {
+                            // Restore grid/frequency cache, but always refresh SNR and clear stale received reports.
+                            strategy.restoreContext(callsign);
+                            if (msg.grid) {
                                 strategy.context.targetGrid = msg.grid;
-                                strategy.context.reportSent = cqCall.snr;
-                                // 记录实际通联频率 (基础频率 + CQ信号的频率偏移)
-                                // 只有当基础频率有效时（大于1MHz）才计算actualFrequency
-                                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                                    strategy.context.actualFrequency = strategy.context.config.frequency + cqCall.df;
-                                }
+                            }
+                            strategy.context.reportSent = cqCall.snr;
+                            strategy.context.reportReceived = undefined;
+                            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                                strategy.context.actualFrequency = strategy.context.config.frequency + cqCall.df;
                             }
 
                             strategy.updateSlots();
@@ -1572,16 +1577,28 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
             && !callsignMatches(patch.targetCallsign, this._context.targetCallsign)) {
             this.beginQsoLifecycle('context target changed');
         }
-        this._context = {
+        const next: QSOContext = {
             ...this._context,
-            ...patch,
         };
+        if (patch.targetCallsign !== undefined) next.targetCallsign = patch.targetCallsign;
+        if (patch.targetGrid !== undefined) next.targetGrid = patch.targetGrid;
+        if (patch.actualFrequency !== undefined) {
+            next.actualFrequency = patch.actualFrequency ?? undefined;
+        }
+        // The Host preserves an explicit undefined property to mean "clear".
+        if (Object.prototype.hasOwnProperty.call(patch, 'reportSent')) {
+            next.reportSent = patch.reportSent;
+        }
+        if (Object.prototype.hasOwnProperty.call(patch, 'reportReceived')) {
+            next.reportReceived = patch.reportReceived;
+        }
+        this._context = next;
 
         const needsSlotUpdate =
             patch.targetCallsign !== undefined ||
             patch.targetGrid !== undefined ||
-            patch.reportSent !== undefined ||
-            patch.reportReceived !== undefined;
+            Object.prototype.hasOwnProperty.call(patch, 'reportSent') ||
+            Object.prototype.hasOwnProperty.call(patch, 'reportReceived');
 
         if (needsSlotUpdate) {
             this.updateSlots();

--- a/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
+++ b/packages/builtin-plugins/src/standard-qso/StandardQSOPluginRuntime.ts
@@ -283,12 +283,13 @@ async function trySwitchToDirectedProtocol(
 
         if (msg.type === FT8MessageType.SIGNAL_REPORT) {
             strategy.logger.debug(`${prefix}: switching to direct signal report ${callsign} (SNR: ${directCall.snr})`);
-            if (!strategy.restoreContext(callsign)) {
-                strategy.context.reportReceived = (msg as FT8MessageSignalReport).report;
-                strategy.context.reportSent = directCall.snr;
-                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                    strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
-                }
+            // Always apply the fresh report from the air message after restore.
+            // Cached context may still hold a UI/default sentinel of 0.
+            strategy.restoreContext(callsign);
+            strategy.context.reportReceived = (msg as FT8MessageSignalReport).report;
+            strategy.context.reportSent = directCall.snr;
+            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                strategy.context.actualFrequency = strategy.context.config.frequency + directCall.df;
             }
             strategy.updateSlots();
             return { changeState: 'TX3' };
@@ -477,14 +478,12 @@ const states: { [key in SlotsIndex]: StandardState } = {
                             // 切换到新呼号
                             strategy.beginQsoWithTarget(newCallsign, 'TX1 signal-report handoff');
 
-                            // 尝试从缓存恢复上下文，如果没有缓存则使用当前消息的信息
-                            if (!strategy.restoreContext(newCallsign)) {
-                                strategy.context.reportReceived = reportMsg.report;
-                                strategy.context.reportSent = newCall.snr;
-                                // 记录实际通联频率
-                                if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
-                                    strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
-                                }
+                            // Restore grid/frequency cache, but always take the fresh report from this message.
+                            strategy.restoreContext(newCallsign);
+                            strategy.context.reportReceived = reportMsg.report;
+                            strategy.context.reportSent = newCall.snr;
+                            if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
+                                strategy.context.actualFrequency = strategy.context.config.frequency + newCall.df;
                             }
 
                             strategy.updateSlots();
@@ -558,12 +557,9 @@ const states: { [key in SlotsIndex]: StandardState } = {
             if (msgRogerReport) {
                 const msg = msgRogerReport.message as FT8MessageRogerReport;
                 strategy.logger.debug('TX2: received ROGER_REPORT, moving to TX4');
-                // 【修复】ROGER_REPORT也包含对方给我们的信号报告（msg.report）
-                // 如果之前没有设置reportReceived，从ROGER_REPORT中获取
-                if (strategy.context.reportReceived === undefined || strategy.context.reportReceived === null) {
-                    strategy.context.reportReceived = msg.report;
-                }
-                // 【修复】允许更新reportSent为当前SNR（移除过于保守的条件限制）
+                // Always take the report from the air message. A prior UI/default
+                // sentinel of 0 must not block updating to the real value.
+                strategy.context.reportReceived = msg.report;
                 strategy.context.reportSent = msgRogerReport.snr;
                 // 记录或更新实际通联频率 (基础频率 + 对方信号的频率偏移)
                 // 只有当基础频率有效时（大于1MHz）才计算actualFrequency
@@ -590,11 +586,7 @@ const states: { [key in SlotsIndex]: StandardState } = {
             if (msgSignalReport) {
                 const msg = msgSignalReport.message as FT8MessageSignalReport;
                 strategy.logger.debug('TX2: fallback - received SIGNAL_REPORT instead of ROGER_REPORT, treating as confirmation, moving to TX4');
-                // 【修复】提取对方告诉我们的信号报告值（msg.report）
-                if (strategy.context.reportReceived === undefined || strategy.context.reportReceived === null) {
-                    strategy.context.reportReceived = msg.report;
-                }
-                // 【修复】允许更新reportSent（移除过于保守的条件限制）
+                strategy.context.reportReceived = msg.report;
                 strategy.context.reportSent = msgSignalReport.snr;
                 // 记录或更新实际通联频率
                 if (strategy.context.config.frequency && strategy.context.config.frequency > 1000000) {
@@ -707,12 +699,7 @@ const states: { [key in SlotsIndex]: StandardState } = {
                 const msg = msgSignalReport.message as FT8MessageSignalReport;
                 strategy.logger.debug(`TX3: fallback - received repeated SIGNAL_REPORT (SNR: ${msgSignalReport.snr}dB), updating report`);
 
-                // 更新接收的信号报告（如果之前没有设置）
-                if (strategy.context.reportReceived === undefined ||
-                    strategy.context.reportReceived === null) {
-                    strategy.context.reportReceived = msg.report;
-                }
-
+                strategy.context.reportReceived = msg.report;
                 // 更新我方准备发送的报告（使用最新的SNR）
                 strategy.context.reportSent = msgSignalReport.snr;
 
@@ -1413,10 +1400,8 @@ export class StandardQSOPluginRuntime implements StrategyRuntime {
                 } else if (msg.type === FT8MessageType.ROGER_REPORT) {
                     // 对方发了 ROGER_REPORT，回复 RR73
                     const rogerMsg = msg as FT8MessageRogerReport;
-                    // 从 ROGER_REPORT 中提取对方给我们的信号报告
-                    if (this.context.reportReceived === undefined || this.context.reportReceived === null) {
-                        this.context.reportReceived = rogerMsg.report;
-                    }
+                    // Always take the report from the air message.
+                    this.context.reportReceived = rogerMsg.report;
                     // 记录实际通联频率
                     if (this.context.config.frequency && this.context.config.frequency > 1000000) {
                         this.context.actualFrequency = this.context.config.frequency + parsedMessage.df;

--- a/packages/contracts/src/schema/__tests__/operator-context-report.schema.test.ts
+++ b/packages/contracts/src/schema/__tests__/operator-context-report.schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  StrategyRuntimeSnapshotSchema,
+  WSMessageSchema,
+  WSMessageType,
+} from '../../index.js';
+
+describe('operator context report contracts', () => {
+  it('accepts null only as an explicit WebSocket clear command', () => {
+    expect(WSMessageSchema.safeParse({
+      type: WSMessageType.SET_OPERATOR_CONTEXT,
+      timestamp: new Date(0).toISOString(),
+      data: {
+        operatorId: 'operator-1',
+        context: {
+          reportSent: null,
+          reportReceived: null,
+        },
+      },
+    }).success).toBe(true);
+  });
+
+  it('keeps normalized strategy snapshots free of nullable reports', () => {
+    expect(StrategyRuntimeSnapshotSchema.safeParse({
+      currentState: 'TX6',
+      context: {
+        reportSent: null,
+      },
+    }).success).toBe(false);
+
+    expect(StrategyRuntimeSnapshotSchema.safeParse({
+      currentState: 'TX6',
+      context: {
+        reportSent: 0,
+        reportReceived: 0,
+      },
+    }).success).toBe(true);
+  });
+});

--- a/packages/contracts/src/schema/websocket.schema.ts
+++ b/packages/contracts/src/schema/websocket.schema.ts
@@ -443,6 +443,9 @@ export type AssistedQueueIcon = z.infer<typeof AssistedQueueIconSchema>;
 export type AssistedQueueRow = z.infer<typeof AssistedQueueRowSchema>;
 export type AssistedQueueSnapshot = z.infer<typeof AssistedQueueSnapshotSchema>;
 
+/** Null clears an unsettable runtime report field over JSON/WebSocket. */
+export const OperatorContextReportFieldSchema = z.number().nullish();
+
 export const StrategyRuntimeSnapshotSchema = z.object({
   currentState: z.string(),
   slots: z.object({
@@ -776,8 +779,8 @@ export const WSSetOperatorContextMessageSchema = WSBaseMessageSchema.extend({
       targetCallsign: z.string().optional(),
       targetGrid: z.string().optional(),
       frequency: z.number().optional(),
-      reportSent: z.number().optional(),
-      reportReceived: z.number().optional(),
+      reportSent: OperatorContextReportFieldSchema,
+      reportReceived: OperatorContextReportFieldSchema,
     }),
   }),
 });

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -77,6 +77,22 @@ function normalizeOperatorContext(context: any): any {
   };
 }
 
+/** True when a logged RST/SNR field is absent. Note: "0" is a valid FT8 report. */
+function isMissingSignalReport(value: string | undefined | null): boolean {
+  return value === undefined || value === null || value === '';
+}
+
+function preferSignalReport(
+  ...candidates: Array<string | undefined | null>
+): string | undefined {
+  for (const candidate of candidates) {
+    if (!isMissingSignalReport(candidate)) {
+      return candidate ?? undefined;
+    }
+  }
+  return undefined;
+}
+
 interface SameTransmissionGuardState {
   canonicalMessage: string;
   count: number;
@@ -877,11 +893,19 @@ export class RadioOperatorManager {
         targetGrid = this.callsignTracker.getGrid(targetCall) ?? '';
       }
 
+      const rawReportSent = runtimeState?.context?.reportSent;
+      const rawReportReceived = runtimeState?.context?.reportReceived;
       const targetContext = {
         targetCall,
         targetGrid,
-        reportSent: Number(runtimeState?.context?.reportSent ?? 0),
-        reportReceived: Number(runtimeState?.context?.reportReceived ?? 0),
+        // Keep unset reports as undefined. Coercing to 0 pollutes QSO logs
+        // because FT8 SNR of 0 is valid and UI echoes can write the sentinel back.
+        reportSent: typeof rawReportSent === 'number' && Number.isFinite(rawReportSent)
+          ? rawReportSent
+          : undefined,
+        reportReceived: typeof rawReportReceived === 'number' && Number.isFinite(rawReportReceived)
+          ? rawReportReceived
+          : undefined,
       };
       
       operators.push({
@@ -2464,24 +2488,6 @@ export class RadioOperatorManager {
     const grid = qsoRecord.grid
       || this.callsignTracker?.getGrid(targetCallsign);
 
-    // Recover signal reports from CallsignContextTracker if missing
-    let reportSent = qsoRecord.reportSent;
-    let reportReceived = qsoRecord.reportReceived;
-    if (this.callsignTracker && myCallsign) {
-      if (!reportSent) {
-        const sent = this.callsignTracker.getReport(myCallsign, targetCallsign);
-        if (sent !== undefined) {
-          reportSent = sent.toString();
-        }
-      }
-      if (!reportReceived) {
-        const received = this.callsignTracker.getReport(targetCallsign, myCallsign);
-        if (received !== undefined) {
-          reportReceived = received.toString();
-        }
-      }
-    }
-
     const messageHistory = this.rebuildQSOMessageHistory(historySlotPacks, {
       operatorId,
       myCallsign,
@@ -2490,13 +2496,41 @@ export class RadioOperatorManager {
       endMs: historyEndMs,
     });
 
+    // Prefer reports decoded from the air messages; context may still hold a
+    // UI/default sentinel of "0" that would otherwise be logged as-is.
+    const fromHistory = this.extractReportsFromMessageHistory(
+      messageHistory,
+      myCallsign,
+      targetCallsign,
+    );
+
+    let reportSent = preferSignalReport(fromHistory.reportSent, qsoRecord.reportSent);
+    let reportReceived = preferSignalReport(fromHistory.reportReceived, qsoRecord.reportReceived);
+
+    // Recover remaining gaps from CallsignContextTracker.
+    // Do not use truthiness checks: "0" is a valid FT8 report.
+    if (this.callsignTracker && myCallsign) {
+      if (isMissingSignalReport(reportSent)) {
+        const sent = this.callsignTracker.getReport(myCallsign, targetCallsign);
+        if (sent !== undefined) {
+          reportSent = sent.toString();
+        }
+      }
+      if (isMissingSignalReport(reportReceived)) {
+        const received = this.callsignTracker.getReport(targetCallsign, myCallsign);
+        if (received !== undefined) {
+          reportReceived = received.toString();
+        }
+      }
+    }
+
     const completedRecord = {
       ...qsoRecord,
       callsign: targetCallsign,
       myCallsign: myCallsign || qsoRecord.myCallsign,
       grid,
-      reportSent: reportSent || qsoRecord.reportSent,
-      reportReceived: reportReceived || qsoRecord.reportReceived,
+      reportSent: preferSignalReport(reportSent, qsoRecord.reportSent),
+      reportReceived: preferSignalReport(reportReceived, qsoRecord.reportReceived),
       messageHistory,
     };
     return {
@@ -2566,6 +2600,46 @@ export class RadioOperatorManager {
     }
 
     return messages;
+  }
+
+  /**
+   * Extract directed SNR reports exchanged between myCallsign and targetCallsign.
+   * Later messages win so the final report in the QSO is preferred.
+   */
+  private extractReportsFromMessageHistory(
+    messages: string[],
+    myCallsign: string,
+    targetCallsign: string,
+  ): { reportSent?: string; reportReceived?: string } {
+    let reportSent: string | undefined;
+    let reportReceived: string | undefined;
+    const me = myCallsign.toUpperCase();
+    const them = targetCallsign.toUpperCase();
+
+    for (const message of messages) {
+      try {
+        const parsed = FT8MessageParser.parseMessage(message);
+        if (parsed.type !== 'signal_report' && parsed.type !== 'roger_report') {
+          continue;
+        }
+        if (typeof parsed.report !== 'number' || !Number.isFinite(parsed.report)) {
+          continue;
+        }
+        const sender = parsed.senderCallsign?.toUpperCase();
+        const target = parsed.targetCallsign?.toUpperCase();
+        // Keep WSJT-X style two-digit reports (e.g. "-09") instead of bare "-9".
+        const report = FT8MessageParser.generateSignalReport(parsed.report);
+        if (sender === me && target === them) {
+          reportSent = report;
+        } else if (sender === them && target === me) {
+          reportReceived = report;
+        }
+      } catch (error) {
+        logger.warn(`Failed to parse frame while extracting QSO reports: "${message}"`, error);
+      }
+    }
+
+    return { reportSent, reportReceived };
   }
 
   private isFrameRelatedToQSO(
@@ -2647,8 +2721,9 @@ export class RadioOperatorManager {
       startTime: Math.min(existing.startTime, incoming.startTime),
       endTime: Math.max(existingEndTime, incomingEndTime),
       grid: incoming.grid || existing.grid,
-      reportSent: incoming.reportSent || existing.reportSent,
-      reportReceived: incoming.reportReceived || existing.reportReceived,
+      // "0" is a valid FT8 report; do not treat it as missing via ||.
+      reportSent: preferSignalReport(incoming.reportSent, existing.reportSent),
+      reportReceived: preferSignalReport(incoming.reportReceived, existing.reportReceived),
       messageHistory,
       lotwQslSent: existing.lotwQslSent,
       lotwQslReceived: existing.lotwQslReceived,

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -2492,7 +2492,7 @@ export class RadioOperatorManager {
     const grid = qsoRecord.grid
       || this.callsignTracker?.getGrid(targetCallsign);
 
-    const messageHistory = this.rebuildQSOMessageHistory(historySlotPacks, {
+    const history = this.rebuildQSOMessageHistory(historySlotPacks, {
       operatorId,
       myCallsign,
       targetCallsign,
@@ -2500,16 +2500,10 @@ export class RadioOperatorManager {
       endMs: historyEndMs,
     });
 
-    // Prefer physically confirmed air history over the speculative runtime
-    // context captured before Host-side persistence begins.
-    const fromHistory = this.extractReportsFromMessageHistory(
-      messageHistory,
-      myCallsign,
-      targetCallsign,
-    );
-
-    let reportSent = preferSignalReport(fromHistory.reportSent, qsoRecord.reportSent);
-    let reportReceived = preferSignalReport(fromHistory.reportReceived, qsoRecord.reportReceived);
+    // Only a local on-air TX frame may refine reportSent. RX frames remain
+    // decoder candidates; reportReceived comes from the strategy-accepted effect.
+    let reportSent = preferSignalReport(history.reportSent, qsoRecord.reportSent);
+    let reportReceived = qsoRecord.reportReceived;
 
     // Recover remaining gaps from CallsignContextTracker.
     // Do not use truthiness checks: "0" is a valid FT8 report.
@@ -2535,7 +2529,7 @@ export class RadioOperatorManager {
       grid,
       reportSent: preferSignalReport(reportSent, qsoRecord.reportSent),
       reportReceived: preferSignalReport(reportReceived, qsoRecord.reportReceived),
-      messageHistory,
+      messageHistory: history.messages,
     };
     return {
       ...completedRecord,
@@ -2587,8 +2581,9 @@ export class RadioOperatorManager {
   private rebuildQSOMessageHistory(
     slotPacks: SlotPack[],
     options: { operatorId: string; myCallsign: string; targetCallsign: string; startMs: number; endMs: number }
-  ): string[] {
+  ): { messages: string[]; reportSent?: string } {
     const messages: string[] = [];
+    let reportSent: string | undefined;
 
     for (const slotPack of slotPacks) {
       if (slotPack.startMs > options.endMs || slotPack.endMs < options.startMs) {
@@ -2600,50 +2595,43 @@ export class RadioOperatorManager {
           continue;
         }
         messages.push(frame.message);
+        if (frame.snr === -999 && frame.operatorId === options.operatorId) {
+          reportSent = this.extractTransmittedReport(
+            frame.message,
+            options.myCallsign,
+            options.targetCallsign,
+          ) ?? reportSent;
+        }
       }
     }
 
-    return messages;
+    return { messages, reportSent };
   }
 
-  /**
-   * Extract directed SNR reports exchanged between myCallsign and targetCallsign.
-   * Later messages win so the final report in the QSO is preferred.
-   */
-  private extractReportsFromMessageHistory(
-    messages: string[],
+  private extractTransmittedReport(
+    message: string,
     myCallsign: string,
     targetCallsign: string,
-  ): { reportSent?: string; reportReceived?: string } {
-    let reportSent: string | undefined;
-    let reportReceived: string | undefined;
+  ): string | undefined {
     const me = myCallsign.toUpperCase();
     const them = targetCallsign.toUpperCase();
 
-    for (const message of messages) {
-      try {
-        const parsed = FT8MessageParser.parseMessage(message);
-        if (parsed.type !== 'signal_report' && parsed.type !== 'roger_report') {
-          continue;
-        }
-        if (typeof parsed.report !== 'number' || !Number.isFinite(parsed.report)) {
-          continue;
-        }
-        const sender = parsed.senderCallsign?.toUpperCase();
-        const target = parsed.targetCallsign?.toUpperCase();
-        // Keep WSJT-X style two-digit reports (e.g. "-09") instead of bare "-9".
-        const report = FT8MessageParser.generateSignalReport(parsed.report);
-        if (sender === me && target === them) {
-          reportSent = report;
-        } else if (sender === them && target === me) {
-          reportReceived = report;
-        }
-      } catch (error) {
-        logger.warn(`Failed to parse frame while extracting QSO reports: "${message}"`, error);
+    try {
+      const parsed = FT8MessageParser.parseMessage(message);
+      if (parsed.type !== 'signal_report' && parsed.type !== 'roger_report') {
+        return undefined;
       }
+      if (typeof parsed.report !== 'number' || !Number.isFinite(parsed.report)) {
+        return undefined;
+      }
+      const sender = parsed.senderCallsign?.toUpperCase();
+      const target = parsed.targetCallsign?.toUpperCase();
+      if (sender !== me || target !== them) return undefined;
+      return FT8MessageParser.generateSignalReport(parsed.report);
+    } catch (error) {
+      logger.warn(`Failed to parse local TX frame while extracting its QSO report: "${message}"`, error);
+      return undefined;
     }
-
-    return { reportSent, reportReceived };
   }
 
   private isFrameRelatedToQSO(

--- a/packages/server/src/operator/RadioOperatorManager.ts
+++ b/packages/server/src/operator/RadioOperatorManager.ts
@@ -77,7 +77,7 @@ function normalizeOperatorContext(context: any): any {
   };
 }
 
-/** True when a logged RST/SNR field is absent. Note: "0" is a valid FT8 report. */
+/** True when a logged RST/SNR field is absent. "0" and "+00" are valid reports. */
 function isMissingSignalReport(value: string | undefined | null): boolean {
   return value === undefined || value === null || value === '';
 }
@@ -988,8 +988,12 @@ export class RadioOperatorManager {
     const runtimePatch: Record<string, unknown> = {};
     if (normalizedContext.targetCallsign !== undefined) runtimePatch.targetCallsign = normalizedContext.targetCallsign;
     if (normalizedContext.targetGrid !== undefined) runtimePatch.targetGrid = normalizedContext.targetGrid;
-    if (normalizedContext.reportSent !== undefined) runtimePatch.reportSent = normalizedContext.reportSent;
-    if (normalizedContext.reportReceived !== undefined) runtimePatch.reportReceived = normalizedContext.reportReceived;
+    if (normalizedContext.reportSent !== undefined) {
+      runtimePatch.reportSent = normalizedContext.reportSent ?? undefined;
+    }
+    if (normalizedContext.reportReceived !== undefined) {
+      runtimePatch.reportReceived = normalizedContext.reportReceived ?? undefined;
+    }
     if (Object.keys(runtimePatch).length > 0) {
       this._pluginManager?.patchOperatorRuntimeContext(operatorId, runtimePatch as any);
     }
@@ -2496,8 +2500,8 @@ export class RadioOperatorManager {
       endMs: historyEndMs,
     });
 
-    // Prefer reports decoded from the air messages; context may still hold a
-    // UI/default sentinel of "0" that would otherwise be logged as-is.
+    // Prefer physically confirmed air history over the speculative runtime
+    // context captured before Host-side persistence begins.
     const fromHistory = this.extractReportsFromMessageHistory(
       messageHistory,
       myCallsign,

--- a/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
+++ b/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
@@ -204,6 +204,32 @@ describe('RadioOperatorManager transmission maintenance', () => {
     eventEmitter.emit('requestTransmit', request);
     expect(manager.getPendingTransmissionsCount()).toBe(1);
   });
+
+  it('normalizes WebSocket null report clears before crossing the plugin boundary', async () => {
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test', provider: {} },
+    });
+    await addBasicOperator(manager, 'op1');
+    const patchOperatorRuntimeContext = vi.fn();
+    manager.setPluginManager({
+      getCurrentTransmission: vi.fn(() => null),
+      getOperatorRuntimeStatus: vi.fn(() => undefined),
+      patchOperatorRuntimeContext,
+    } as any);
+
+    await manager.updateOperatorContext('op1', {
+      reportSent: null,
+      reportReceived: null,
+    });
+
+    expect(patchOperatorRuntimeContext).toHaveBeenCalledOnce();
+    const patch = patchOperatorRuntimeContext.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(Object.keys(patch).sort()).toEqual(['reportReceived', 'reportSent']);
+    expect(patch).toEqual({
+      reportSent: undefined,
+      reportReceived: undefined,
+    });
+  });
 });
 
 describe('RadioOperatorManager logbook startup binding', () => {
@@ -705,7 +731,14 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       activeSlotPacks: [
         buildSlotPack(`ft8-${base}`, base, [
           {
-            message: 'BG5DRB N0CALL -12',
+            message: 'BG5DRB N0CALL -09',
+            snr: -12,
+            dt: 0,
+            freq: 1300,
+            confidence: 1,
+          },
+          {
+            message: 'N0CALL BG5DRB -12',
             snr: -999,
             dt: 0,
             freq: 1300,
@@ -744,7 +777,10 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     expect(provider.addQSO).toHaveBeenCalledTimes(1);
     expect(updatedSpy).not.toHaveBeenCalled();
     expect(addedSpy).toHaveBeenCalledTimes(1);
-    expect(provider.addQSO.mock.calls[0]?.[0]?.messageHistory).toEqual(['BG5DRB N0CALL -12']);
+    expect(provider.addQSO.mock.calls[0]?.[0]?.messageHistory).toEqual([
+      'BG5DRB N0CALL -09',
+      'N0CALL BG5DRB -12',
+    ]);
     expect(provider.addQSO.mock.calls[0]?.[0]?.comment).toBe('FT8  Sent: -12  Rcvd: -09');
     expect(autoSync).toHaveBeenCalledTimes(1);
     expect(notifyQSOComplete).toHaveBeenCalledTimes(1);
@@ -753,7 +789,10 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       expect.objectContaining({
         id: 'temp-2',
         callsign: 'N0CALL',
-        messageHistory: ['BG5DRB N0CALL -12'],
+        messageHistory: [
+          'BG5DRB N0CALL -09',
+          'N0CALL BG5DRB -12',
+        ],
         comment: 'FT8  Sent: -12  Rcvd: -09',
       }),
     );
@@ -835,6 +874,153 @@ describe('RadioOperatorManager automatic QSO logging', () => {
         comment: 'FT8  Sent: -12  Rcvd: -09',
       }),
     );
+  });
+
+  it('prefers physically confirmed message history over stale runtime reports', async () => {
+    const base = Date.parse('2026-07-23T07:43:00.000Z');
+    const provider = {
+      addQSO: vi.fn(async (record: QSORecord) => record),
+      updateQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 1 }),
+    };
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5FRH',
+      activeSlotPacks: [
+        buildSlotPack(`ft8-${base}`, base, [{
+          message: 'BG5FRH RW9HSB -15',
+          snr: -2,
+          dt: 0.1,
+          freq: 2557,
+          confidence: 1,
+        }]),
+        buildSlotPack(`ft8-${base + MODES.FT8.slotMs}`, base + MODES.FT8.slotMs, [{
+          message: 'RW9HSB BG5FRH R-02',
+          snr: -999,
+          dt: 0,
+          freq: 2386,
+          confidence: 1,
+          operatorId: 'op1',
+        }]),
+      ],
+      storedRecords: [],
+    });
+    attachQSOHookSpy(manager);
+
+    await invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoRecord: {
+        id: 'temp-issue-70-83',
+        callsign: 'RW9HSB',
+        frequency: 21_076_000,
+        mode: 'FT8',
+        startTime: base,
+        endTime: base + MODES.FT8.slotMs * 2,
+        reportSent: '-4',
+        reportReceived: '0',
+        messageHistory: [],
+        myCallsign: 'BG5FRH',
+      },
+    });
+
+    expect(provider.addQSO).toHaveBeenCalledOnce();
+    expect(provider.addQSO.mock.calls[0]?.[0]).toMatchObject({
+      reportSent: '-02',
+      reportReceived: '-15',
+      comment: 'FT8  Sent: -02  Rcvd: -15',
+    });
+  });
+
+  it('preserves a legitimate bare zero report when no air history is available', async () => {
+    const base = Date.parse('2026-07-23T08:00:00.000Z');
+    const provider = {
+      addQSO: vi.fn(async (record: QSORecord) => record),
+      updateQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 1 }),
+    };
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5DRB',
+      activeSlotPacks: [],
+      storedRecords: [],
+    });
+    attachQSOHookSpy(manager);
+
+    await invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoRecord: {
+        id: 'temp-zero',
+        callsign: 'N0CALL',
+        frequency: 14_074_000,
+        mode: 'FT8',
+        startTime: base,
+        reportSent: '0',
+        reportReceived: '0',
+        messageHistory: [],
+        myCallsign: 'BG5DRB',
+      },
+    });
+
+    expect(provider.addQSO.mock.calls[0]?.[0]).toMatchObject({
+      reportSent: '0',
+      reportReceived: '0',
+      comment: 'FT8  Sent: 0  Rcvd: 0',
+    });
+  });
+
+  it('normalizes a physically confirmed zero report to FT8 +00 notation', async () => {
+    const base = Date.parse('2026-07-23T08:30:00.000Z');
+    const provider = {
+      addQSO: vi.fn(async (record: QSORecord) => record),
+      updateQSO: vi.fn(),
+      getLastQSOWithCallsign: vi.fn().mockResolvedValue(null),
+      getStatistics: vi.fn().mockResolvedValue({ totalQSOs: 1 }),
+    };
+    const received = FT8MessageParser.generateMessage({
+      type: FT8MessageType.SIGNAL_REPORT,
+      senderCallsign: 'N0CALL',
+      targetCallsign: 'BG5DRB',
+      report: 0,
+    });
+    const sent = FT8MessageParser.generateMessage({
+      type: FT8MessageType.ROGER_REPORT,
+      senderCallsign: 'BG5DRB',
+      targetCallsign: 'N0CALL',
+      report: 0,
+    });
+    const { manager } = createManager({
+      logBook: { id: 'log-1', name: 'Test Log', provider },
+      callsign: 'BG5DRB',
+      activeSlotPacks: [buildSlotPack(`ft8-${base}`, base, [
+        { message: received, snr: 0, dt: 0, freq: 1500, confidence: 1 },
+        { message: sent, snr: -999, dt: 0, freq: 1500, confidence: 1, operatorId: 'op1' },
+      ])],
+      storedRecords: [],
+    });
+    attachQSOHookSpy(manager);
+
+    await invokeRecordQSO(manager, {
+      operatorId: 'op1',
+      qsoRecord: {
+        id: 'temp-zero-history',
+        callsign: 'N0CALL',
+        frequency: 14_074_000,
+        mode: 'FT8',
+        startTime: base,
+        reportSent: '0',
+        reportReceived: '0',
+        messageHistory: [],
+        myCallsign: 'BG5DRB',
+      },
+    });
+
+    expect(provider.addQSO.mock.calls[0]?.[0]).toMatchObject({
+      reportSent: '+00',
+      reportReceived: '+00',
+      comment: 'FT8  Sent: +00  Rcvd: +00',
+    });
   });
 
   it('does not emit success effects when durable persistence fails', async () => {

--- a/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
+++ b/packages/server/src/operator/__tests__/RadioOperatorManager.test.ts
@@ -876,7 +876,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     );
   });
 
-  it('prefers physically confirmed message history over stale runtime reports', async () => {
+  it('uses physical TX history without letting conflicting RX decodes override the accepted effect', async () => {
     const base = Date.parse('2026-07-23T07:43:00.000Z');
     const provider = {
       addQSO: vi.fn(async (record: QSORecord) => record),
@@ -888,13 +888,22 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       logBook: { id: 'log-1', name: 'Test Log', provider },
       callsign: 'BG5FRH',
       activeSlotPacks: [
-        buildSlotPack(`ft8-${base}`, base, [{
-          message: 'BG5FRH RW9HSB -15',
-          snr: -2,
-          dt: 0.1,
-          freq: 2557,
-          confidence: 1,
-        }]),
+        buildSlotPack(`ft8-${base}`, base, [
+          {
+            message: 'BG5FRH RW9HSB -15',
+            snr: -2,
+            dt: 0.1,
+            freq: 2557,
+            confidence: 1,
+          },
+          {
+            message: 'BG5FRH RW9HSB +03',
+            snr: -20,
+            dt: 0.4,
+            freq: 2557,
+            confidence: 0.2,
+          },
+        ]),
         buildSlotPack(`ft8-${base + MODES.FT8.slotMs}`, base + MODES.FT8.slotMs, [{
           message: 'RW9HSB BG5FRH R-02',
           snr: -999,
@@ -918,7 +927,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
         startTime: base,
         endTime: base + MODES.FT8.slotMs * 2,
         reportSent: '-4',
-        reportReceived: '0',
+        reportReceived: '-15',
         messageHistory: [],
         myCallsign: 'BG5FRH',
       },
@@ -930,6 +939,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
       reportReceived: '-15',
       comment: 'FT8  Sent: -02  Rcvd: -15',
     });
+    expect(provider.addQSO.mock.calls[0]?.[0]?.messageHistory).toContain('BG5FRH RW9HSB +03');
   });
 
   it('preserves a legitimate bare zero report when no air history is available', async () => {
@@ -970,7 +980,7 @@ describe('RadioOperatorManager automatic QSO logging', () => {
     });
   });
 
-  it('normalizes a physically confirmed zero report to FT8 +00 notation', async () => {
+  it('normalizes a physically confirmed sent zero report to FT8 +00 notation', async () => {
     const base = Date.parse('2026-07-23T08:30:00.000Z');
     const provider = {
       addQSO: vi.fn(async (record: QSORecord) => record),
@@ -1018,8 +1028,8 @@ describe('RadioOperatorManager automatic QSO logging', () => {
 
     expect(provider.addQSO.mock.calls[0]?.[0]).toMatchObject({
       reportSent: '+00',
-      reportReceived: '+00',
-      comment: 'FT8  Sent: +00  Rcvd: +00',
+      reportReceived: '0',
+      comment: 'FT8  Sent: +00  Rcvd: 0',
     });
   });
 

--- a/packages/server/src/websocket/WSServer.ts
+++ b/packages/server/src/websocket/WSServer.ts
@@ -2550,15 +2550,15 @@ export class WSServer extends WSMessageHandler {
   private broadcastQSOToast(operatorId: string, qso: any, key: ServerMessageKey.QSO_LOGGED | ServerMessageKey.QSO_UPDATED): void {
     try {
       const mhz = (qso.frequency / 1_000_000).toFixed(3);
-      const reportSent = qso.reportSent || '--';
-      const reportReceived = qso.reportReceived || '--';
+      const reportSent = qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '--';
+      const reportReceived = qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '--';
       const summaryParts = [qso.callsign];
       if (qso.grid) {
         summaryParts.push(qso.grid);
       }
       summaryParts.push(`${mhz} MHz`);
       summaryParts.push(qso.mode);
-      if (qso.reportSent || qso.reportReceived) {
+      if ((qso.reportSent != null && qso.reportSent !== '') || (qso.reportReceived != null && qso.reportReceived !== '')) {
         summaryParts.push(`${reportSent}/${reportReceived}`);
       }
 

--- a/packages/web/src/components/app/GlobalShortcutBridge.tsx
+++ b/packages/web/src/components/app/GlobalShortcutBridge.tsx
@@ -149,8 +149,8 @@ export function GlobalShortcutBridge() {
       radioService.setOperatorContext(activeOperator.id, {
         targetCallsign: '',
         targetGrid: '',
-        reportSent: 0,
-        reportReceived: 0,
+        reportSent: null,
+        reportReceived: null,
       });
       radioService.setOperatorRuntimeState(activeOperator.id, 'TX6');
       dispatchOperatorSlotShortcutFeedback(activeOperator.id, 'TX6');

--- a/packages/web/src/components/logbook/LogbookViewer.tsx
+++ b/packages/web/src/components/logbook/LogbookViewer.tsx
@@ -1197,9 +1197,9 @@ const LogbookViewer: React.FC<LogbookViewerProps> = ({ operatorId, logBookId, op
           </Chip>
         );
       case "reportSent":
-        return qso.reportSent || '-';
+        return qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '-';
       case "reportReceived":
-        return qso.reportReceived || '-';
+        return qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '-';
       case "qslStatus": {
         const isLotwConfirmed = qso.lotwQslReceived === 'Y' || qso.lotwQslReceived === 'V';
         const isQrzConfirmed = qso.qrzQslReceived === 'Y';

--- a/packages/web/src/components/logbook/QSOFormModal.tsx
+++ b/packages/web/src/components/logbook/QSOFormModal.tsx
@@ -176,12 +176,12 @@ const QSOFormModal: React.FC<QSOFormModalProps> = ({
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <Input
                 label={t('editQso.reportSent')}
-                value={formData.reportSent || ''}
+                value={formData.reportSent ?? ''}
                 onChange={e => onChange({ ...formData, reportSent: e.target.value || undefined })}
               />
               <Input
                 label={t('editQso.reportReceived')}
-                value={formData.reportReceived || ''}
+                value={formData.reportReceived ?? ''}
                 onChange={e => onChange({ ...formData, reportReceived: e.target.value || undefined })}
               />
             </div>

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -16,6 +16,7 @@ import {
   getRadioOperatorProgressAnimation,
   shouldRadioOperatorPropsBeEqual,
 } from './radioOperatorProgress';
+import { applyOperatorContextDraft } from './operatorContextDraft';
 import { resolveRadioOperatorCyclePresentation } from './radioOperatorPresentation';
 import {
   OPERATOR_FORCE_STOP_REQUESTED_EVENT,
@@ -491,8 +492,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
 
   // 处理上下文更新（用户每次击键）
   const handleContextUpdate = (field: string, value: string | number | null) => {
-    const newContext = { ...localContext, [field]: value };
-    setLocalContext(newContext);
+    const newContext = applyOperatorContextDraft(
+      localContextRef,
+      setLocalContext,
+      { [field]: value },
+    );
 
     // 重置防抖
     if (debounceTimerRef.current) {

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -135,9 +135,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
     };
   });
 
-  // 报告字段的原始字符串（支持 ""、"-" 等中间态）
+  // 报告字段的原始字符串（支持 ""、"-" 等中间态；未设置时显示空而非哨兵 0）
   const [reportSentRaw, setReportSentRaw] = React.useState(() =>
-    (operatorStatus.context.reportSent ?? 0).toString()
+    operatorStatus.context.reportSent === undefined || operatorStatus.context.reportSent === null
+      ? ''
+      : operatorStatus.context.reportSent.toString()
   );
 
   // 频率字段的原始字符串（支持编辑中间态，失焦时 clamp）
@@ -370,7 +372,9 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
 
         // 同步原始字符串显示（仅非聚焦/冷却时）
         if (!focusedFields.has('reportSent') && !cooldownFields.has('reportSent')) {
-          const newVal = (newContext.reportSent ?? 0).toString();
+          const newVal = newContext.reportSent === undefined || newContext.reportSent === null
+            ? ''
+            : newContext.reportSent.toString();
           if (reportSentRaw !== newVal) {
             setReportSentRaw(newVal);
           }
@@ -475,16 +479,18 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       targetCallsign: ctx.targetCall,
       targetGrid: ctx.targetGrid,
       frequency: ctx.frequency,
-      // Only send reportSent when explicitly set. Never echo a UI default of 0 for
+      // Only send reportSent when explicitly set. Never echo a UI default for
       // reportReceived — that field is driven by FT8 exchanges on the server.
       ...(typeof ctx.reportSent === 'number' && Number.isFinite(ctx.reportSent)
         ? { reportSent: ctx.reportSent }
-        : {}),
+        : ctx.reportSent === null
+          ? { reportSent: null }
+          : {}),
     });
   }, [setOperatorContext]);
 
   // 处理上下文更新（用户每次击键）
-  const handleContextUpdate = (field: string, value: string | number) => {
+  const handleContextUpdate = (field: string, value: string | number | null) => {
     const newContext = { ...localContext, [field]: value };
     setLocalContext(newContext);
 
@@ -547,7 +553,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
         // 同步原始字符串显示
         if (field === 'reportSent') {
           setReportSentRaw(
-            typeof bufferedValue === 'number' ? bufferedValue.toString() : '0',
+            typeof bufferedValue === 'number' ? bufferedValue.toString() : '',
           );
         } else if (field === 'frequency') {
           setFrequencyRaw(bufferedValue.toString());
@@ -1297,8 +1303,8 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
                     setOperatorContext({
                       targetCallsign: '',
                       targetGrid: '',
-                      reportSent: 0,
-                      reportReceived: 0,
+                      reportSent: null,
+                      reportReceived: null,
                     });
 
                     // 第2步：切换到 TX6 槽位
@@ -1357,11 +1363,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
             }}
             onFocus={() => handleInputFocus('reportSent')}
             onBlur={() => {
-              // 失焦时修正中间态
+              // 失焦时修正中间态：空输入表示清除，不再写入哨兵 0
               const num = parseInt(reportSentRaw);
               if (isNaN(num)) {
-                setReportSentRaw('0');
-                handleContextUpdate('reportSent', 0);
+                setReportSentRaw('');
+                handleContextUpdate('reportSent', null);
               }
               handleInputBlur('reportSent');
             }}

--- a/packages/web/src/components/radio/operators/RadioOperator.tsx
+++ b/packages/web/src/components/radio/operators/RadioOperator.tsx
@@ -128,8 +128,10 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       targetCall: operatorStatus.context.targetCall || '',
       targetGrid: operatorStatus.context.targetGrid || '',
       frequency: operatorStatus.context.frequency, // 频率可选，用于无电台模式设置完整的无线电频率（Hz）
-      reportSent: operatorStatus.context.reportSent ?? 0,
-      reportReceived: operatorStatus.context.reportReceived ?? 0,
+      // Keep unset reports as undefined. FT8 SNR of 0 is valid; defaulting to 0
+      // caused QSO logs to record a sentinel "0" (issue #70).
+      reportSent: operatorStatus.context.reportSent,
+      reportReceived: operatorStatus.context.reportReceived,
     };
   });
 
@@ -174,7 +176,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
   const [cooldownSlotFields, setCooldownSlotFields] = React.useState<Set<OperatorRuntimeSlot>>(new Set());
 
   // 冷却期缓冲区：存储冷却期间服务端推送的最新值
-  const cooldownBufferRef = React.useRef<Record<string, string | number>>({});
+  const cooldownBufferRef = React.useRef<Record<string, string | number | undefined>>({});
   const cooldownSlotBufferRef = React.useRef<RuntimeSlotContents>({});
 
   // localContext ref，供回调函数读取最新值
@@ -336,13 +338,13 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
     if (operatorStatus.context && operatorStatus.context.myCall) {
       const serverCtx = operatorStatus.context;
       const fields = ['myCall', 'myGrid', 'targetCall', 'targetGrid', 'frequency', 'reportSent'] as const;
-      const serverMap: Record<string, string | number> = {
+      const serverMap: Record<string, string | number | undefined> = {
         myCall: serverCtx.myCall || '',
         myGrid: serverCtx.myGrid || '',
         targetCall: serverCtx.targetCall || '',
         targetGrid: serverCtx.targetGrid || '',
         frequency: serverCtx.frequency ?? 0,
-        reportSent: serverCtx.reportSent ?? 0,
+        reportSent: serverCtx.reportSent,
       };
 
       // 冷却中的字段：更新缓冲区
@@ -359,7 +361,7 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
             // 聚焦或冷却中 → 保留本地值
             continue;
           }
-          (newContext as Record<string, string | number>)[field] = serverMap[field];
+          (newContext as Record<string, string | number | undefined>)[field] = serverMap[field];
         }
 
         const hasChanged = fields.some(f =>
@@ -473,8 +475,11 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
       targetCallsign: ctx.targetCall,
       targetGrid: ctx.targetGrid,
       frequency: ctx.frequency,
-      reportSent: ctx.reportSent,
-      reportReceived: ctx.reportReceived,
+      // Only send reportSent when explicitly set. Never echo a UI default of 0 for
+      // reportReceived — that field is driven by FT8 exchanges on the server.
+      ...(typeof ctx.reportSent === 'number' && Number.isFinite(ctx.reportSent)
+        ? { reportSent: ctx.reportSent }
+        : {}),
     });
   }, [setOperatorContext]);
 
@@ -541,7 +546,9 @@ export const RadioOperator: React.FC<RadioOperatorProps> = React.memo(({ operato
         });
         // 同步原始字符串显示
         if (field === 'reportSent') {
-          setReportSentRaw(bufferedValue.toString());
+          setReportSentRaw(
+            typeof bufferedValue === 'number' ? bufferedValue.toString() : '0',
+          );
         } else if (field === 'frequency') {
           setFrequencyRaw(bufferedValue.toString());
         }

--- a/packages/web/src/components/radio/operators/operatorContextDraft.test.ts
+++ b/packages/web/src/components/radio/operators/operatorContextDraft.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyOperatorContextDraft } from './operatorContextDraft';
+
+describe('applyOperatorContextDraft', () => {
+  it('updates the authoritative ref before React state scheduling', () => {
+    const ref = { current: { reportSent: -12, targetCall: 'JA1AAA' } };
+    const setDraft = vi.fn(() => {
+      expect(ref.current.reportSent).toBeNull();
+    });
+
+    const next = applyOperatorContextDraft(ref, setDraft, { reportSent: null });
+
+    expect(next).toEqual({ reportSent: null, targetCall: 'JA1AAA' });
+    expect(ref.current).toBe(next);
+    expect(setDraft).toHaveBeenCalledWith(next);
+  });
+});

--- a/packages/web/src/components/radio/operators/operatorContextDraft.ts
+++ b/packages/web/src/components/radio/operators/operatorContextDraft.ts
@@ -1,0 +1,10 @@
+export function applyOperatorContextDraft<T extends object>(
+  ref: { current: T },
+  setDraft: (next: T) => void,
+  patch: Partial<T>,
+): T {
+  const next = { ...ref.current, ...patch };
+  ref.current = next;
+  setDraft(next);
+  return next;
+}

--- a/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
+++ b/packages/web/src/components/radio/spectrum/SpectrumDisplay.tsx
@@ -1253,8 +1253,14 @@ export const SpectrumDisplay: React.FC<SpectrumDisplayProps> = ({
       targetCallsign: operator.context.targetCall,
       targetGrid: operator.context.targetGrid,
       frequency: Math.round(frequency),
-      reportSent: operator.context.reportSent,
-      reportReceived: operator.context.reportReceived,
+      // Only forward finite reports; omit unset so a frequency drag cannot
+      // re-inject a missing/sentinel report into the runtime.
+      ...(typeof operator.context.reportSent === 'number' && Number.isFinite(operator.context.reportSent)
+        ? { reportSent: operator.context.reportSent }
+        : {}),
+      ...(typeof operator.context.reportReceived === 'number' && Number.isFinite(operator.context.reportReceived)
+        ? { reportReceived: operator.context.reportReceived }
+        : {}),
     });
   }, [connection.state.radioService, operators]);
 

--- a/packages/web/src/notifications/notificationDriver.ts
+++ b/packages/web/src/notifications/notificationDriver.ts
@@ -261,8 +261,8 @@ export function buildQsoNotificationSummary(qso: Pick<QSORecord, 'callsign' | 'g
     summaryParts.push(qso.mode);
   }
 
-  if (qso.reportSent || qso.reportReceived) {
-    summaryParts.push(`${qso.reportSent || '--'}/${qso.reportReceived || '--'}`);
+  if (qso.reportSent != null && qso.reportSent !== '' || qso.reportReceived != null && qso.reportReceived !== '') {
+    summaryParts.push(`${qso.reportSent != null && qso.reportSent !== '' ? qso.reportSent : '--'}/${qso.reportReceived != null && qso.reportReceived !== '' ? qso.reportReceived : '--'}`);
   }
 
   return summaryParts.join(' • ');

--- a/packages/web/src/utils/__tests__/operatorReset.test.ts
+++ b/packages/web/src/utils/__tests__/operatorReset.test.ts
@@ -16,8 +16,8 @@ function createOperator(overrides: Partial<OperatorStatus> = {}): OperatorStatus
       targetCall: '',
       targetGrid: '',
       frequency: 1500,
-      reportSent: 0,
-      reportReceived: 0,
+      reportSent: undefined,
+      reportReceived: undefined,
     },
     strategy: {
       name: 'standard-qso',
@@ -65,8 +65,8 @@ describe('resetOperatorsForOperatingStateChange', () => {
     expect(radioService.setOperatorContext).toHaveBeenCalledWith('op-1', {
       targetCallsign: '',
       targetGrid: '',
-      reportSent: 0,
-      reportReceived: 0,
+      reportSent: null,
+      reportReceived: null,
     });
     expect(radioService.setOperatorRuntimeState).toHaveBeenCalledWith('op-1', 'TX6');
     expect(radioService.stopOperator).toHaveBeenCalledWith('op-1');
@@ -101,5 +101,33 @@ describe('resetOperatorsForOperatingStateChange', () => {
     expect(radioService.removeOperatorFromTransmission).not.toHaveBeenCalled();
     expect(radioService.setOperatorContext).not.toHaveBeenCalled();
     expect(radioService.setOperatorRuntimeState).not.toHaveBeenCalled();
+  });
+
+  it('clears a legitimate 0 dB report when resetting for an operating-state change', () => {
+    const radioService = createRadioService();
+    const operator = createOperator({
+      context: {
+        myCall: 'BG5DRB',
+        myGrid: 'PM01',
+        targetCall: '',
+        targetGrid: '',
+        frequency: 1500,
+        reportSent: 0,
+        reportReceived: undefined,
+      },
+    });
+
+    const result = resetOperatorsForOperatingStateChange({
+      operators: [operator],
+      radioService,
+    });
+
+    expect(result.operatorsChanged).toBe(1);
+    expect(radioService.setOperatorContext).toHaveBeenCalledWith('op-1', {
+      targetCallsign: '',
+      targetGrid: '',
+      reportSent: null,
+      reportReceived: null,
+    });
   });
 });

--- a/packages/web/src/utils/operatorReset.ts
+++ b/packages/web/src/utils/operatorReset.ts
@@ -16,7 +16,7 @@ const hasText = (value: unknown): boolean => (
 );
 
 const hasNonDefaultReport = (value: unknown): boolean => (
-  typeof value === 'number' && Number.isFinite(value) && value !== 0
+  typeof value === 'number' && Number.isFinite(value)
 );
 
 const getOperatorSlot = (operator: OperatorStatus): string | undefined => (
@@ -54,8 +54,8 @@ export const resetOperatorsForOperatingStateChange = ({
   const clearContext: WSSetOperatorContextMessage['data']['context'] = {
     targetCallsign: '',
     targetGrid: '',
-    reportSent: 0,
-    reportReceived: 0,
+    reportSent: null,
+    reportReceived: null,
   };
 
   for (const operator of operators) {


### PR DESCRIPTION
## 背景

这是 PR #71 在当前主线架构上的新版适配。原 PR 针对 #70 修复自动 QSO 日志中 RST 偶发记录为哨兵 `0` 的问题；其后 `main` 已完成 Plugin API v2、事务化发射生命周期、声明式 QSO completion effect 和 assisted QSO queue 重构，原分支因此发生冲突，旧测试也仍按 v1 strategy API 调用。

本 PR 将 #71 的两笔提交 rebase 到最新 `main`，保留 ChristianSwift 的原始作者归属，并按 v2 的状态、事实与持久化边界重新完成冲突解决和回归验证。

## 设计理由

### 1. TX 物理事实与 RX 决策事实分离

Plugin API v2 中，strategy runtime 的 context 属于可 checkpoint/restore 的 speculative state；但 Host 接受的 QSO completion effect 已经包含 strategy 对 RX decode 的最终选择。SlotPack 中的 RX frame 仍是候选集合，不能按插入顺序覆盖已接受的 effect。

当前主线只在 `PhysicalTxCoordinator` 进入 `on_air` 后发出 `physicalConfirmed: true` 的 `transmissionLog`，随后同步写入带 `operatorId` 的 SlotPack TX frame。因此落盘规则为：

- `reportSent`：当前 operator 的 on-air TX fact → accepted effect → CallsignContextTracker fallback；
- `reportReceived`：accepted effect → CallsignContextTracker fallback；
- RX SlotPack 只进入 `messageHistory` 供审计，不覆盖 `reportReceived`。

这样既修复 #70/#83，也避免同一 slot 中较弱或矛盾的后插入 decode 污染 ADIF。

### 2. 保持 v2 的声明式持久化边界

strategy 只更新可回滚的本地状态并返回 `qsoCompletion` effect，不直接写 ADIF。Host 接受 effect 后再补齐 message history、实际 TX 报告和 comment，并沿用现有 runtime generation / QSO lifecycle epoch 隔离。

本 PR 不改变 RF frame、PTT lease、decision epoch 或 durability failure 的行为，也不为 SlotPack 引入新的 lifecycle 字段。

### 3. Context draft 在 UI 事件内保持单一事实源

RadioOperator 输入同时服务 debounce、blur 和 Enter 提交。React state 更新是异步的，因此 context mutation 会先同步更新 `localContextRef`，再调度 React state；所有立即提交路径都读取同一份最新 draft。

这避免“UI 已清空但 blur 发送旧 RST”的竞态，同时不引入新的全局 store、公共 hook 或 RST 专用发送旁路。

### 4. `null` 只用于 WebSocket 清空命令

UI 需要区分“未提供字段”和“显式清空报告”，因此 `SET_OPERATOR_CONTEXT` 允许 `null`。Host 在进入插件边界前将其归一为带 own-property 的 `undefined` patch：

- 不扩宽公开 `StrategyRuntimeContext`；
- 不让 `null` 进入 checkpoint 或 runtime snapshot；
- 保持现有第三方 v2 strategy 和脚手架实现兼容；
- contracts 测试明确 snapshot 仍只接受 number/undefined。

### 5. 0 dB 是合法值

`"0"` 和 `"+00"` 都可能表示合法的 0 dB 报告，不能在持久化层全局当作哨兵。本 PR 只把 `undefined`、`null` 和空串视为缺失，并将 physically confirmed 的 sent 0 dB 规范化为 FT8 `+00`。

## 主要改动

- 在 SIGNAL_REPORT / ROGER_REPORT / CALL / CQ 路径中，用当前空口消息刷新报告，避免旧缓存阻止更新。
- 只从当前 operator 的 on-air TX frame 提取实际 `reportSent`。
- 保留 strategy 已接受的 `reportReceived`，矛盾 RX decode 只作为审计历史。
- 保留合法 bare `0`，并正确合并、显示和通知 0 dB 日志。
- 操作员 draft mutation 同步更新 ref，保证 blur/Enter 不发送旧值。
- 操作员重置和输入清空使用显式 clear 语义，不再向 runtime 回写默认 `0`。
- 保留 v2 target lifecycle generation、checkpoint/restore 和 AbortSignal 约束。
- 新增矛盾 decode、physical TX、0/+00、WebSocket clear 和同步 draft 回归测试。

## 兼容性边界

- 不修改公开 Plugin API v2 类型。
- 不修改 ADIF/FileStore/durability 契约。
- 不修改 transmission、PTT、audio 或 radio lifecycle。
- 不把 queued/encoding/committed 状态当作已发送事实。
- 不关闭原 PR #71，待本 PR 合并后再由维护者处理 superseded 状态。

## 验证

- `yarn workspace @tx5dr/server test`
  - 172 files / 1674 tests passed
  - ADIF 70K performance test passed
- `yarn workspace @tx5dr/web test`
  - 87 files / 539 tests passed
- 最终定向回归：
  - contracts：2 / 2
  - standard-qso：25 / 25
  - RadioOperatorManager：67 / 67
- `yarn build`：12 / 12 packages passed
- `yarn lint`：0 errors；9 个主线既有 warnings
- `git diff --check`：passed

Supersedes #71
Fixes #70
Related: #83
